### PR TITLE
:children_crossing: Port hf download fix to V1

### DIFF
--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Tuple
 
 import torch
 import torch.distributed as dist
+from huggingface_hub import hf_hub_download
 from vllm.config import VllmConfig
 from vllm.distributed import (ensure_model_parallel_initialized,
                               init_distributed_environment)
@@ -173,8 +174,14 @@ class SpyreWorker(WorkerBaseV1):
     def load_model(self):
         assert self._env_initialized
 
-        with open(os.path.join(self.model_config.model, 'config.json'),
-                  'rb') as f:
+        is_local = os.path.isdir(self.model_config.model)
+        if is_local:
+            cf_file = os.path.join(self.model_config.model, 'config.json')
+        else:
+            cf_file = hf_hub_download(repo_id=self.model_config.model,
+                                      revision=self.model_config.revision,
+                                      filename="config.json")
+        with open(cf_file, 'rb') as f:
             config = json.load(f)
 
         restricted_tokens = []


### PR DESCRIPTION
This ports the fix from #5 to the V1 worker.

I tested that this can download and run a small model from HF, on both v0 and v1. Tested with `Cheng98/llama-160m` and `JackFram/llama-160m`