### PR TITLE
:bug: fix batch handling in V1 runner

### DIFF
--- a/tests/test_spyre_basic.py
+++ b/tests/test_spyre_basic.py
@@ -77,7 +77,7 @@ def test_output(
 
 @pytest.mark.parametrize("model", get_spyre_model_list())
 @pytest.mark.parametrize("backend", get_spyre_backend_list())
-@pytest.mark.parametrize("vllm_version", ["V1"])
+@pytest.mark.parametrize("vllm_version", ["V0", "V1"])
 def test_batch_handling(
     model: str,
     backend: str,
@@ -97,10 +97,10 @@ def test_batch_handling(
     # Importantly, these prompts are ordered so that they don't finish in the
     # order given
     prompts = [
-        "6 5 4 3",
-        "9 8 7 6",
-        "7 6 5 4",
-        "8 7 6 5",
+        "7 6 5 4 3",
+        "10 9 8 7 6",
+        "8 7 6 5 4",
+        "9 8 7 6 5",
     ]
 
     # Ensure that both:

--- a/tests/test_spyre_basic.py
+++ b/tests/test_spyre_basic.py
@@ -89,18 +89,18 @@ def test_batch_handling(
     # Test with batch size 4
     warmup_shape = (64, 20, 4)
 
-    # Have the model count down to zero and stop
+    # Have the model count down to one and stop
     vllm_sampling_params = SamplingParams(max_tokens=20,
                                           temperature=0,
-                                          stop="0",
+                                          stop="1",
                                           logprobs=0)
     # Importantly, these prompts are ordered so that they don't finish in the
     # order given
     prompts = [
-        "7 6 5 4 3",
-        "10 9 8 7 6",
-        "8 7 6 5 4",
-        "9 8 7 6 5",
+        "7 6 5 4",
+        "10 9 8 7",
+        "8 7 6 5",
+        "9 8 7 6",
     ]
 
     # Ensure that both:
@@ -117,7 +117,7 @@ def test_batch_handling(
         backend=backend,
         vllm_version=vllm_version)
 
-    assert vllm_results[0]["text"] == " 2 1 "
-    assert vllm_results[1]["text"] == " 5 4 3 2 1 "
-    assert vllm_results[2]["text"] == " 3 2 1 "
-    assert vllm_results[3]["text"] == " 4 3 2 1 "
+    assert vllm_results[0]["text"] == " 3 2 "
+    assert vllm_results[1]["text"] == " 6 5 4 3 2 "
+    assert vllm_results[2]["text"] == " 4 3 2 "
+    assert vllm_results[3]["text"] == " 5 4 3 2 "

--- a/tests/test_spyre_basic.py
+++ b/tests/test_spyre_basic.py
@@ -77,7 +77,7 @@ def test_output(
 
 @pytest.mark.parametrize("model", get_spyre_model_list())
 @pytest.mark.parametrize("backend", get_spyre_backend_list())
-@pytest.mark.parametrize("vllm_version", ["V0", "V1"])
+@pytest.mark.parametrize("vllm_version", ["V1"])
 def test_batch_handling(
     model: str,
     backend: str,

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -102,7 +102,15 @@ class SpyrePlatform(Platform):
             #       the scheduler always thinks there's a block available
             model_config.max_model_len = max_seq_len
             cache_config.block_size = model_config.max_model_len
-            cache_config.num_gpu_blocks_override = scheduler_config.max_num_seqs
+
+            if envs.VLLM_USE_V1:
+                # The V1 scheduler actually needs 2 blocks for each sequence...
+                cache_config.num_gpu_blocks_override = \
+                    scheduler_config.max_num_seqs * 2
+            else:
+                cache_config.num_gpu_blocks_override = \
+                    scheduler_config.max_num_seqs
+
             logger.info(
                 "Overriding configurations based on warmup shapes. "
                 "max_model_len=%d, max_num_seqs=%d, block_size=%d, "

--- a/vllm_spyre/v1/core/scheduler.py
+++ b/vllm_spyre/v1/core/scheduler.py
@@ -106,6 +106,13 @@ class SpyreScheduler(Scheduler):
                         # can work with the batch we have
                         break
 
+            logger.debug(
+                "Scheduling a new batch of %d requests, holding back %d "
+                "requests", len(self.waiting), len(self.holdback_queue))
+        else:
+            logger.debug("Scheduling a running batch of %d requests",
+                         len(self.running))
+
         outputs = super().schedule()
         return outputs
 

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -366,7 +366,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
 
         model_output = ModelRunnerOutput(
             req_ids=list(self._req_ids2idx.keys()),
-            req_id_to_index=self._req_ids2idx,
+            req_id_to_index=self._map_output_indices(),
             sampled_token_ids=output.sampled_token_ids.tolist(),
             spec_token_ids=None,
             logprobs=output.logprobs_tensors.tolists()
@@ -377,6 +377,28 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
             }  # TODO: prompt logprobs too
         )
         return model_output
+
+    def _map_output_indices(self) -> dict[str, int]:
+        """The inputs to the model are all padded to a constant batch size, and
+        self.req_id2idx is the map of request id -> padded index.
+        However, finished requests and padded requests are stripped from the
+        output, so the mapping of request id -> unpadded output index needs to
+        be created to be returned in `ModelRunnerOutput`.
+
+        For example if:
+        - self.model.indices = [F, T, T, F]
+        - self.req_ids2ix = {"A": 0, "B": 1, "C": 2, "D": 3}
+        This will output: {"B": 0, "C": 1}
+        """
+        remapped_indices = {}
+        for req_id, idx in self._req_ids2idx.items():
+            if self.model.indices[idx]:
+                # Sum up all the requests to the left of this one that are still
+                # processing. That should be this requests' index in the output
+                # tensor.
+                remapped_indices[req_id] = self.model.indices[0:idx].sum(
+                ).item()
+        return remapped_indices
 
     def _prepare_pad_input_ids(
         self,

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -366,7 +366,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
 
         model_output = ModelRunnerOutput(
             req_ids=list(self._req_ids2idx.keys()),
-            req_id_to_index=self._map_output_indices(),
+            req_id_to_index=self._get_unpadded_output_indices(),
             sampled_token_ids=output.sampled_token_ids.tolist(),
             spec_token_ids=None,
             logprobs=output.logprobs_tensors.tolists()
@@ -378,7 +378,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
         )
         return model_output
 
-    def _map_output_indices(self) -> dict[str, int]:
+    def _get_unpadded_output_indices(self) -> dict[str, int]:
         """The inputs to the model are all padded to a constant batch size, and
         self.req_id2idx is the map of request id -> padded index.
         However, finished requests and padded requests are stripped from the


### PR DESCRIPTION
@wallashss related to https://github.com/vllm-project/vllm-spyre/pull/24/files#r2001886143

This fixes an issue where requests could not finish out of order in a batch in the v1 model runner. The request indices need to be remapped to the un-padded output tensors so that the engine knows which output does with which request. Before this change, if the first request in a batch finished before any others, the v1 engine would index past the end of the tensor.

This _also_ addresses a small issue where the v1 scheduler actually seems to need at least 2 blocks for each sequence. I haven't looked into why exactly this is, but without this change it seems that we can only schedule at most half of a full batch. I added some debug logs to the SpyreScheduler so you can see how many requests it passes to the v1 scheduler when starting a new batch.