### PR TITLE
[draft] add warmup and startup metrics

### DIFF
--- a/vllm_spyre/model_executor/model_loader/spyre_setup.py
+++ b/vllm_spyre/model_executor/model_loader/spyre_setup.py
@@ -130,6 +130,11 @@ def spyre_setup(rank=0, world_size=1, local_rank=0, local_size=1, verbose=False)
 
     # Export spyre configuration through metrics as fixed label
     if rank == 0:
+        name = "vllm:plugin:spyre:config"
+        # Cleanup existing, for CI.
+        if name in prometheus_client.REGISTRY._names_to_collectors:
+            collector = prometheus_client.REGISTRY._names_to_collectors[name]
+            prometheus_client.REGISTRY.unregister(collector)
         labels = {}
         for k in envs_spyre.environment_variables.keys():
             labels[k] = str(envs_spyre.environment_variables[k]())

--- a/vllm_spyre/worker/spyre_worker.py
+++ b/vllm_spyre/worker/spyre_worker.py
@@ -38,7 +38,12 @@ except ImportError:
 
 # Capture a oneshot metric (e.x warmup)
 def _spyre_metric_oneshot(name, labels, value):
-    gauge = prometheus_client.Gauge(name="vllm:plugin:spyre:" + name,
+    name = "vllm:plugin:spyre:" + name
+    # Cleanup existing, for CI.
+    if name in prometheus_client.REGISTRY._names_to_collectors:
+        collector = prometheus_client.REGISTRY._names_to_collectors[name]
+        prometheus_client.REGISTRY.unregister(collector)
+    gauge = prometheus_client.Gauge(name=name,
                                     documentation="Oneshot spyre metric",
                                     multiprocess_mode='mostrecent',
                                     labelnames=labels)


### PR DESCRIPTION
Export the startup variable configuration, and warmup metrics to the /metrics endpoint.

The gauges are prefixed vllm:plugin:spyre in hopes of avoiding namespace conflicts with other users.

For #58

TODO: also port to V1 plugin.