### PR TITLE
Ensure that warmup shapes are available after forking.

### DIFF
--- a/vllm_spyre/core/scheduler.py
+++ b/vllm_spyre/core/scheduler.py
@@ -28,6 +28,8 @@ from vllm.sequence import (Sequence, SequenceData, SequenceGroup,
                            SequenceStatus)
 from vllm.utils import Device, PyObjectCache
 
+from vllm_spyre.platform import SpyrePlatform
+
 logger = init_logger(__name__)
 
 
@@ -143,6 +145,12 @@ class SpyreScheduler:
         for i in range(1, self.scheduler_config.max_num_partial_prefills + 1):
             self.partial_prefill_budget_lookup_list[i] = (
                 scheduler_config.max_num_batched_tokens // i)
+
+        # SPYRE SPECIFIC CODE BLOCK START
+        self.spyre_warmup_shapes = SpyrePlatform.get_warmup_shapes(
+            self.scheduler_config
+        )
+        # SPYRE SPECIFIC CODE BLOCK END
 
     @property
     def next_cache_id(self):
@@ -668,8 +676,7 @@ class SpyreScheduler:
         seq_groups: List[ScheduledSequenceGroup] = []
 
         # SPYRE SPECIFIC CODE BLOCK START
-        spyre_warmup_shapes = self.scheduler_config.spyre_warmup_shapes
-        applicable_spyre_warmup_shapes = list(spyre_warmup_shapes)
+        applicable_spyre_warmup_shapes = list(self.spyre_warmup_shapes)
         # SPYRE SPECIFIC CODE BLOCK END
 
         waiting_queue = self.waiting

--- a/vllm_spyre/core/scheduler.py
+++ b/vllm_spyre/core/scheduler.py
@@ -669,7 +669,7 @@ class SpyreScheduler:
         seq_groups: List[ScheduledSequenceGroup] = []
 
         # SPYRE SPECIFIC CODE BLOCK START
-        spyre_warmup_shapes = current_platform.get_warmup_shapes()
+        spyre_warmup_shapes = self.scheduler_config.spyre_warmup_shapes
         applicable_spyre_warmup_shapes = list(spyre_warmup_shapes)
         # SPYRE SPECIFIC CODE BLOCK END
 

--- a/vllm_spyre/core/scheduler.py
+++ b/vllm_spyre/core/scheduler.py
@@ -22,7 +22,6 @@ from vllm.core.scheduler import (ARTIFICIAL_PREEMPTION_MAX_CNT,
                                  scheduler_running_outputs_builder,
                                  seq_group_metadata_builder)
 from vllm.logger import init_logger
-from vllm.platforms import current_platform
 # SPYRE SPECIFIC CODE BLOCK END
 from vllm.sequence import (Sequence, SequenceData, SequenceGroup,
                            SequenceGroupMetadata, SequenceGroupMetadataDelta,

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -75,10 +75,10 @@ class SpyrePlatform(Platform):
 
         # Override --max-num-seqs to the biggest warmup batch size
         # And override --max-model-len to the biggest warmup sequence
-        cls.set_warmup_shapes(scheduler_config)
+        spyre_warmup_shapes = cls.get_warmup_shapes(scheduler_config)
         max_batch_size = 0
         max_seq_len = 0
-        for shape in scheduler_config.spyre_warmup_shapes:
+        for shape in spyre_warmup_shapes:
             max_batch_size = max(max_batch_size, shape['batch_size'])
             max_seq_len = max(max_batch_size,
                               shape['prompt_length'] + shape['new_tokens'])
@@ -131,7 +131,7 @@ class SpyrePlatform(Platform):
         return torch.no_grad()
 
     @classmethod
-    def set_warmup_shapes(cls, scheduler_config) -> None:
+    def get_warmup_shapes(cls, scheduler_config) -> tuple[dict[str, int], ...]:
         # load warmup shapes and sort by "speed"
         wup_prompt_lens = envs_spyre.VLLM_SPYRE_WARMUP_PROMPT_LENS or []
         wup_batch_sizes = envs_spyre.VLLM_SPYRE_WARMUP_BATCH_SIZES or []
@@ -152,7 +152,7 @@ class SpyrePlatform(Platform):
         logger.info("VLLM_SPYRE_WARMUP_NEW_TOKENS = %s", wup_new_tokens)
         logger.info("VLLM_SPYRE_WARMUP_BATCH_SIZES = %s", wup_batch_sizes)
 
-        scheduler_config.spyre_warmup_shapes = tuple(
+        return tuple(
             sorted([{
                 'prompt_length': pl,
                 'new_tokens': nt,

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -1,5 +1,4 @@
 import operator
-import os
 from typing import TYPE_CHECKING, Optional
 
 import torch
@@ -51,16 +50,6 @@ class SpyrePlatform(Platform):
             if envs.VLLM_USE_V1:
                 parallel_config.worker_cls = \
                     "vllm_spyre.v1.worker.spyre_worker.SpyreWorker"
-
-                # Forking is required here because this class is used to set up
-                # the warmup shapes, and the workers that are now in separate
-                # processes need to retrieve them.
-                # If we can refactor the workers to setup the warmup shapes
-                # themselves, then we can support process spawning too.
-                if envs.VLLM_WORKER_MULTIPROC_METHOD != "fork":
-                    logger.warning("V1 integration requires "
-                                   "VLLM_WORKER_MULTIPROC_METHOD=fork")
-                    os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "fork"
             else:
                 parallel_config.worker_cls = \
                     "vllm_spyre.worker.spyre_worker.SpyreWorker"

--- a/vllm_spyre/v1/core/scheduler.py
+++ b/vllm_spyre/v1/core/scheduler.py
@@ -11,6 +11,8 @@ from vllm.v1.engine import EngineCoreOutput, EngineCoreOutputs, FinishReason
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
 
+from vllm_spyre.platform import SpyrePlatform
+
 logger = init_logger(__name__)
 
 
@@ -28,7 +30,7 @@ class SpyreScheduler(Scheduler):
 
         # All warmup shapes that we can support
         self.spyre_warmup_shapes: tuple[dict[str, int], ...] = \
-            self.scheduler_config.spyre_warmup_shapes
+            SpyrePlatform.get_warmup_shapes(self.scheduler_config)
 
         # We'll put all new requests into this queue so that the base scheduler
         # does not attempt to schedule them until we release them into the

--- a/vllm_spyre/v1/core/scheduler.py
+++ b/vllm_spyre/v1/core/scheduler.py
@@ -4,7 +4,6 @@ from collections import deque
 from typing import Deque
 
 from vllm.logger import init_logger
-from vllm.platforms import current_platform
 from vllm.sampling_params import SamplingParams
 from vllm.v1.core.scheduler import Scheduler
 from vllm.v1.core.scheduler_output import SchedulerOutput
@@ -29,7 +28,7 @@ class SpyreScheduler(Scheduler):
 
         # All warmup shapes that we can support
         self.spyre_warmup_shapes: tuple[dict[str, int], ...] = \
-            current_platform.get_warmup_shapes()
+            self.scheduler_config.spyre_warmup_shapes
 
         # We'll put all new requests into this queue so that the base scheduler
         # does not attempt to schedule them until we release them into the

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -7,7 +7,6 @@ import torch
 from torch import nn
 from vllm.config import DeviceConfig, VllmConfig
 from vllm.logger import init_logger
-from vllm.platforms import current_platform
 from vllm.sampling_params import SamplingParams
 from vllm.utils import is_pin_memory_available
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec
@@ -128,7 +127,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
         input_token_list: List[torch.Tensor] = []
 
         # find warmup shape to be used for padding and batching
-        spyre_warmup_shapes = current_platform.get_warmup_shapes()
+        spyre_warmup_shapes = self.scheduler_config.spyre_warmup_shapes
         applicable_spyre_warmup_shapes = [
             shape for shape in spyre_warmup_shapes
             if len(new_requests) <= shape['batch_size']

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -7,8 +7,7 @@ import torch
 from torch import nn
 from vllm.config import DeviceConfig, VllmConfig
 from vllm.logger import init_logger
-from vllm.platforms import current_platform
-from vllm.sampling_params import SamplingParams, SamplingType
+from vllm.sampling_params import SamplingType
 from vllm.utils import is_pin_memory_available
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec
 from vllm.v1.outputs import SamplerOutput
@@ -470,7 +469,6 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
                 req_index,
                 start_token_index:end_token_index] = req_data.new_token_ids
 
-
     def _get_padded_batch_size(self, new_requests: list[NewRequestData]):
         # find warmup shape to be used for padding and batching
         applicable_spyre_warmup_shapes = [
@@ -496,6 +494,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
         # If multiple warmup shapes apply, the first one is selected.
         # For improving performance, the warmup shapes in scheduler_config
         # are ordered by "processing speed".
-        min_pad_length_batch = applicable_spyre_warmup_shapes[0]['prompt_length']
+        min_pad_length_batch = applicable_spyre_warmup_shapes[0][
+            'prompt_length']
         padded_batch_size = applicable_spyre_warmup_shapes[0]['batch_size']
         return padded_batch_size, min_pad_length_batch

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -103,6 +103,9 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
         self._sampling_params_by_request: dict[str, SamplingParams] = {}
         self._max_logprobs: Optional[int] = None
 
+        self.spyre_warmup_shapes = SpyrePlatform.get_warmup_shapes(
+            self.scheduler_config)
+
     def get_model(self) -> nn.Module:
         return self.model
 
@@ -127,9 +130,8 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
         input_token_list: List[torch.Tensor] = []
 
         # find warmup shape to be used for padding and batching
-        spyre_warmup_shapes = self.scheduler_config.spyre_warmup_shapes
         applicable_spyre_warmup_shapes = [
-            shape for shape in spyre_warmup_shapes
+            shape for shape in self.spyre_warmup_shapes
             if len(new_requests) <= shape['batch_size']
         ]
         for request_data in new_requests:

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -13,7 +13,6 @@ from vllm.distributed import (ensure_model_parallel_initialized,
                               init_distributed_environment)
 from vllm.logger import init_logger
 from vllm.model_executor import set_random_seed
-from vllm.platforms import current_platform
 from vllm.sampling_params import SamplingParams
 from vllm.v1.core.scheduler import (CachedRequestData, NewRequestData,
                                     SchedulerOutput)
@@ -47,7 +46,8 @@ class SpyreWorker(WorkerBaseV1):
 
     def compile_or_warm_up_model(self) -> None:
         """Prepare model for execution through compilation/warmup."""
-        spyre_warmup_shapes = current_platform.get_warmup_shapes()
+        spyre_warmup_shapes = \
+            self.vllm_config.scheduler_config.spyre_warmup_shapes
         wup_prompt_lens, wup_new_tokens = zip(*[(s["prompt_length"],
                                                  s["new_tokens"])
                                                 for s in spyre_warmup_shapes])
@@ -221,7 +221,8 @@ class SpyreWorker(WorkerBaseV1):
         # for all requested model warmups
         # printing env variables for debugging purposes
         load_model_start_t = time.time()
-        spyre_warmup_shapes = current_platform.get_warmup_shapes()
+        spyre_warmup_shapes = \
+            self.vllm_config.scheduler_config.spyre_warmup_shapes
         wup_prompt_lens, wup_new_tokens = zip(*[(s["prompt_length"],
                                                  s["new_tokens"])
                                                 for s in spyre_warmup_shapes])

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -46,11 +46,9 @@ class SpyreWorker(WorkerBaseV1):
 
     def compile_or_warm_up_model(self) -> None:
         """Prepare model for execution through compilation/warmup."""
-        spyre_warmup_shapes = \
-            self.vllm_config.scheduler_config.spyre_warmup_shapes
-        wup_prompt_lens, wup_new_tokens = zip(*[(s["prompt_length"],
-                                                 s["new_tokens"])
-                                                for s in spyre_warmup_shapes])
+        wup_prompt_lens, wup_new_tokens = zip(
+            *[(s["prompt_length"], s["new_tokens"])
+              for s in self.spyre_warmup_shapes])
 
         logger.info(
             "Start warming up %d different "
@@ -58,7 +56,7 @@ class SpyreWorker(WorkerBaseV1):
         all_warmup_start_t = time.time()
         for i, (prompt_len, num_decode_tokens, batch_size) in enumerate([
             (s["prompt_length"], s["new_tokens"], s["batch_size"])
-                for s in spyre_warmup_shapes
+                for s in self.spyre_warmup_shapes
         ]):
             if self.model_config.task != "embed":
                 # TODO: remove if spyre supports
@@ -144,6 +142,8 @@ class SpyreWorker(WorkerBaseV1):
             self.model_runner = SpyreModelRunner(self.vllm_config,
                                                  self.is_driver_worker)
         self._env_initialized = False
+        self.spyre_warmup_shapes = SpyrePlatform.get_warmup_shapes(
+            self.vllm_config.scheduler_config)
 
     def init_distributed_environment(self) -> None:
         """Initialize the distributed environment."""
@@ -221,11 +221,9 @@ class SpyreWorker(WorkerBaseV1):
         # for all requested model warmups
         # printing env variables for debugging purposes
         load_model_start_t = time.time()
-        spyre_warmup_shapes = \
-            self.vllm_config.scheduler_config.spyre_warmup_shapes
-        wup_prompt_lens, wup_new_tokens = zip(*[(s["prompt_length"],
-                                                 s["new_tokens"])
-                                                for s in spyre_warmup_shapes])
+        wup_prompt_lens, wup_new_tokens = zip(
+            *[(s["prompt_length"], s["new_tokens"])
+              for s in self.spyre_warmup_shapes])
 
         self.model_runner.load_model(prompt_lens=wup_prompt_lens,
                                      num_decode_tokens=wup_new_tokens)

--- a/vllm_spyre/worker/spyre_model_runner.py
+++ b/vllm_spyre/worker/spyre_model_runner.py
@@ -126,7 +126,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
         input_token_list: List[torch.Tensor] = []
 
         # find warmup shape to be used for padding and batching
-        spyre_warmup_shapes = current_platform.get_warmup_shapes()
+        spyre_warmup_shapes = self.scheduler_config.spyre_warmup_shapes
         applicable_spyre_warmup_shapes = [
             shape for shape in spyre_warmup_shapes
             if len(seq_group_metadata_list) <= shape['batch_size']

--- a/vllm_spyre/worker/spyre_model_runner.py
+++ b/vllm_spyre/worker/spyre_model_runner.py
@@ -10,7 +10,6 @@ from vllm.config import (DeviceConfig, ModelConfig, ParallelConfig,
 from vllm.logger import init_logger
 from vllm.model_executor import SamplingMetadata
 from vllm.model_executor.layers.sampler import SamplerOutput
-from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors, SequenceGroupMetadata
 from vllm.utils import is_pin_memory_available
 from vllm.worker.model_runner_base import (

--- a/vllm_spyre/worker/spyre_model_runner.py
+++ b/vllm_spyre/worker/spyre_model_runner.py
@@ -10,6 +10,7 @@ from vllm.config import (DeviceConfig, ModelConfig, ParallelConfig,
 from vllm.logger import init_logger
 from vllm.model_executor import SamplingMetadata
 from vllm.model_executor.layers.sampler import SamplerOutput
+from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors, SequenceGroupMetadata
 from vllm.utils import is_pin_memory_available
 from vllm.worker.model_runner_base import (
@@ -79,6 +80,8 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
         self.scheduler_config = scheduler_config
         self.device_config = device_config
         self.is_driver_worker = is_driver_worker
+        self.spyre_warmup_shapes = current_platform.get_warmup_shapes(
+            self.scheduler_config)
 
         self.pad_token_id = 0
         if model_config is not None:
@@ -125,9 +128,8 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
         input_token_list: List[torch.Tensor] = []
 
         # find warmup shape to be used for padding and batching
-        spyre_warmup_shapes = self.scheduler_config.spyre_warmup_shapes
         applicable_spyre_warmup_shapes = [
-            shape for shape in spyre_warmup_shapes
+            shape for shape in self.spyre_warmup_shapes
             if len(seq_group_metadata_list) <= shape['batch_size']
         ]
         for seq_group_metadata in seq_group_metadata_list:

--- a/vllm_spyre/worker/spyre_worker.py
+++ b/vllm_spyre/worker/spyre_worker.py
@@ -146,7 +146,7 @@ class SpyreWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
         # for all requested model warmups
         # printing env variables for debugging purposes
         load_model_start_t = time.time()
-        spyre_warmup_shapes = current_platform.get_warmup_shapes()
+        spyre_warmup_shapes = self.vllm_config.scheduler_config.spyre_warmup_shapes
         wup_prompt_lens, wup_new_tokens = zip(*[(s["prompt_length"],
                                                  s["new_tokens"])
                                                 for s in spyre_warmup_shapes])

--- a/vllm_spyre/worker/spyre_worker.py
+++ b/vllm_spyre/worker/spyre_worker.py
@@ -12,7 +12,6 @@ from vllm.config import VllmConfig
 from vllm.distributed import (ensure_model_parallel_initialized,
                               init_distributed_environment)
 from vllm.model_executor import set_random_seed
-from vllm.platforms import current_platform
 from vllm.sequence import ExecuteModelRequest
 from vllm.worker.worker_base import (LocalOrDistributedWorkerBase, WorkerBase,
                                      WorkerInput)
@@ -146,7 +145,8 @@ class SpyreWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
         # for all requested model warmups
         # printing env variables for debugging purposes
         load_model_start_t = time.time()
-        spyre_warmup_shapes = self.vllm_config.scheduler_config.spyre_warmup_shapes
+        spyre_warmup_shapes = \
+            self.vllm_config.scheduler_config.spyre_warmup_shapes
         wup_prompt_lens, wup_new_tokens = zip(*[(s["prompt_length"],
                                                  s["new_tokens"])
                                                 for s in spyre_warmup_shapes])


### PR DESCRIPTION
I need to do a demo using V0 online serving today, and I noticed that it is currently not working using latest `aiu-vllm-dev` image:

Trying to deploy the following:
```
python3 -m vllm.entrypoints.openai.api_server --model /models/llama-194m/ --max-model-len=2048 --block-size=128
```
produces:
```
[SpyreWorker] load model...
ERROR 03-25 09:16:21 [engine.py:448] type object 'SpyrePlatform' has no attribute 'spyre_warmup_shapes'
ERROR 03-25 09:16:21 [engine.py:448] Traceback (most recent call last):
ERROR 03-25 09:16:21 [engine.py:448]   File "/opt/vllm/lib64/python3.11/site-packages/vllm/engine/multiprocessing/engine.py", line 436, in run_mp_engine
ERROR 03-25 09:16:21 [engine.py:448]     engine = MQLLMEngine.from_vllm_config(
ERROR 03-25 09:16:21 [engine.py:448]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-25 09:16:21 [engine.py:448]   File "/opt/vllm/lib64/python3.11/site-packages/vllm/engine/multiprocessing/engine.py", line 128, in from_vllm_config
ERROR 03-25 09:16:21 [engine.py:448]     return cls(
ERROR 03-25 09:16:21 [engine.py:448]            ^^^^
ERROR 03-25 09:16:21 [engine.py:448]   File "/opt/vllm/lib64/python3.11/site-packages/vllm/engine/multiprocessing/engine.py", line 82, in __init__
ERROR 03-25 09:16:21 [engine.py:448]     self.engine = LLMEngine(*args, **kwargs)
ERROR 03-25 09:16:21 [engine.py:448]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-25 09:16:21 [engine.py:448]   File "/opt/vllm/lib64/python3.11/site-packages/vllm/engine/llm_engine.py", line 280, in __init__
ERROR 03-25 09:16:21 [engine.py:448]     self.model_executor = executor_class(vllm_config=vllm_config, )
ERROR 03-25 09:16:21 [engine.py:448]                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-25 09:16:21 [engine.py:448]   File "/opt/vllm/lib64/python3.11/site-packages/vllm/executor/executor_base.py", line 52, in __init__
ERROR 03-25 09:16:21 [engine.py:448]     self._init_executor()
ERROR 03-25 09:16:21 [engine.py:448]   File "/opt/vllm/lib64/python3.11/site-packages/vllm/executor/uniproc_executor.py", line 47, in _init_executor
ERROR 03-25 09:16:21 [engine.py:448]     self.collective_rpc("load_model")
ERROR 03-25 09:16:21 [engine.py:448]   File "/opt/vllm/lib64/python3.11/site-packages/vllm/executor/uniproc_executor.py", line 56, in collective_rpc
ERROR 03-25 09:16:21 [engine.py:448]     answer = run_method(self.driver_worker, method, args, kwargs)
ERROR 03-25 09:16:21 [engine.py:448]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-25 09:16:21 [engine.py:448]   File "/opt/vllm/lib64/python3.11/site-packages/vllm/utils.py", line 2216, in run_method
ERROR 03-25 09:16:21 [engine.py:448]     return func(*args, **kwargs)
ERROR 03-25 09:16:21 [engine.py:448]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 03-25 09:16:21 [engine.py:448]   File "/opt/vllm/lib64/python3.11/site-packages/vllm_spyre/worker/spyre_worker.py", line 149, in load_model
ERROR 03-25 09:16:21 [engine.py:448]     spyre_warmup_shapes = current_platform.get_warmup_shapes()
ERROR 03-25 09:16:21 [engine.py:448]                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-25 09:16:21 [engine.py:448]   File "/opt/vllm/lib64/python3.11/site-packages/vllm_spyre/platform.py", line 167, in get_warmup_shapes
ERROR 03-25 09:16:21 [engine.py:448]     return cls.spyre_warmup_shapes
ERROR 03-25 09:16:21 [engine.py:448]            ^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-25 09:16:21 [engine.py:448] AttributeError: type object 'SpyrePlatform' has no attribute 'spyre_warmup_shapes'
```

It looks like the engine process is getting forked **after** we parse the warmup shapes in the main process, and thus in the engine process they don't exist. 

It doesn't look like the platform is really the best place to store "state". Why don't we just use the config instead? I understand it is a little bit nasty since we can't "change" that class in the plugin, but it works very nicely. 