### PR TITLE
:recycle: Use real logger

### DIFF
--- a/vllm_spyre/__init__.py
+++ b/vllm_spyre/__init__.py
@@ -1,3 +1,30 @@
+from logging.config import dictConfig
+
+from vllm.logger import DEFAULT_LOGGING_CONFIG
+
+
 def register():
     """Register the Spyre platform."""
     return "vllm_spyre.platform.SpyrePlatform"
+
+
+def _init_logging():
+    """Setup logging, extending from the vLLM logging config"""
+    config = {**DEFAULT_LOGGING_CONFIG}
+
+    # Copy the vLLM logging configurations for our package
+    config["formatters"]["vllm_spyre"] = DEFAULT_LOGGING_CONFIG["formatters"][
+        "vllm"]
+
+    handler_config = DEFAULT_LOGGING_CONFIG["handlers"]["vllm"]
+    handler_config["formatter"] = "vllm_spyre"
+    config["handlers"]["vllm_spyre"] = handler_config
+
+    logger_config = DEFAULT_LOGGING_CONFIG["loggers"]["vllm"]
+    logger_config["handlers"] = ["vllm_spyre"]
+    config["loggers"]["vllm_spyre"] = logger_config
+
+    dictConfig(config)
+
+
+_init_logging()

--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -129,11 +129,11 @@ class SpyreCausalLM(nn.Module):
             if envs_spyre.VLLM_SPYRE_DYNAMO_BACKEND == "sendnn_decoder":
                 from aiu_as_addon import aiu_adapter, aiu_linear  # noqa: F401
                 linear_type = "gptq_aiu"
-                print("Loaded `aiu_as_addon` functionalities")
+                logger.info("Loaded `aiu_as_addon` functionalities")
             else:
                 from cpu_addon import cpu_linear  # noqa: F401
                 linear_type = "gptq_cpu"
-                print("Loaded `cpu_addon` functionalities")
+                logger.info("Loaded `cpu_addon` functionalities")
 
             quant_cfg = model_config._parse_quant_hf_config()
 
@@ -185,21 +185,25 @@ class SpyreCausalLM(nn.Module):
             _prev = torch._dynamo.config.accumulated_cache_size_limit
             torch._dynamo.config.accumulated_cache_size_limit = \
                 _target_cache_size
-            print("NOTICE: Adjusting "
-                  "torch._dynamo.config.accumulated_cache_size_limit"
-                  f" from {_prev} to "
-                  f"{torch._dynamo.config.accumulated_cache_size_limit} "
-                  f"to accommodate prompt size of {max_prompt_length} "
-                  f"and decode tokens of {max_decode_length}")
+            logger.info(
+                "NOTICE: Adjusting "
+                "torch._dynamo.config.accumulated_cache_size_limit "
+                "from %s to %s "
+                "to accommodate prompt size of %d "
+                "and decode tokens of %d", _prev,
+                torch._dynamo.config.accumulated_cache_size_limit,
+                max_prompt_length, max_decode_length)
 
         if _target_cache_size > torch._dynamo.config.cache_size_limit:
             _prev = torch._dynamo.config.cache_size_limit
             torch._dynamo.config.cache_size_limit = _target_cache_size
-            print(
-                "NOTICE: Adjusting torch._dynamo.config.cache_size_limit from"
-                f" {_prev} to {torch._dynamo.config.cache_size_limit} to "
-                f"accommodate prompt size of {max_prompt_length} and "
-                f"decode tokens of {max_decode_length}")
+            logger.info(
+                "NOTICE: Adjusting torch._dynamo.config.cache_size_limit "
+                "from %s to %s "
+                "to accommodate prompt size of %d "
+                "and decode tokens of %d", _prev,
+                torch._dynamo.config.accumulated_cache_size_limit,
+                max_prompt_length, max_decode_length)
 
         if envs_spyre.VLLM_SPYRE_DYNAMO_BACKEND in BACKEND_LIST:
             self.model = torch.compile(

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -111,12 +111,9 @@ class SpyrePlatform(Platform):
                     "The lists in VLLM_SPYRE_WARMUP_PROMPT_LENS and "
                     "VLLM_SPYRE_WARMUP_NEW_TOKENS must have equal length")
 
-        print("[SchedulerConfig] VLLM_SPYRE_WARMUP_PROMPT_LENS =",
-              wup_prompt_lens)
-        print("[SchedulerConfig] VLLM_SPYRE_WARMUP_NEW_TOKENS =",
-              wup_new_tokens)
-        print("[SchedulerConfig] VLLM_SPYRE_WARMUP_BATCH_SIZES =",
-              wup_batch_sizes)
+        logger.info("VLLM_SPYRE_WARMUP_PROMPT_LENS = %s", wup_prompt_lens)
+        logger.info("VLLM_SPYRE_WARMUP_NEW_TOKENS = %s", wup_new_tokens)
+        logger.info("VLLM_SPYRE_WARMUP_BATCH_SIZES = %s", wup_batch_sizes)
 
         cls.spyre_warmup_shapes = tuple(
             sorted([{

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -368,8 +368,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
             sampling_metadata=model_input.sampling_metadata,
         )
         t1 = time.time() - t0
-        print("[spyre_model_runner:execute_model] t_token: %.2fms" %
-              (t1 * 1000))
+        logger.debug("t_token: %.2fms", (t1 * 1000))
 
         model_output = ModelRunnerOutput(
             req_ids=list(self._req_ids2idx.keys()),
@@ -400,8 +399,9 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
         for input_ids_i in input_ids_list:
             seq_len = input_ids_i.size(0)
             if max_len > seq_len:
-                print(f"[SpyreModelRunner] INFO: Padding request of length "
-                      f"{seq_len} tokens to {max_len} tokens.")
+                logger.info(
+                    "Padding request of length %d tokens to %d tokens.",
+                    seq_len, max_len)
             pads = torch.ones(max_len - seq_len,
                               dtype=torch.long,
                               device=input_ids_i.device) * self.pad_token_id

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -69,18 +69,16 @@ class SpyreWorker(WorkerBaseV1):
                 "Warmup %d/%d prompt/decode/batchsize-shape "
                 "combinations...", i + 1, len(wup_new_tokens))
             logger.info(
-                "[SpyreWorker] Warming up for prompt length %d, "
-                "decoding %d tokens with batch size %d", prompt_len,
-                num_decode_tokens, batch_size)
+                "Warming up for prompt length %d, decoding %d tokens with "
+                "batch size %d", prompt_len, num_decode_tokens, batch_size)
             self._warmup_spyre_fixed_size(prompt_len, num_decode_tokens,
                                           self.restricted_tokens, batch_size)
         all_warmup_end_t = time.time()
         all_warmup_total_t = all_warmup_end_t - all_warmup_start_t
         logger.info(
-            "[SpyreWorker] All warmups for %d different "
-            "prompt/decode/batchsize-shape combinations finished. "
-            "Total warmup time %.3fs.", len(wup_new_tokens),
-            all_warmup_total_t)
+            "All warmups for %d different prompt/decode/batchsize-shape "
+            "combinations finished. Total warmup time %.3fs.",
+            len(wup_new_tokens), all_warmup_total_t)
 
     def check_health(self) -> None:
         """Basic health check (override for device-specific checks)."""

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -11,6 +11,7 @@ from huggingface_hub import hf_hub_download
 from vllm.config import VllmConfig
 from vllm.distributed import (ensure_model_parallel_initialized,
                               init_distributed_environment)
+from vllm.logger import init_logger
 from vllm.model_executor import set_random_seed
 from vllm.platforms import current_platform
 from vllm.v1.core.scheduler import SchedulerOutput
@@ -24,6 +25,8 @@ import vllm_spyre.envs as envs_spyre
 from vllm_spyre.model_executor.model_loader import spyre_setup
 from vllm_spyre.platform import SpyrePlatform
 from vllm_spyre.v1.worker.spyre_model_runner import SpyreModelRunner
+
+logger = init_logger(__name__)
 
 
 class SpyreWorker(WorkerBaseV1):
@@ -47,9 +50,9 @@ class SpyreWorker(WorkerBaseV1):
                                                  s["new_tokens"])
                                                 for s in spyre_warmup_shapes])
 
-        print(f"[SpyreWorker] Start warming up "
-              f"{len(wup_new_tokens)} "
-              f"different prompt/decode/batchsize-shape combinations.")
+        logger.info(
+            "Start warming up %d different "
+            "prompt/decode/batchsize-shape combinations.", len(wup_new_tokens))
         all_warmup_start_t = time.time()
         for i, (prompt_len, num_decode_tokens, batch_size) in enumerate([
             (s["prompt_length"], s["new_tokens"], s["batch_size"])
@@ -62,20 +65,22 @@ class SpyreWorker(WorkerBaseV1):
                     "VLLM_SPYRE_WARMUP_NEW_TOKENS must be "
                     "at least 2 (spyre requirement).")
             # warmup individual combination
-            print(f"[SpyreWorker] Warmup {i+1}/"
-                  f"{len(wup_new_tokens)} "
-                  f"prompt/decode/batchsize-shape combinations...")
-            print(f"[SpyreWorker] Warming up for prompt length {prompt_len}, "
-                  f"decoding {num_decode_tokens} tokens with batch "
-                  f"size {batch_size}")
+            logger.info(
+                "Warmup %d/%d prompt/decode/batchsize-shape "
+                "combinations...", i + 1, len(wup_new_tokens))
+            logger.info(
+                "[SpyreWorker] Warming up for prompt length %d, "
+                "decoding %d tokens with batch size %d", prompt_len,
+                num_decode_tokens, batch_size)
             self._warmup_spyre_fixed_size(prompt_len, num_decode_tokens,
                                           self.restricted_tokens, batch_size)
         all_warmup_end_t = time.time()
         all_warmup_total_t = all_warmup_end_t - all_warmup_start_t
-        print(f"[SpyreWorker] All warmups for "
-              f"{len(wup_new_tokens)} different "
-              f"prompt/decode/batchsize-shape combinations finished. "
-              f"Total warmup time {all_warmup_total_t}s.")
+        logger.info(
+            "[SpyreWorker] All warmups for %d different "
+            "prompt/decode/batchsize-shape combinations finished. "
+            "Total warmup time %.3fs.", len(wup_new_tokens),
+            all_warmup_total_t)
 
     def check_health(self) -> None:
         """Basic health check (override for device-specific checks)."""
@@ -192,7 +197,7 @@ class SpyreWorker(WorkerBaseV1):
 
         self.restricted_tokens = restricted_tokens
 
-        print("[SpyreWorker] load model...")
+        logger.info("load model...")
         # TODO: check additionally if the Spyre card has enough memory
         # for all requested model warmups
         # printing env variables for debugging purposes
@@ -207,7 +212,7 @@ class SpyreWorker(WorkerBaseV1):
 
         load_model_end_t = time.time()
         load_model_total_t = load_model_end_t - load_model_start_t
-        print(f"\tload model took {load_model_total_t}s")
+        logger.info("load model took %.3fs", load_model_total_t)
 
     def _warmup_spyre_fixed_size(self, prompt_len, num_decode_tokens,
                                  special_token_ids, batch_size):


### PR DESCRIPTION
I noticed that we weren't seeing some of the `logger.warning` messages that I had put into the v1 code, because we never initialized the logging package correctly for the plugin.

This PR reconfigures the logging package on import, and copies the vllm logging config for `vllm_spyre` so that all the usual logging configurations still work. For example, `VLLM_LOGGING_LEVEL=WARNING` will turn the level down to warning for the vllm_spyre logs too. This allows users to configure logging the same way as they do with other hardware backends.

I went ahead and ported some of the prints in the v1 codepath to use logging as well. This now logs the file and line number where the logs came from, so we no longer need to maintain manual prefixes like `[SchedulerConfig]`  to denote where the log is from. An example snippet:

```
INFO 03-17 18:51:10 [spyre_worker.py:200] load model...
WARNING 03-17 18:51:10 [config.py:3600] Current VLLM config is not set.
INFO 03-17 18:51:10 [platform.py:114] VLLM_SPYRE_WARMUP_PROMPT_LENS = [64]
INFO 03-17 18:51:10 [platform.py:115] VLLM_SPYRE_WARMUP_NEW_TOKENS = [20]
INFO 03-17 18:51:10 [platform.py:116] VLLM_SPYRE_WARMUP_BATCH_SIZES = [1]
WARNING 03-17 18:51:10 [topk_topp_sampler.py:46] FlashInfer is not available. Falling back to the PyTorch-native implementation of top-p & top-k sampling. For the best performance, please install FlashInfer.
ignoring module=WordEmbedding when distributing module
INFO 03-17 18:51:10 [spyre.py:200] NOTICE: Adjusting torch._dynamo.config.cache_size_limit from 8 to 256 to accommodate prompt size of 64 and decode tokens of 20
INFO 03-17 18:51:10 [spyre_worker.py:215] load model took 0.237s
INFO 03-17 18:51:10 [kv_cache_utils.py:537] GPU KV cache size: 1,073,741,824 tokens
INFO 03-17 18:51:10 [kv_cache_utils.py:540] Maximum concurrency for 4,096 tokens per request: 262144.00x
INFO 03-17 18:51:10 [spyre_worker.py:53] Start warming up 1 different prompt/decode/batchsize-shape combinations.
INFO 03-17 18:51:10 [spyre_worker.py:68] Warmup 1/1 prompt/decode/batchsize-shape combinations...
```
