### PR TITLE
[V1] Cleanup kv-caching apis and disable paged attention

### DIFF
--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -85,7 +85,7 @@ class SpyrePlatform(Platform):
                               shape['prompt_length'] + shape['new_tokens'])
 
         if envs.VLLM_USE_V1:
-            # The v0 scheduler will run out of blocks if this is overriden
+            # The v0 scheduler will run out of blocks if this is overridden
             scheduler_config.max_num_seqs = max_batch_size
 
         cache_config = vllm_config.cache_config
@@ -104,7 +104,7 @@ class SpyrePlatform(Platform):
             cache_config.block_size = model_config.max_model_len
             cache_config.num_gpu_blocks_override = scheduler_config.max_num_seqs
             logger.info(
-                "Overriding configurations based on warmup shaped. "
+                "Overriding configurations based on warmup shapes. "
                 "max_model_len=%d, max_num_seqs=%d, block_size=%d, "
                 "num_gpu_blocks_override=%d", model_config.max_model_len,
                 scheduler_config.max_num_seqs, cache_config.block_size,

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -39,6 +39,7 @@ class SpyrePlatform(Platform):
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
         parallel_config = vllm_config.parallel_config
         scheduler_config = vllm_config.scheduler_config
+        model_config = vllm_config.model_config
 
         if scheduler_config.is_multi_step:
             raise NotImplementedError
@@ -73,12 +74,32 @@ class SpyrePlatform(Platform):
             scheduler_config.scheduler_cls = \
                 "vllm_spyre.core.scheduler.SpyreScheduler"
 
-        cache_config = vllm_config.cache_config
-        if cache_config:
-            # spyre needs block_size = max_model_len
-            vllm_config.cache_config.block_size = \
-                vllm_config.model_config.max_model_len
+        # Override --max-num-seqs to the biggest warmup batch size
+        # And override --max-model-len to the biggest warmup sequence
         cls.set_warmup_shapes(scheduler_config)
+        max_batch_size = 0
+        max_seq_len = 0
+        for shape in cls.get_warmup_shapes():
+            max_batch_size = max(max_batch_size, shape['batch_size'])
+            max_seq_len = max(max_batch_size,
+                              shape['prompt_length'] + shape['new_tokens'])
+        scheduler_config.max_num_seqs = max_batch_size
+
+        cache_config = vllm_config.cache_config
+
+        if cache_config and model_config:
+            # Cache and model config aren't set in the individual worker procs
+            # These are set in the main engine process
+
+            # To disable any paged attention ops in the base scheduler, we both:
+            # - Set the block size (in tokens) to the maximum sequence length
+            #       so that the scheduler thinks an entire sequence will fit in
+            #       one single block.
+            # - Set the number of blocks to the maximum number of sequences, so
+            #       the scheduler always thinks there's a block available
+            model_config.max_model_len = max_seq_len
+            cache_config.block_size = model_config.max_model_len
+            cache_config.num_gpu_blocks_override = scheduler_config.max_num_seqs
 
     @classmethod
     def is_pin_memory_available(cls) -> bool:

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -3,7 +3,7 @@ import json
 import os
 import platform
 import time
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import torch
 import torch.distributed as dist
@@ -14,8 +14,7 @@ from vllm.distributed import (ensure_model_parallel_initialized,
 from vllm.model_executor import set_random_seed
 from vllm.platforms import current_platform
 from vllm.v1.core.scheduler import SchedulerOutput
-from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
-                                        KVCacheSpec)
+from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.worker.worker_base import WorkerBase as WorkerBaseV1
 from vllm.worker.worker_base import WorkerBase
@@ -31,14 +30,15 @@ class SpyreWorker(WorkerBaseV1):
     """
 
     def get_kv_cache_spec(self) -> KVCacheSpec:
-        """Get specifications for KV cache implementation."""
-        return {
-            "foo":
-            FullAttentionSpec(block_size=10,
-                              num_kv_heads=1,
-                              head_size=1,
-                              dtype=torch.float16)
-        }
+        """Get specifications for KV cache implementation.
+        
+        These specs are used to:
+        - build the kv_cache_configs that are then passed to 
+            initialize_from_config() on this instance
+        - determine the number of available kv_cache_blocks, see
+            SpyreWorker.determine_available_memory
+        """
+        return self.model_runner.get_kv_cache_spec()
 
     def compile_or_warm_up_model(self) -> None:
         """Prepare model for execution through compilation/warmup."""
@@ -83,11 +83,26 @@ class SpyreWorker(WorkerBaseV1):
         return
 
     def determine_available_memory(self) -> int:
+        """Return available device memory in bytes.
+        
+        This is used in conjunction with the result from `get_kv_cache_spec`
+        to determine the number of KV cache blocks that can fit on the device.
+
+        The number of available blocks is calculated as:
+            available_memory / page_size / # of layers
+        where the page size and number of layers come from the kv cache spec.
+
+        The number of device blocks (called "gpu blocks" in most places) can
+        also be overridden by `--num-gpu-blocks-override`, which is set under
+        `vllm_config.cache_config.num_gpu_blocks_override`.
+        """
         # TODO: figure out what to do based on determine_num_available_blocks
         return 10 * 1024 * 1024
 
     def initialize_from_config(self,
                                kv_cache_configs: List[KVCacheConfig]) -> None:
+        """Construct the KV cache from the provided configs.
+        Currently, we do not support paged attention or kv caching"""
         pass
 
     def __init__(
@@ -320,30 +335,6 @@ class SpyreWorker(WorkerBaseV1):
                 use_cache=True,
                 only_last_token=True,
                 **extra_kwargs)
-
-    def determine_num_available_blocks(self) -> Tuple[int, int]:
-        """Determine the number of available KV blocks.
-
-        Swapping is not yet supported, so always return num_cpu_blocks=0.
-
-        We configure num_gpu_blocks to be equal to max_num_seqs.
-        """
-        # Set the number of GPU blocks to be the same as the maximum number of
-        # sequences that can be processed in a single batch. This is equivalent
-        # to schedule without PagedAttention.
-        num_gpu_blocks = self.scheduler_config.max_num_seqs
-
-        # Swap not yet supported with Spyre backend.
-        num_cpu_blocks = 0
-
-        return num_gpu_blocks, num_cpu_blocks
-
-    def get_cache_block_size_bytes(self) -> int:
-        """Determine the size in bytes of a cache block.
-
-        This is required for speculative decoding; it is not yet implemented.
-        """
-        raise NotImplementedError
 
     @property
     def do_metadata_broadcast(self) -> bool:


### PR DESCRIPTION
This PR
- Cleans up unused kv-cache related APIs from the v1 worker
- Adds detailed docstrings about how the new kv-cache related v1 apis work
- Overrides the necessary values to copy v0's behavior of 1 block per sequence to avoid any preemption, prefix caching, or other kv cache block related logic in the scheduler
- Does a small refactor to use `super().__init__` in the model runner

Closes #19 