### PR TITLE
[Bugfix][V0][V1] Fix crashes from cancelling requests

### DIFF
--- a/vllm_spyre/core/scheduler.py
+++ b/vllm_spyre/core/scheduler.py
@@ -24,8 +24,8 @@ from vllm.core.scheduler import (ARTIFICIAL_PREEMPTION_MAX_CNT,
 from vllm.logger import init_logger
 # SPYRE SPECIFIC CODE BLOCK END
 from vllm.sequence import (Sequence, SequenceData, SequenceGroup,
-                           SequenceGroupMetadata, SequenceGroupMetadataDelta,
-                           SequenceStatus)
+                           SequenceGroupBase, SequenceGroupMetadata,
+                           SequenceGroupMetadataDelta, SequenceStatus)
 from vllm.utils import Device, PyObjectCache
 
 from vllm_spyre.platform import SpyrePlatform
@@ -179,7 +179,11 @@ class SpyreScheduler:
         # Only for testing purposes.
         self.swapped.append(seq_group)
 
-    def abort_seq_group(self, request_id: Union[str, Iterable[str]]) -> None:
+    def abort_seq_group(
+        self,
+        request_id: Union[str, Iterable[str]],
+        seq_id_to_seq_group: Optional[Dict[str, SequenceGroupBase]] = None,
+    ) -> None:
         """Aborts a sequence group with the given ID.
 
         Check if the sequence group with the given ID

--- a/vllm_spyre/worker/spyre_model_runner.py
+++ b/vllm_spyre/worker/spyre_model_runner.py
@@ -284,7 +284,10 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
             # updating indices: set indices of newly finished sequences False
             if finished_requests_ids:
                 for seq_id in finished_requests_ids:
-                    self.model.indices[self._req_ids2idx[seq_id]] = False
+                    # ignore requests that are not in the batch, eg. requests
+                    # cancelled while waiting
+                    if idx := self._req_ids2idx.get(seq_id):
+                        self.model.indices[idx] = False
             (input_tokens, input_positions,
              input_masks) = self._prepare_decode(seq_group_metadata_list)
             seq_lens = []

--- a/vllm_spyre/worker/spyre_model_runner.py
+++ b/vllm_spyre/worker/spyre_model_runner.py
@@ -286,7 +286,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
                 for seq_id in finished_requests_ids:
                     # ignore requests that are not in the batch, eg. requests
                     # cancelled while waiting
-                    if idx := self._req_ids2idx.get(seq_id):
+                    if (idx := self._req_ids2idx.get(seq_id)) is not None:
                         self.model.indices[idx] = False
             (input_tokens, input_positions,
              input_masks) = self._prepare_decode(seq_group_metadata_list)


### PR DESCRIPTION
Some fixes from testing handling of request cancellation:
- in V0, guard against a KeyError in `_req_ids2idx`
- in v1, specialize the Scheduler's `finish_requests()` to handle the holdback_queue

FIX https://github.com/vllm-project/vllm-spyre/issues/36