### PR TITLE
[V1] Fix importings for schedule repackaging

### DIFF
--- a/vllm_spyre/v1/core/sched/output.py
+++ b/vllm_spyre/v1/core/sched/output.py
@@ -1,0 +1,11 @@
+# This import wraps the importing of some vLLM classes based on the version
+
+try:
+    # vllm v0.8.2+
+    from vllm.v1.core.sched.output import CachedRequestData  # noqa: F401
+    from vllm.v1.core.sched.output import NewRequestData  # noqa: F401
+    from vllm.v1.core.sched.output import SchedulerOutput  # noqa: F401
+except ImportError:
+    from vllm.v1.core.scheduler import CachedRequestData  # noqa: F401
+    from vllm.v1.core.scheduler import NewRequestData  # noqa: F401
+    from vllm.v1.core.scheduler import SchedulerOutput  # noqa: F401

--- a/vllm_spyre/v1/core/scheduler.py
+++ b/vllm_spyre/v1/core/scheduler.py
@@ -1,16 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import deque
-from typing import Deque
+from typing import TYPE_CHECKING, Deque
 
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.sampling_params import SamplingParams
-from vllm.v1.core.scheduler import Scheduler
-from vllm.v1.core.scheduler_output import SchedulerOutput
 from vllm.v1.engine import EngineCoreOutput, EngineCoreOutputs, FinishReason
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
+
+try:
+    from vllm.v1.core.sched.scheduler import Scheduler
+except ImportError:
+    from vllm.v1.core.scheduler import Scheduler
+
+if TYPE_CHECKING:
+    from vllm_spyre.v1.core.sched.output import SchedulerOutput
 
 logger = init_logger(__name__)
 
@@ -71,7 +77,7 @@ class SpyreScheduler(Scheduler):
 
     def update_from_output(
         self,
-        scheduler_output: SchedulerOutput,
+        scheduler_output: "SchedulerOutput",
         model_runner_output: ModelRunnerOutput,
     ) -> EngineCoreOutputs:
         """Temporary override to handle rejected requests that were too large

--- a/vllm_spyre/v1/core/scheduler.py
+++ b/vllm_spyre/v1/core/scheduler.py
@@ -16,6 +16,8 @@ except ImportError:
 
 if TYPE_CHECKING:
     from vllm_spyre.v1.core.sched.output import SchedulerOutput
+else:
+    SchedulerOutput = None
 from vllm_spyre.platform import SpyrePlatform
 
 logger = init_logger(__name__)
@@ -77,7 +79,7 @@ class SpyreScheduler(Scheduler):
 
     def update_from_output(
         self,
-        scheduler_output: "SchedulerOutput",
+        scheduler_output: SchedulerOutput,
         model_runner_output: ModelRunnerOutput,
     ) -> EngineCoreOutputs:
         """Temporary override to handle rejected requests that were too large
@@ -88,7 +90,7 @@ class SpyreScheduler(Scheduler):
         outputs.outputs.extend(reject_outputs)
         return outputs
 
-    def schedule(self) -> "SchedulerOutput":
+    def schedule(self) -> SchedulerOutput:
         """This override adds constraints and then delegates most of the work
         to the base scheduler"""
 

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -26,9 +26,10 @@ from vllm_spyre.v1.worker.spyre_input_batch import (CachedRequestState,
 if TYPE_CHECKING:
     from vllm.attention.backends.abstract import AttentionBackend
     from vllm.model_executor.pooling_metadata import PoolingMetadata
+    from vllm_spyre.v1.core.sched.output import (CachedRequestData,
+                                                 NewRequestData,
+                                                 SchedulerOutput)
 
-from vllm.v1.core.scheduler import (CachedRequestData, NewRequestData,
-                                    SchedulerOutput)
 from vllm.v1.outputs import ModelRunnerOutput
 
 logger = init_logger(__name__)
@@ -131,7 +132,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
 
     def _prepare_prompt(
         self,
-        new_requests: List[NewRequestData],
+        new_requests: List["NewRequestData"],
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, List[int]]:
         assert len(new_requests) > 0
         input_token_list: List[torch.Tensor] = []
@@ -197,7 +198,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
 
     def _prepare_decode(
         self,
-        cached_requests: List[CachedRequestData],
+        cached_requests: list["CachedRequestData"],
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         assert len(cached_requests) > 0
         input_tokens: List[List[int]] = [
@@ -258,7 +259,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
         return ModelInputForSpyre.from_broadcasted_tensor_dict(tensor_dict)
 
     def prepare_model_input(
-            self, scheduler_output: SchedulerOutput) -> ModelInputForSpyre:
+            self, scheduler_output: "SchedulerOutput") -> ModelInputForSpyre:
 
         # NOTE: We assume that all sequences in the group are all prompts or
         # all decodes.
@@ -432,7 +433,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
                                       use_mla=False)
         return {"foo": attn_spec}
 
-    def _update_states(self, scheduler_output: SchedulerOutput):
+    def _update_states(self, scheduler_output: "SchedulerOutput"):
         # Update the states of the running/resumed requests.
         # For now, we are updating input_batch.'s `token_ids_cpu`,
         # `num_tokens`
@@ -469,7 +470,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
                 start_token_index:end_token_index] = req_data.new_token_ids
 
 
-def get_padded_batch_size(new_requests: list[NewRequestData]):
+def get_padded_batch_size(new_requests: list["NewRequestData"]):
     # find warmup shape to be used for padding and batching
     spyre_warmup_shapes = current_platform.get_warmup_shapes()
     applicable_spyre_warmup_shapes = [

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -470,7 +470,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
                 req_index,
                 start_token_index:end_token_index] = req_data.new_token_ids
 
-    def _get_padded_batch_size(self, new_requests: list[NewRequestData]):
+    def _get_padded_batch_size(self, new_requests: list['NewRequestData']):
         # find warmup shape to be used for padding and batching
         applicable_spyre_warmup_shapes = [
             shape for shape in self.spyre_warmup_shapes

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -25,9 +25,14 @@ from vllm_spyre.v1.worker.spyre_input_batch import (CachedRequestState,
 if TYPE_CHECKING:
     from vllm.attention.backends.abstract import AttentionBackend
     from vllm.model_executor.pooling_metadata import PoolingMetadata
+
     from vllm_spyre.v1.core.sched.output import (CachedRequestData,
                                                  NewRequestData,
                                                  SchedulerOutput)
+else:
+    CachedRequestData = None
+    SchedulerOutput = None
+    NewRequestData = None
 
 from vllm.v1.outputs import ModelRunnerOutput
 
@@ -134,7 +139,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
 
     def _prepare_prompt(
         self,
-        new_requests: List["NewRequestData"],
+        new_requests: list[NewRequestData],
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, List[int]]:
         assert len(new_requests) > 0
         input_token_list: List[torch.Tensor] = []
@@ -199,7 +204,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
 
     def _prepare_decode(
         self,
-        cached_requests: list["CachedRequestData"],
+        cached_requests: list[CachedRequestData],
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         assert len(cached_requests) > 0
         input_tokens: List[List[int]] = [
@@ -260,7 +265,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
         return ModelInputForSpyre.from_broadcasted_tensor_dict(tensor_dict)
 
     def prepare_model_input(
-            self, scheduler_output: "SchedulerOutput") -> ModelInputForSpyre:
+            self, scheduler_output: SchedulerOutput) -> ModelInputForSpyre:
 
         # NOTE: We assume that all sequences in the group are all prompts or
         # all decodes.
@@ -294,7 +299,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
     @SpyrePlatform.inference_mode()
     def execute_model(
         self,
-        scheduler_output: "SchedulerOutput",
+        scheduler_output: SchedulerOutput,
         **kwargs,
     ) -> ModelRunnerOutput:
 
@@ -434,7 +439,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
                                       use_mla=False)
         return {"foo": attn_spec}
 
-    def _update_states(self, scheduler_output: "SchedulerOutput"):
+    def _update_states(self, scheduler_output: SchedulerOutput):
         # Update the states of the running/resumed requests.
         # For now, we are updating input_batch.'s `token_ids_cpu`,
         # `num_tokens`
@@ -470,7 +475,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
                 req_index,
                 start_token_index:end_token_index] = req_data.new_token_ids
 
-    def _get_padded_batch_size(self, new_requests: list['NewRequestData']):
+    def _get_padded_batch_size(self, new_requests: list[NewRequestData]):
         # find warmup shape to be used for padding and batching
         applicable_spyre_warmup_shapes = [
             shape for shape in self.spyre_warmup_shapes

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -15,8 +15,6 @@ from vllm.logger import init_logger
 from vllm.model_executor import set_random_seed
 from vllm.platforms import current_platform
 from vllm.sampling_params import SamplingParams
-from vllm.v1.core.scheduler import (CachedRequestData, NewRequestData,
-                                    SchedulerOutput)
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.worker.worker_base import WorkerBase as WorkerBaseV1
@@ -25,6 +23,8 @@ from vllm.worker.worker_base import WorkerBase
 import vllm_spyre.envs as envs_spyre
 from vllm_spyre.model_executor.model_loader import spyre_setup
 from vllm_spyre.platform import SpyrePlatform
+from vllm_spyre.v1.core.sched.output import (CachedRequestData, NewRequestData,
+                                             SchedulerOutput)
 from vllm_spyre.v1.worker.spyre_model_runner import SpyreModelRunner
 
 logger = init_logger(__name__)


### PR DESCRIPTION
Fix #45 

I created a new file that we can import the needed classes from vllm and it solves depending the installed version (for backward compatibility). 

I also did some changes that are only related to TYPE_CHECKING
