### PR TITLE
[V1] tests

### DIFF
--- a/.github/workflows/test-spyre.yml
+++ b/.github/workflows/test-spyre.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Run Spyre tests within docker container
       run: |
         docker run -i --rm --entrypoint /bin/bash vllm-spyre -c '''
-          pip install pytest sentence-transformers && \
+          pip install pytest sentence-transformers pytest-timeout pytest-forked && \
           python -c "from transformers import pipeline; pipeline(\"text-generation\", model=\"JackFram/llama-160m\")" && \
           export VARIANT=$(ls /root/.cache/huggingface/hub/models--JackFram--llama-160m/snapshots/) && \
           mkdir -p /models && \
@@ -24,5 +24,5 @@ jobs:
           export MASTER_ADDR=localhost && \
           export DISTRIBUTED_STRATEGY_IGNORE_MODULES=WordEmbedding && \
           cd vllm-spyre && \
-          python -m pytest tests -v -k eager
+          python -m pytest --forked --timeout=300  tests -v -k eager
         '''

--- a/Dockerfile.spyre
+++ b/Dockerfile.spyre
@@ -16,7 +16,15 @@ RUN ln -sf $(which python${PYTHON_VERSION}) /usr/bin/python && \
     ln -sf $(which pip${PYTHON_VERSION}) /usr/bin/pip
 
 # Download and install vllm ###########################################################
-RUN pip install vllm==0.7.3
+RUN git clone --depth 1 https://github.com/vllm-project/vllm.git \
+    && cd vllm \
+    && git fetch origin pull/14242/head:spyre-workarounds \
+    && git checkout spyre-workarounds \
+    && python -m pip install --upgrade pip \
+    && pip3 install torch=="2.5.1+cpu" --index-url https://download.pytorch.org/whl/cpu \
+    && python use_existing_torch.py \
+    && pip install -r requirements-build.txt \
+    && SETUPTOOLS_SCM_PRETEND_VERSION=0.7.3 VLLM_TARGET_DEVICE=empty pip install --verbose . --no-build-isolation
 
 # Install vllm Spyre plugin ##################################################################
 RUN mkdir /workspace/vllm-spyre

--- a/tests/spyre_util.py
+++ b/tests/spyre_util.py
@@ -47,7 +47,7 @@ def generate_spyre_vllm_output(model: str, prompts: List[str],
     for req_output in vllm_outputs:
         result = {}
         result['text'] = req_output.outputs[0].text
-        result['token_ids'] = req_output.outputs[0].token_ids
+        result['token_ids'] = tuple(req_output.outputs[0].token_ids)
         result['tokens'] = tuple([
             req_output.outputs[0].logprobs[i][t].decoded_token
             for i, t in enumerate(result['token_ids'])

--- a/tests/spyre_util.py
+++ b/tests/spyre_util.py
@@ -19,8 +19,8 @@ def generate_spyre_vllm_output(model: str, prompts: List[str],
                                max_model_len: int, block_size: int,
                                sampling_params: Union[SamplingParams,
                                                       List[SamplingParams]],
-                               tensor_parallel_size: int,
-                               backend: str) -> List[Dict[str, Any]]:
+                               tensor_parallel_size: int, backend: str,
+                               vllm_version: str) -> List[Dict[str, Any]]:
 
     warmup_prompt_length = [t[0] for t in warmup_shapes]
     warmup_new_tokens = [t[1] for t in warmup_shapes]
@@ -33,6 +33,7 @@ def generate_spyre_vllm_output(model: str, prompts: List[str],
     os.environ['VLLM_SPYRE_WARMUP_BATCH_SIZES'] = ','.join(
         str(val) for val in warmup_batch_size)
     os.environ['VLLM_SPYRE_DYNAMO_BACKEND'] = backend
+    os.environ['VLLM_USE_V1'] = "1" if vllm_version == "V1" else "0"
 
     vllm_model = LLM(model=model,
                      tokenizer=model,
@@ -200,10 +201,10 @@ def compare_results(model: str, prompts: List[str],
 
 # vLLM / Spyre
 def spyre_vllm_embeddings(model: str, prompts: List[str],
-                          warmup_shapes: List[Tuple[int,
-                                                    int]], max_model_len: int,
-                          block_size: int, tensor_parallel_size: int,
-                          backend: str) -> List[Dict[str, Any]]:
+                          warmup_shapes: List[Tuple[int, int]],
+                          max_model_len: int, block_size: int,
+                          tensor_parallel_size: int, backend: str,
+                          vllm_version: str) -> List[Dict[str, Any]]:
 
     warmup_prompt_length = [t[0] for t in warmup_shapes]
     warmup_new_tokens = [0] * len(warmup_shapes)
@@ -216,6 +217,7 @@ def spyre_vllm_embeddings(model: str, prompts: List[str],
     os.environ['VLLM_SPYRE_WARMUP_BATCH_SIZES'] = ','.join(
         str(val) for val in warmup_batch_size)
     os.environ['VLLM_SPYRE_DYNAMO_BACKEND'] = backend
+    os.environ['VLLM_USE_V1'] = "1" if vllm_version == "V1" else "0"
 
     vllm_model = LLM(model=model,
                      tokenizer=model,

--- a/tests/test_spyre_basic.py
+++ b/tests/test_spyre_basic.py
@@ -22,11 +22,13 @@ from vllm import SamplingParams
                                           (128, 20, 4), (128, 20, 8)]
                          )  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend", get_spyre_backend_list())
+@pytest.mark.parametrize("vllm_version", ["V0", "V1"])
 def test_output(
     model: str,
     prompts: List[str],
     warmup_shape: Tuple[int, int, int],
     backend: str,
+    vllm_version: str,
 ) -> None:
     '''
     The warmup is based on a single shape. After the warmup,
@@ -57,7 +59,8 @@ def test_output(
         block_size=2048,
         sampling_params=vllm_sampling_params,
         tensor_parallel_size=1,
-        backend=backend)
+        backend=backend,
+        vllm_version=vllm_version)
 
     hf_results = generate_hf_output(model=model,
                                     prompts=prompts,

--- a/tests/test_spyre_embeddings.py
+++ b/tests/test_spyre_embeddings.py
@@ -22,11 +22,13 @@ from spyre_util import (compare_embedding_results, get_spyre_backend_list,
                          [(64, 4), (64, 8), (128, 4),
                           (128, 8)])  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend", get_spyre_backend_list())
+@pytest.mark.parametrize("vllm_version", ["V0"])  # Todo: V1 support
 def test_output(
     model: str,
     prompts: List[str],
     warmup_shape: Tuple[int, int],
     backend: str,
+    vllm_version: str,
 ) -> None:
     '''
     The warmup is based on a single shape. After the warmup,
@@ -41,7 +43,8 @@ def test_output(
                                          max_model_len=256,
                                          block_size=256,
                                          tensor_parallel_size=1,
-                                         backend=backend)
+                                         backend=backend,
+                                         vllm_version=vllm_version)
 
     hf_results = st_embeddings(model=model, prompts=prompts)
 

--- a/tests/test_spyre_max_new_tokens.py
+++ b/tests/test_spyre_max_new_tokens.py
@@ -29,12 +29,14 @@ prompt2 = template.format("Provide a list of instructions for preparing "
 @pytest.mark.parametrize("warmup_shape", [(64, 10, 4)]
                          )  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend", get_spyre_backend_list())
+@pytest.mark.parametrize("vllm_version", ["V0", "V1"])
 def test_output(
     model: str,
     prompts: List[str],
     stop_last: bool,
     warmup_shape: Tuple[int, int, int],
     backend: str,
+    vllm_version: str,
 ) -> None:
     '''
     The warmup is based on a single shape. After the warmup,
@@ -86,7 +88,8 @@ def test_output(
         block_size=2048,
         sampling_params=vllm_sampling_params,
         tensor_parallel_size=1,
-        backend=backend)
+        backend=backend,
+        vllm_version=vllm_version)
 
     hf_results = generate_hf_output(model=model,
                                     prompts=prompts,

--- a/tests/test_spyre_max_prompt_length.py
+++ b/tests/test_spyre_max_prompt_length.py
@@ -29,7 +29,7 @@ from vllm import SamplingParams
                          [[(64, 20, 4)], [(64, 20, 4), (128, 20, 4)]]
                          )  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend", get_spyre_backend_list())
-@pytest.mark.parametrize("vllm_version", ["V0", "V1"])
+@pytest.mark.parametrize("vllm_version", ["V0"])  # Todo: V1 support
 def test_output(
     model: str,
     prompts: List[str],

--- a/tests/test_spyre_max_prompt_length.py
+++ b/tests/test_spyre_max_prompt_length.py
@@ -29,11 +29,13 @@ from vllm import SamplingParams
                          [[(64, 20, 4)], [(64, 20, 4), (128, 20, 4)]]
                          )  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend", get_spyre_backend_list())
+@pytest.mark.parametrize("vllm_version", ["V0", "V1"])
 def test_output(
     model: str,
     prompts: List[str],
     warmup_shapes: List[Tuple[int, int, int]],
     backend: str,
+    vllm_version: str,
 ) -> None:
     '''
     The warmup is based on one or multiple shapes. After the warmup,
@@ -71,7 +73,8 @@ def test_output(
         block_size=2048,
         sampling_params=vllm_sampling_params,
         tensor_parallel_size=1,
-        backend=backend)
+        backend=backend,
+        vllm_version=vllm_version)
 
     hf_results = generate_hf_output(model=model,
                                     prompts=prompts,

--- a/tests/test_spyre_seed.py
+++ b/tests/test_spyre_seed.py
@@ -23,6 +23,7 @@ from vllm import SamplingParams
                                           (128, 20, 4), (128, 20, 8)]
                          )  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend", get_spyre_backend_list())
+@pytest.mark.parametrize("vllm_version", ["V0"])  # Todo: V1 support
 def test_seed(
     model: str,
     prompt: str,
@@ -30,6 +31,7 @@ def test_seed(
     seed: int,
     warmup_shape: Tuple[int, int, int],
     backend: str,
+    vllm_version: str,
 ) -> None:
     '''
     The warmup is based on a single shape. After the warmup,
@@ -58,7 +60,8 @@ def test_seed(
         block_size=2048,
         sampling_params=vllm_sampling_params,
         tensor_parallel_size=1,
-        backend=backend)
+        backend=backend,
+        vllm_version=vllm_version)
 
     # compare all generated outputs against the first generated output
     for vllm_result in vllm_results:

--- a/tests/test_spyre_tensor_parallel.py
+++ b/tests/test_spyre_tensor_parallel.py
@@ -23,7 +23,7 @@ from vllm import SamplingParams
 # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("tp_size", [2])
 @pytest.mark.parametrize("backend", get_spyre_backend_list())
-@pytest.mark.parametrize("vllm_version", ["V0"])  # Todo: V1 support
+@pytest.mark.parametrize("vllm_version", ["V0", "V1"])
 def test_output(
     model: str,
     prompts: List[str],

--- a/tests/test_spyre_tensor_parallel.py
+++ b/tests/test_spyre_tensor_parallel.py
@@ -23,12 +23,14 @@ from vllm import SamplingParams
 # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("tp_size", [2])
 @pytest.mark.parametrize("backend", get_spyre_backend_list())
+@pytest.mark.parametrize("vllm_version", ["V0"])  # Todo: V1 support
 def test_output(
     model: str,
     prompts: List[str],
     warmup_shapes: List[Tuple[int, int, int]],
     tp_size: int,
     backend: str,
+    vllm_version: str,
 ) -> None:
     '''
     The warmup is based on one or multiple shapes. After the warmup,
@@ -60,7 +62,8 @@ def test_output(
         block_size=2048,
         sampling_params=vllm_sampling_params,
         tensor_parallel_size=tp_size,
-        backend=backend)
+        backend=backend,
+        vllm_version=vllm_version)
 
     hf_results = generate_hf_output(model=model,
                                     prompts=prompts,

--- a/tests/test_spyre_warmup_shapes.py
+++ b/tests/test_spyre_warmup_shapes.py
@@ -27,11 +27,13 @@ from vllm import SamplingParams
 @pytest.mark.parametrize("warmup_shapes", [[(64, 20, 8), (128, 20, 4)]]
                          )  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend", get_spyre_backend_list())
+@pytest.mark.parametrize("vllm_version", ["V0", "V1"])
 def test_output(
     model: str,
     prompts: List[str],
     warmup_shapes: List[Tuple[int, int, int]],
     backend: str,
+    vllm_version: str,
 ) -> None:
     '''
     The warmup is based on two shapes, that 'overlap' each
@@ -69,7 +71,8 @@ def test_output(
         block_size=2048,
         sampling_params=vllm_sampling_params,
         tensor_parallel_size=1,
-        backend=backend)
+        backend=backend,
+        vllm_version=vllm_version)
 
     hf_results = generate_hf_output(model=model,
                                     prompts=prompts,


### PR DESCRIPTION
### V1 tests
Adding tests for V1 alongside the existing V0 tests.

-> This PR can be merged while still working on #17, #24 and #29

**Further TO DOs**
- [ ] Add V1 support for `test_spyre_seed.py`: Sampling temperature has to be passed instead of hard coded [here](https://github.com/vllm-project/vllm-spyre/pull/6/files#r1983384389) (open PR #24)
- [ ] Add V1 support for `test_spyre_embeddings.py` (open issue #17)
- [ ] Add V1 support for `test_spyre_max_prompt_length.py` (open issue #29)
- [x] Add V1 support for `test_spyre_tensor_parallel.py` (open issue #25)
- [x] Investigating issue where tokens are prepended with Ġ instead of a whitespace (see comments [1](https://github.com/vllm-project/vllm-spyre/pull/11#issuecomment-2706872622) and [2](https://github.com/vllm-project/vllm-spyre/pull/11#issuecomment-2711847556))
- [x] Investigating hanging V1 engine in pytests when compiling multiple configurations (see comments [1](https://github.com/vllm-project/vllm-spyre/pull/11#issuecomment-2711244246) and [2](https://github.com/vllm-project/vllm-spyre/pull/11#issuecomment-2711368047))