### PR TITLE
:construction_worker: Only fork v1 tests

### DIFF
--- a/.github/workflows/test-spyre.yml
+++ b/.github/workflows/test-spyre.yml
@@ -24,5 +24,6 @@ jobs:
           export MASTER_ADDR=localhost && \
           export DISTRIBUTED_STRATEGY_IGNORE_MODULES=WordEmbedding && \
           cd vllm-spyre && \
-          python -m pytest --forked --timeout=300  tests -v -k eager
+          python -m pytest --timeout=300  tests -v -k "V0 and eager" && \
+          python -m pytest --forked --timeout=300  tests -v -k "V1 and eager"
         '''


### PR DESCRIPTION
The v0 tests shouldn't need forking, since they clean up properly after themselves. This PR splits the pytest command into two separate runs, using `--forked` only for the v1 tests. 

This recent run took 12 minutes: https://github.com/vllm-project/vllm-spyre/actions/runs/13910223043/job/38922610694?pr=28
Let's see if this is faster without forking half the tests 🤞 