### PR TITLE
remove '--no-build-isolation' flag when installing vllm-spyre

### DIFF
--- a/Dockerfile.spyre
+++ b/Dockerfile.spyre
@@ -21,8 +21,7 @@ RUN pip install vllm==0.7.3
 # Install vllm Spyre plugin ##################################################################
 RUN mkdir /workspace/vllm-spyre
 COPY . /workspace/vllm-spyre
-RUN cd /workspace/vllm-spyre && pip install --no-build-isolation -v -e .
+RUN cd /workspace/vllm-spyre && pip install -v -e .
 ENV VLLM_PLUGINS=spyre
 
 CMD ["/bin/bash"]
-


### PR DESCRIPTION
Remove unecessary `--no-build-isolation` flag when installing vllm-spyre from source.