### PR TITLE
Update deeptools logging options default

### DIFF
--- a/vllm_spyre/model_executor/model_loader/spyre_setup.py
+++ b/vllm_spyre/model_executor/model_loader/spyre_setup.py
@@ -42,7 +42,7 @@ def spyre_setup(rank=0, world_size=1, local_rank=0, local_size=1, verbose=False)
         os.environ["DEEPRT_EXPORT_DIR"] += f"/{rank}"
         os.environ["DTCOMPILER_EXPORT_DIR"] += f"/{rank}"
         sys.pycache_prefix=os.getenv("DEEPRT_EXPORT_DIR")+"/py-" + str(rank)
-    os.environ.setdefault("DTCOMPILER_KEEP_EXPORT", "1")
+    os.environ.setdefault("DTCOMPILER_KEEP_EXPORT", "0")
 
     # Inform Flex of the size of this job
     os.environ.setdefault("FLEX_RDMA_WORLD_SIZE", str(world_size))

--- a/vllm_spyre/model_executor/model_loader/spyre_setup.py
+++ b/vllm_spyre/model_executor/model_loader/spyre_setup.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+import tempfile
 
 import torch
 
@@ -36,8 +37,9 @@ def spyre_setup(rank=0, world_size=1, local_rank=0, local_size=1, verbose=False)
     # Each rank needs a unique space to write its binaries
     # For both 'export' and '__pycache'
     # https://docs.python.org/3/library/sys.html#sys.pycache_prefix
-    os.environ.setdefault("DEEPRT_EXPORT_DIR", "export")
-    os.environ.setdefault("DTCOMPILER_EXPORT_DIR", "export")
+    with tempfile.TemporaryDirectory() as exportdir:
+        os.environ.setdefault("DEEPRT_EXPORT_DIR", exportdir)
+        os.environ.setdefault("DTCOMPILER_EXPORT_DIR", exportdir)
     if world_size > 1:
         os.environ["DEEPRT_EXPORT_DIR"] += f"/{rank}"
         os.environ["DTCOMPILER_EXPORT_DIR"] += f"/{rank}"


### PR DESCRIPTION
This fixes [issue #253](https://github.ibm.com/ai-foundation/aiu-app-sw-tracker/issues/253).
From my understanding, using `tempfile.TemporaryDirectory()` is a typical way to export to user's temporary directory.  