### PR TITLE
Remove path filtering for PR mandatory git actions

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -16,13 +16,18 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "**/*.py"
-      - "**/*.md"
-      - "**/*.rst"
-      - pyproject.toml
-      - requirements-lint.txt
-      - .github/workflows/codespell.yml
+    # This workflow is only relevant when one of the following files changes.
+    # However, we have github configured to expect and require this workflow
+    # to run and pass before github with auto-merge a pull request. Until github
+    # allows more flexible auto-merge policy, we can just run this on every PR.
+    # It doesn't take that long to run, anyway.
+    # paths:
+    #   - "**/*.py"
+    #   - "**/*.md"
+    #   - "**/*.rst"
+    #   - pyproject.toml
+    #   - requirements-lint.txt
+    #   - .github/workflows/codespell.yml
 
 jobs:
   codespell:

--- a/.github/workflows/reminder_comment.yml
+++ b/.github/workflows/reminder_comment.yml
@@ -15,7 +15,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: "👋 Hi! Thank you for contributing to the vLLM support on Spyre.\n Just a reminder: Make sure that your code passes all the linting checks, otherwise your PR won't be able to be merged. To do so, first install the linting requirements, then run `format.sh` and commit the changes:\n```\npip install -r requirements-lint.txt\nbash format.sh\n```\nNow you are good to go 🚀"
+              body: "👋 Hi! Thank you for contributing to vLLM support on Spyre.\n Just a reminder: Make sure that your code passes all the linting checks, otherwise your PR won't be able to be merged. To do so, first install the linting requirements, then run `format.sh` and commit the changes:\n```\npip install -r requirements-lint.txt\nbash format.sh\n```\nNow you are good to go 🚀"
             })
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/yapf.yml
+++ b/.github/workflows/yapf.yml
@@ -12,9 +12,14 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "**/*.py"
-      - .github/workflows/yapf.yml
+    # This workflow is only relevant when one of the following files changes.
+    # However, we have github configured to expect and require this workflow
+    # to run and pass before github with auto-merge a pull request. Until github
+    # allows more flexible auto-merge policy, we can just run this on every PR.
+    # It doesn't take that long to run, anyway.
+    # paths:
+    #   - "**/*.py"
+    #   - .github/workflows/yapf.yml
 
 jobs:
   yapf:


### PR DESCRIPTION
Because of Path filtering in github actions, some PRs didn't trigger checks that are mandatory for the PR to be merged, and the check were staying the "Pending" state: see the effect description [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks).

This PRs remove the path filtering for mandatory actions, which will from now on be triggered on all the PRs.