### PR TITLE
Enable V1 in test_spyre_max_prompt_length

### DIFF
--- a/tests/test_spyre_max_prompt_length.py
+++ b/tests/test_spyre_max_prompt_length.py
@@ -29,7 +29,7 @@ from vllm import SamplingParams
                          [[(64, 20, 4)], [(64, 20, 4), (128, 20, 4)]]
                          )  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend", get_spyre_backend_list())
-@pytest.mark.parametrize("vllm_version", ["V0","V1"])
+@pytest.mark.parametrize("vllm_version", ["V0", "V1"])
 def test_output(
     model: str,
     prompts: List[str],

--- a/tests/test_spyre_max_prompt_length.py
+++ b/tests/test_spyre_max_prompt_length.py
@@ -29,7 +29,7 @@ from vllm import SamplingParams
                          [[(64, 20, 4)], [(64, 20, 4), (128, 20, 4)]]
                          )  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend", get_spyre_backend_list())
-@pytest.mark.parametrize("vllm_version", ["V0"])  # Todo: V1 support
+@pytest.mark.parametrize("vllm_version", ["V0","V1"])
 def test_output(
     model: str,
     prompts: List[str],


### PR DESCRIPTION
[Issue 29](https://github.com/vllm-project/vllm-spyre/issues/29) presents a bug where a specific item in a test was working in V0 and stopped working in V1. 

Currently it seams to be fixed since all tests passed when using V1 and one timeout occurred when using V0. The item that got a timeout passes the test when it is run alone.

I ran the tests using the following commands:

v0: `python -m pytest --timeout=300  tests -v -k "V0 and eager"` 
v1: `python -m pytest --forked --timeout=300  tests -v -k "V1- and eager"`

Item that got a timeout:

`python -m pytest --forked tests -v -k tests/test_spyre_tensor_parallel.py::test_output[V0-eager-2-warmup_shapes0-prompts0-/models/llama-194m]
`

I also run the test using:

`pytest -v -s --forked tests/test_spyre_max_prompt_length.py`

In this last the only item that didn't pass was a in the combination `[V0-sendnn_decoder-warmup_shapes1-prompts0-/models/llama-194m]` and `[V1-sendnn_decoder-warmup_shapes1-prompts0-/models/llama-194m]`, both using sendnn, which to my knowledge we are not looking at right now.


