### PR TITLE
FMS Wrapper for static batching

### DIFF
--- a/examples/offline_inference_spyre_cb.py
+++ b/examples/offline_inference_spyre_cb.py
@@ -14,6 +14,7 @@ os.environ['VLLM_SPYRE_WARMUP_BATCH_SIZES'] = '4'
 os.environ['VLLM_SPYRE_DYNAMO_BACKEND'] = 'eager'
 os.environ['MASTER_ADDR'] = 'localhost'
 os.environ['MASTER_PORT'] = '12355'
+os.environ['VLLM_SPYRE_USE_CB'] = '1'
 
 # Sample prompts.
 template = (

--- a/vllm_spyre/envs.py
+++ b/vllm_spyre/envs.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     VLLM_SPYRE_WARMUP_PROMPT_LENS: Optional[List[int]] = None
     VLLM_SPYRE_WARMUP_NEW_TOKENS: Optional[List[int]] = None
     VLLM_SPYRE_WARMUP_BATCH_SIZES: Optional[List[int]] = None
+    VLLM_SPYRE_USE_CB: bool = False
 
 environment_variables: Dict[str, Callable[[], Any]] = {
     # Defines the prompt lengths the Spyre accelerator should be prepared
@@ -40,6 +41,10 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # - "eager": Skip compile entirely (for debug and testing
     "VLLM_SPYRE_DYNAMO_BACKEND":
     lambda: os.getenv("VLLM_SPYRE_DYNAMO_BACKEND", "sendnn_decoder"),
+
+    # If set, use the V1 continuous batching implementation
+    "VLLM_SPYRE_USE_CB":
+    lambda: bool(int(os.getenv("VLLM_SPYRE_USE_CB", "0"))),
 }
 
 

--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -83,7 +83,7 @@ class SpyreCausalLM(nn.Module):
 
         if is_prompt:
             self.tkv = 0
-            if envs_spyre.VLLM_SPYRE_USE_CB:
+            if not envs_spyre.VLLM_SPYRE_USE_CB:
                 self.model.past_key_value_states = None
 
         extra_kwargs = {}

--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -429,16 +429,16 @@ class FmsModelWrapper(FmsModelBaseWrapper):
         logits, key_value_states = output
 
         # updating (physical) KV cache: self.fms_kv_cache
-        for page in active_pages:
+        for idx, page in enumerate(sorted(active_pages)):
             for layer in range(len(self.fms_kv_cache)):
                 # inserting partial KV cache at correct location
                 # (page, tkv) in the KV cache of the whole batch
                 self.fms_kv_cache[layer][0][
                     page, :, :tkv, :] = key_value_states[layer][0][
-                        page, :, :, :]  # [1, 8, L, 128]
+                        idx, :, :, :]  # [1, 8, L, 128]
                 self.fms_kv_cache[layer][1][
                     page, :, :tkv, :] = key_value_states[layer][1][
-                        page, :, :, :]  # [1, 8, L, 128]
+                        idx, :, :, :]  # [1, 8, L, 128]
 
         return logits, tkv + 1
 


### PR DESCRIPTION
### FMS Wrapper for static batching

changes: 
- introducing env var `VLLM_SPYRE_USE_CB` to switch between continuous batching and static batching
- introducing `FmsModelPseudoWrapper` which mimics the static batching kv cache handling alongside the existing `FmsModelWrapper` for continuous batching kv cache handling
- both wrapper classes inherit from a base class `FmsModelBaseWrapper` to avoid code duplication. 