### PR TITLE
Add `requires-python` and update type hints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "ibm-fms==0.0.8",
     "vllm",
 ]
+requires-python = ">=3.9"
 
 [project.entry-points."vllm.platform_plugins"]
 spyre = "vllm_spyre:register"

--- a/tests/e2e/test_spyre_basic.py
+++ b/tests/e2e/test_spyre_basic.py
@@ -3,8 +3,6 @@
 Run `python -m pytest tests/test_spyre_basic.py`.
 """
 
-from typing import List, Tuple
-
 import pytest
 from spyre_util import (compare_results, generate_hf_output,
                         generate_spyre_vllm_output, get_spyre_backend_list,
@@ -25,8 +23,8 @@ from vllm import SamplingParams
 @pytest.mark.parametrize("vllm_version", ["V0", "V1"])
 def test_output(
     model: str,
-    prompts: List[str],
-    warmup_shape: Tuple[int, int, int],
+    prompts: list[str],
+    warmup_shape: tuple[int, int, int],
     backend: str,
     vllm_version: str,
 ) -> None:

--- a/tests/e2e/test_spyre_embeddings.py
+++ b/tests/e2e/test_spyre_embeddings.py
@@ -3,8 +3,6 @@
 Run `python -m pytest tests/test_spyre_embeddings.py`.
 """
 
-from typing import List, Tuple
-
 import pytest
 from spyre_util import (compare_embedding_results, get_spyre_backend_list,
                         get_spyre_model_list, spyre_vllm_embeddings,
@@ -25,8 +23,8 @@ from spyre_util import (compare_embedding_results, get_spyre_backend_list,
 @pytest.mark.parametrize("vllm_version", ["V0"])  # Todo: V1 support
 def test_output(
     model: str,
-    prompts: List[str],
-    warmup_shape: Tuple[int, int],
+    prompts: list[str],
+    warmup_shape: tuple[int, int],
     backend: str,
     vllm_version: str,
 ) -> None:

--- a/tests/e2e/test_spyre_max_new_tokens.py
+++ b/tests/e2e/test_spyre_max_new_tokens.py
@@ -3,8 +3,6 @@
 Run `python -m pytest tests/test_spyre_max_new_tokens.py`.
 """
 
-from typing import List, Tuple
-
 import pytest
 from spyre_util import (compare_results, generate_hf_output,
                         generate_spyre_vllm_output, get_spyre_backend_list,
@@ -32,9 +30,9 @@ prompt2 = template.format("Provide a list of instructions for preparing "
 @pytest.mark.parametrize("vllm_version", ["V0", "V1"])
 def test_output(
     model: str,
-    prompts: List[str],
+    prompts: list[str],
     stop_last: bool,
-    warmup_shape: Tuple[int, int, int],
+    warmup_shape: tuple[int, int, int],
     backend: str,
     vllm_version: str,
 ) -> None:

--- a/tests/e2e/test_spyre_max_prompt_length.py
+++ b/tests/e2e/test_spyre_max_prompt_length.py
@@ -3,8 +3,6 @@
 Run `python -m pytest tests/test_spyre_max_prompt_length.py`.
 """
 
-from typing import List, Tuple
-
 import pytest
 from spyre_util import (compare_results, generate_hf_output,
                         generate_spyre_vllm_output, get_spyre_backend_list,
@@ -33,8 +31,8 @@ from vllm import SamplingParams
 @pytest.mark.parametrize("vllm_version", ["V0", "V1"])
 def test_output(
     model: str,
-    prompts: List[str],
-    warmup_shapes: List[Tuple[int, int, int]],
+    prompts: list[str],
+    warmup_shapes: list[tuple[int, int, int]],
     backend: str,
     vllm_version: str,
 ) -> None:

--- a/tests/e2e/test_spyre_seed.py
+++ b/tests/e2e/test_spyre_seed.py
@@ -4,7 +4,6 @@ Run `python -m pytest tests/test_spyre_seed.py`.
 """
 
 import math
-from typing import Tuple
 
 import pytest
 from spyre_util import (generate_spyre_vllm_output, get_spyre_backend_list,
@@ -29,7 +28,7 @@ def test_seed(
     prompt: str,
     temperature: float,
     seed: int,
-    warmup_shape: Tuple[int, int, int],
+    warmup_shape: tuple[int, int, int],
     backend: str,
     vllm_version: str,
 ) -> None:

--- a/tests/e2e/test_spyre_tensor_parallel.py
+++ b/tests/e2e/test_spyre_tensor_parallel.py
@@ -3,8 +3,6 @@
 Run `python -m pytest tests/test_spyre_tensor_parallel.py`.
 """
 
-from typing import List, Tuple
-
 import pytest
 from spyre_util import (compare_results, generate_hf_output,
                         generate_spyre_vllm_output, get_spyre_backend_list,
@@ -27,8 +25,8 @@ from vllm import SamplingParams
 @pytest.mark.parametrize("vllm_version", ["V0", "V1"])
 def test_output(
     model: str,
-    prompts: List[str],
-    warmup_shapes: List[Tuple[int, int, int]],
+    prompts: list[str],
+    warmup_shapes: list[tuple[int, int, int]],
     tp_size: int,
     backend: str,
     vllm_version: str,

--- a/tests/e2e/test_spyre_warmup_shapes.py
+++ b/tests/e2e/test_spyre_warmup_shapes.py
@@ -3,8 +3,6 @@
 Run `python -m pytest tests/test_spyre_warmup_shapes.py`.
 """
 
-from typing import List, Tuple
-
 import pytest
 from spyre_util import (compare_results, generate_hf_output,
                         generate_spyre_vllm_output, get_spyre_backend_list,
@@ -31,8 +29,8 @@ from vllm import SamplingParams
 @pytest.mark.parametrize("vllm_version", ["V0", "V1"])
 def test_output(
     model: str,
-    prompts: List[str],
-    warmup_shapes: List[Tuple[int, int, int]],
+    prompts: list[str],
+    warmup_shapes: list[tuple[int, int, int]],
     backend: str,
     vllm_version: str,
 ) -> None:

--- a/tests/spyre_util.py
+++ b/tests/spyre_util.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import sys
 import time
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 import openai
@@ -133,13 +133,13 @@ class RemoteOpenAIServer:
 
 
 # vLLM / Spyre
-def generate_spyre_vllm_output(model: str, prompts: List[str],
-                               warmup_shapes: List[Tuple[int, int, int]],
+def generate_spyre_vllm_output(model: str, prompts: list[str],
+                               warmup_shapes: list[tuple[int, int, int]],
                                max_model_len: int, block_size: int,
                                sampling_params: Union[SamplingParams,
-                                                      List[SamplingParams]],
+                                                      list[SamplingParams]],
                                tensor_parallel_size: int, backend: str,
-                               vllm_version: str) -> List[Dict[str, Any]]:
+                               vllm_version: str) -> list[dict[str, Any]]:
 
     warmup_prompt_length = [t[0] for t in warmup_shapes]
     warmup_new_tokens = [t[1] for t in warmup_shapes]
@@ -186,8 +186,8 @@ def generate_spyre_vllm_output(model: str, prompts: List[str],
 
 # Hugging Face
 def generate_hf_output(
-        model: str, prompts: List[str],
-        max_new_tokens: Union[int, List[int]]) -> List[Dict[str, Any]]:
+        model: str, prompts: list[str],
+        max_new_tokens: Union[int, list[int]]) -> list[dict[str, Any]]:
 
     if not isinstance(max_new_tokens, list):
         max_new_tokens = [max_new_tokens] * len(prompts)
@@ -232,11 +232,11 @@ def generate_hf_output(
 
 
 # compare results
-def compare_results(model: str, prompts: List[str],
-                    warmup_shapes: List[Tuple[int, int,
+def compare_results(model: str, prompts: list[str],
+                    warmup_shapes: list[tuple[int, int,
                                               int]], tensor_parallel_size: int,
-                    backend: str, vllm_results: List[Dict[str, Any]],
-                    hf_results: List[Dict[str, Any]]):
+                    backend: str, vllm_results: list[dict[str, Any]],
+                    hf_results: list[dict[str, Any]]):
 
     print(f"\nmodel:         {model:s}")
     print(f"warmup shapes: {warmup_shapes}")
@@ -323,11 +323,11 @@ def compare_results(model: str, prompts: List[str],
 
 
 # vLLM / Spyre
-def spyre_vllm_embeddings(model: str, prompts: List[str],
-                          warmup_shapes: List[Tuple[int, int]],
+def spyre_vllm_embeddings(model: str, prompts: list[str],
+                          warmup_shapes: list[tuple[int, int]],
                           max_model_len: int, block_size: int,
                           tensor_parallel_size: int, backend: str,
-                          vllm_version: str) -> List[Dict[str, Any]]:
+                          vllm_version: str) -> list[dict[str, Any]]:
 
     warmup_prompt_length = [t[0] for t in warmup_shapes]
     warmup_new_tokens = [0] * len(warmup_shapes)
@@ -360,7 +360,7 @@ def spyre_vllm_embeddings(model: str, prompts: List[str],
 
 
 # Hugging Face
-def st_embeddings(model: str, prompts: List[str]) -> List[Dict[str, Any]]:
+def st_embeddings(model: str, prompts: list[str]) -> list[dict[str, Any]]:
 
     model = SentenceTransformer(model)
 
@@ -377,11 +377,11 @@ def st_embeddings(model: str, prompts: List[str]) -> List[Dict[str, Any]]:
 
 
 # compare results
-def compare_embedding_results(model: str, prompts: List[str],
-                              warmup_shapes: List[Tuple[int, int]],
+def compare_embedding_results(model: str, prompts: list[str],
+                              warmup_shapes: list[tuple[int, int]],
                               tensor_parallel_size: int, backend: str,
-                              vllm_results: List[Dict[str, Any]],
-                              hf_results: List[Dict[str, Any]]):
+                              vllm_results: list[dict[str, Any]],
+                              hf_results: list[dict[str, Any]]):
 
     print(f"\nmodel:         {model:s}")
     print(f"warmup shapes: {warmup_shapes}")

--- a/vllm_spyre/envs.py
+++ b/vllm_spyre/envs.py
@@ -1,16 +1,16 @@
 import os
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 if TYPE_CHECKING:
     VLLM_SPYRE_DYNAMO_BACKEND: str = "sendnn_decoder"
-    VLLM_SPYRE_WARMUP_PROMPT_LENS: Optional[List[int]] = None
-    VLLM_SPYRE_WARMUP_NEW_TOKENS: Optional[List[int]] = None
-    VLLM_SPYRE_WARMUP_BATCH_SIZES: Optional[List[int]] = None
+    VLLM_SPYRE_WARMUP_PROMPT_LENS: Optional[list[int]] = None
+    VLLM_SPYRE_WARMUP_NEW_TOKENS: Optional[list[int]] = None
+    VLLM_SPYRE_WARMUP_BATCH_SIZES: Optional[list[int]] = None
     VLLM_SPYRE_USE_CB: bool = False
     VLLM_SPYRE_MAX_BATCH_SIZE: int = 0
     VLLM_SPYRE_MAX_CONTEXT_LENGTH: int = 0
 
-environment_variables: Dict[str, Callable[[], Any]] = {
+environment_variables: dict[str, Callable[[], Any]] = {
     # Defines the prompt lengths the Spyre accelerator should be prepared
     # for, formatted as comma separated list.
     "VLLM_SPYRE_WARMUP_PROMPT_LENS":

--- a/vllm_spyre/v1/core/scheduler.py
+++ b/vllm_spyre/v1/core/scheduler.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import deque
-from typing import TYPE_CHECKING, Deque
+from typing import TYPE_CHECKING
 
 from vllm.logger import init_logger
 from vllm.sampling_params import SamplingParams
@@ -46,7 +46,7 @@ class SpyreScheduler(Scheduler):
         # Requests are temporarily moved to this queue so that the base
         # scheduler does not see them. This lets us ensure that the set of
         # requests scheduled have at least one common warmup shape.
-        self.holdback_queue: Deque[Request] = deque()
+        self.holdback_queue: deque[Request] = deque()
 
         self.rejected_requests: set[str] = set()
 
@@ -176,7 +176,7 @@ class SpyreScheduler(Scheduler):
         return reject_outputs
 
     def _reject_from_queue(self,
-                           queue: Deque[Request]) -> list[EngineCoreOutput]:
+                           queue: deque[Request]) -> list[EngineCoreOutput]:
         """Remove rejected requests from a given queue and return a list of 
         engine core outputs to return for them"""
         reject_outputs: list[EngineCoreOutput] = []

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -1,7 +1,7 @@
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import (TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple,
-                    Type, TypeVar)
+from typing import TYPE_CHECKING, Any, Optional, TypeVar
 
 import torch
 from torch import nn
@@ -58,7 +58,7 @@ class ModelInputForSpyre(ModelRunnerInputBase):
     # unused
     virtual_engine: Optional[int] = None
 
-    def as_broadcastable_tensor_dict(self) -> Dict[str, Any]:
+    def as_broadcastable_tensor_dict(self) -> dict[str, Any]:
         tensor_dict = {
             "input_tokens": self.input_tokens,
             "input_positions": self.input_positions,
@@ -71,8 +71,8 @@ class ModelInputForSpyre(ModelRunnerInputBase):
 
     @classmethod
     def from_broadcasted_tensor_dict(
-        cls: Type[TModelInputForSpyre],
-        tensor_dict: Dict[str, Any],
+        cls: type[TModelInputForSpyre],
+        tensor_dict: dict[str, Any],
         attn_backend: Optional["AttentionBackend"] = None,
     ) -> TModelInputForSpyre:
         tensor_dict = _init_sampling_metadata_from_tensor_dict(tensor_dict)
@@ -122,14 +122,14 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
         return self.model.model.model.config.src_vocab_size
 
     def make_model_input_from_broadcasted_tensor_dict(
-            self, tensor_dict: Dict[str, Any]) -> ModelInputForSpyre:
+            self, tensor_dict: dict[str, Any]) -> ModelInputForSpyre:
         return ModelInputForSpyre.from_broadcasted_tensor_dict(tensor_dict)
 
     def _prepare_pad_input_ids(
         self,
-        input_ids_list: List[torch.Tensor],
+        input_ids_list: list[torch.Tensor],
         min_pad_length: int = 0,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """left side padding implemented as
         in fms.utils.generation.pad_input_id"""
         max_len = max([min_pad_length] +
@@ -167,9 +167,9 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
 
     def pad_input_ids(
         self,
-        input_ids_list: List[torch.Tensor],
+        input_ids_list: list[torch.Tensor],
         min_pad_length: int = 0,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
 
         padded_input_ids_list, mask_list, position_ids_list = self.\
             _prepare_pad_input_ids(input_ids_list, min_pad_length)
@@ -245,9 +245,9 @@ class StaticBatchingSpyreModelRunner(SpyreModelRunner):
     def _prepare_prompt(
         self,
         new_requests: list[NewRequestData],
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, List[int]]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, list[int]]:
         assert len(new_requests) > 0
-        input_token_list: List[torch.Tensor] = []
+        input_token_list: list[torch.Tensor] = []
         padded_batch_size, min_pad_length_batch = \
             self._get_padded_batch_size(new_requests)
 
@@ -310,9 +310,9 @@ class StaticBatchingSpyreModelRunner(SpyreModelRunner):
     def _prepare_decode(
         self,
         cached_requests: list[CachedRequestData],
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         assert len(cached_requests) > 0
-        input_tokens: List[List[int]] = [
+        input_tokens: list[list[int]] = [
             [0] for _ in range(self._position_ids.shape[0])
         ]
 
@@ -552,17 +552,17 @@ class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):
 
         # TO DO: move to InputBatch
         self.req_ids2page: dict = {}
-        self.active_pages: List[int] = []
+        self.active_pages: list[int] = []
         self.tkv = 0
         self.free_pages = [i for i in range(max_batch_size)]
         self.min_pad_length_batch = max_prompt_length
 
     def _prepare_prompt(
         self,
-        new_requests: List[NewRequestData],
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, List[int]]:
+        new_requests: list[NewRequestData],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, list[int]]:
         assert len(new_requests) > 0
-        input_token_list: List[torch.Tensor] = []
+        input_token_list: list[torch.Tensor] = []
 
         # Internal state is managed here.
         self.active_pages = []
@@ -599,8 +599,8 @@ class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):
 
     def _prepare_decode(
         self,
-        cached_requests: List[CachedRequestData],
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        cached_requests: list[CachedRequestData],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         assert len(cached_requests) > 0
         input_tokens = []
         self.active_pages = []
@@ -626,9 +626,9 @@ class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):
 
     def _prepare_pos_mask_decode(
         self,
-        cached_requests: List[CachedRequestData],
+        cached_requests: list[CachedRequestData],
         tkv: int = 0,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
 
         mask_list = []
         position_ids_list = []

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -3,7 +3,7 @@ import json
 import os
 import platform
 import time
-from typing import List, Optional
+from typing import Optional
 
 import torch
 import torch.distributed as dist
@@ -115,7 +115,7 @@ class SpyreWorker(WorkerBaseV1):
         return 1 << 64
 
     def initialize_from_config(self,
-                               kv_cache_configs: List[KVCacheConfig]) -> None:
+                               kv_cache_configs: list[KVCacheConfig]) -> None:
         """Construct the KV cache from the provided configs.
         Currently, we do not support paged attention or kv caching"""
         pass
@@ -347,8 +347,8 @@ class SpyreWorker(WorkerBaseV1):
     def _warmup_model_forward_pass(
         self,
         scheduler_output: SchedulerOutput,
-        requests: List[NewRequestData],
-        cached_requests: List[CachedRequestData],
+        requests: list[NewRequestData],
+        cached_requests: list[CachedRequestData],
         num_decode_tokens,
     ):
         """Handle a complete forward pass"""
@@ -367,7 +367,7 @@ class SpyreWorker(WorkerBaseV1):
         return True
 
     @property
-    def kv_cache(self) -> Optional[List[List[torch.Tensor]]]:
+    def kv_cache(self) -> Optional[list[list[torch.Tensor]]]:
         return None
 
     @SpyrePlatform.inference_mode()

--- a/vllm_spyre/worker/spyre_embedding_model_runner.py
+++ b/vllm_spyre/worker/spyre_embedding_model_runner.py
@@ -1,5 +1,6 @@
 import time
-from typing import Dict, Iterable, List, Optional, Tuple
+from collections.abc import Iterable
+from typing import Optional
 
 import torch
 from transformers import AutoModel
@@ -24,7 +25,7 @@ BACKEND_LIST = ['sendnn', 'inductor']
 class SpyreEmbeddingModelRunner(SpyreModelRunner):
 
     # Map of request_id -> generator used for seeded random sampling
-    generators: Dict[str, torch.Generator] = {}
+    generators: dict[str, torch.Generator] = {}
 
     def __init__(
         self,
@@ -65,9 +66,9 @@ class SpyreEmbeddingModelRunner(SpyreModelRunner):
 
     def prepare_input_tensors(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
-        finished_requests_ids: Optional[List[str]] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, PoolingMetadata]:
+        seq_group_metadata_list: list[SequenceGroupMetadata],
+        finished_requests_ids: Optional[list[str]] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, PoolingMetadata]:
         # NOTE: We assume that all sequences in the group are all prompts
         (input_tokens, input_positions, input_masks,
          seq_lens) = self._prepare_prompt(seq_group_metadata_list)
@@ -79,17 +80,17 @@ class SpyreEmbeddingModelRunner(SpyreModelRunner):
 
     def _prepare_pooling(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
-        prompt_lens: List[int],
+        seq_group_metadata_list: list[SequenceGroupMetadata],
+        prompt_lens: list[int],
     ) -> PoolingMetadata:
         """Prepare PoolingMetadata for the sequence group metadata list."""
-        seq_groups: List[Tuple[List[int], PoolingParams]] = []
+        seq_groups: list[tuple[list[int], PoolingParams]] = []
         for i, seq_group_metadata in enumerate(seq_group_metadata_list):
             seq_ids = list(seq_group_metadata.seq_data.keys())
             pooling_params = seq_group_metadata.pooling_params
             seq_groups.append((seq_ids, pooling_params))
 
-        seq_data: Dict[int, SequenceData] = {}
+        seq_data: dict[int, SequenceData] = {}
         for seq_group_metadata in seq_group_metadata_list:
             seq_data.update(seq_group_metadata.seq_data)
 
@@ -103,9 +104,9 @@ class SpyreEmbeddingModelRunner(SpyreModelRunner):
 
     def pad_input_ids(
         self,
-        input_ids_list: List[torch.Tensor],
+        input_ids_list: list[torch.Tensor],
         min_pad_length: int = 0,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
 
         padded_input_ids_list, mask_list, position_ids_list = self.\
             _prepare_pad_input_ids(input_ids_list, min_pad_length)
@@ -118,9 +119,9 @@ class SpyreEmbeddingModelRunner(SpyreModelRunner):
 
     def prepare_model_input(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
+        seq_group_metadata_list: list[SequenceGroupMetadata],
         virtual_engine: int = 0,
-        finished_requests_ids: Optional[List[str]] = None
+        finished_requests_ids: Optional[list[str]] = None
     ) -> ModelInputForSpyre:
 
         (input_tokens, input_positions, input_masks,
@@ -135,11 +136,11 @@ class SpyreEmbeddingModelRunner(SpyreModelRunner):
     def execute_model(
         self,
         model_input: ModelInputForSpyre,
-        kv_caches: Optional[List[torch.Tensor]] = None,
+        kv_caches: Optional[list[torch.Tensor]] = None,
         intermediate_tensors: Optional[IntermediateTensors] = None,
         num_steps: int = 1,
         **kwargs,
-    ) -> Optional[List[PoolerOutput]]:
+    ) -> Optional[list[PoolerOutput]]:
 
         t0 = time.time()
 
@@ -178,12 +179,12 @@ class SpyreEmbeddingModelRunner(SpyreModelRunner):
         input_ids: torch.Tensor,
         mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.Tensor] = None,
-        past_key_value_states: Optional[List[Tuple[torch.Tensor,
+        past_key_value_states: Optional[list[tuple[torch.Tensor,
                                                    torch.Tensor]]] = None,
         use_cache: bool = False,
         only_last_token: bool = False,
         attn_algorithm: Optional[str] = None
-    ) -> Tuple[torch.Tensor, Optional[List[Tuple[torch.Tensor,
+    ) -> tuple[torch.Tensor, Optional[list[tuple[torch.Tensor,
                                                  torch.Tensor]]]]:
 
         hidden_states, _ = self.model(

--- a/vllm_spyre/worker/spyre_model_runner.py
+++ b/vllm_spyre/worker/spyre_model_runner.py
@@ -1,7 +1,7 @@
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import (TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple,
-                    Type, TypeVar)
+from typing import TYPE_CHECKING, Any, Optional, TypeVar
 
 import torch
 from torch import nn
@@ -44,7 +44,7 @@ class ModelInputForSpyre(ModelRunnerInputBase):
     # unused
     virtual_engine: Optional[int] = None
 
-    def as_broadcastable_tensor_dict(self) -> Dict[str, Any]:
+    def as_broadcastable_tensor_dict(self) -> dict[str, Any]:
         tensor_dict = {
             "input_tokens": self.input_tokens,
             "input_positions": self.input_positions,
@@ -57,8 +57,8 @@ class ModelInputForSpyre(ModelRunnerInputBase):
 
     @classmethod
     def from_broadcasted_tensor_dict(
-        cls: Type[TModelInputForSpyre],
-        tensor_dict: Dict[str, Any],
+        cls: type[TModelInputForSpyre],
+        tensor_dict: dict[str, Any],
         attn_backend: Optional["AttentionBackend"] = None,
     ) -> TModelInputForSpyre:
         tensor_dict = _init_sampling_metadata_from_tensor_dict(tensor_dict)
@@ -122,10 +122,10 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
 
     def _prepare_prompt(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, List[int]]:
+        seq_group_metadata_list: list[SequenceGroupMetadata],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, list[int]]:
         assert len(seq_group_metadata_list) > 0
-        input_token_list: List[torch.Tensor] = []
+        input_token_list: list[torch.Tensor] = []
 
         # find warmup shape to be used for padding and batching
         applicable_spyre_warmup_shapes = [
@@ -198,10 +198,10 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
 
     def _prepare_decode(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        seq_group_metadata_list: list[SequenceGroupMetadata],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         assert len(seq_group_metadata_list) > 0
-        input_tokens: List[List[int]] = [
+        input_tokens: list[list[int]] = [
             [0] for _ in range(self._position_ids.shape[0])
         ]
 
@@ -260,14 +260,14 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
         self._mask = torch.stack(masks_new, dim=0)
 
     def make_model_input_from_broadcasted_tensor_dict(
-            self, tensor_dict: Dict[str, Any]) -> ModelInputForSpyre:
+            self, tensor_dict: dict[str, Any]) -> ModelInputForSpyre:
         return ModelInputForSpyre.from_broadcasted_tensor_dict(tensor_dict)
 
     def prepare_model_input(
         self,
-        seq_group_metadata_list: List[SequenceGroupMetadata],
+        seq_group_metadata_list: list[SequenceGroupMetadata],
         virtual_engine: int = 0,
-        finished_requests_ids: Optional[List[str]] = None
+        finished_requests_ids: Optional[list[str]] = None
     ) -> ModelInputForSpyre:
 
         # NOTE: We assume that all sequences in the group are all prompts or
@@ -312,11 +312,11 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
     def execute_model(
         self,
         model_input: ModelInputForSpyre,
-        kv_caches: Optional[List[torch.Tensor]] = None,
+        kv_caches: Optional[list[torch.Tensor]] = None,
         intermediate_tensors: Optional[IntermediateTensors] = None,
         num_steps: int = 1,
         **kwargs,
-    ) -> Optional[List[SamplerOutput]]:
+    ) -> Optional[list[SamplerOutput]]:
 
         t0 = time.time()
 
@@ -352,9 +352,9 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
 
     def _prepare_pad_input_ids(
         self,
-        input_ids_list: List[torch.Tensor],
+        input_ids_list: list[torch.Tensor],
         min_pad_length: int = 0,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """left side padding implemented as
         in fms.utils.generation.pad_input_id"""
         max_len = max([min_pad_length] +
@@ -391,9 +391,9 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
 
     def pad_input_ids(
         self,
-        input_ids_list: List[torch.Tensor],
+        input_ids_list: list[torch.Tensor],
         min_pad_length: int = 0,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
 
         padded_input_ids_list, mask_list, position_ids_list = self.\
             _prepare_pad_input_ids(input_ids_list, min_pad_length)
@@ -413,12 +413,12 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
         input_ids: torch.Tensor,
         mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.Tensor] = None,
-        past_key_value_states: Optional[List[Tuple[torch.Tensor,
+        past_key_value_states: Optional[list[tuple[torch.Tensor,
                                                    torch.Tensor]]] = None,
         use_cache: bool = False,
         only_last_token: bool = False,
         attn_algorithm: Optional[str] = None
-    ) -> Tuple[torch.Tensor, Optional[List[Tuple[torch.Tensor,
+    ) -> tuple[torch.Tensor, Optional[list[tuple[torch.Tensor,
                                                  torch.Tensor]]]]:
 
         return self.model.model.model(

--- a/vllm_spyre/worker/spyre_worker.py
+++ b/vllm_spyre/worker/spyre_worker.py
@@ -3,7 +3,7 @@ import json
 import os
 import platform
 import time
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import torch
 import torch.distributed as dist
@@ -296,7 +296,7 @@ class SpyreWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
                 only_last_token=True,
                 **extra_kwargs)
 
-    def determine_num_available_blocks(self) -> Tuple[int, int]:
+    def determine_num_available_blocks(self) -> tuple[int, int]:
         """Determine the number of available KV blocks.
 
         Swapping is not yet supported, so always return num_cpu_blocks=0.
@@ -337,7 +337,7 @@ class SpyreWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
         return True
 
     @property
-    def kv_cache(self) -> Optional[List[List[torch.Tensor]]]:
+    def kv_cache(self) -> Optional[list[list[torch.Tensor]]]:
         return None
 
     def prepare_worker_input(


### PR DESCRIPTION
This PR adds `requires-python` to the project table in our pyproject.toml. This tells installers what versions of python we support, which is good practice to include when publishing a package. Currently python 3.9 is the oldest version of python that has official support, it will reach end of life this October: https://devguide.python.org/versions/. This plugin shouldn't have any code that specifically prohibits installing with future python versions, so this sets the valid python version range to 3.9+.

As of python 3.9, type hinting with primitive container types (list, dict, tuple) became supported and type hinting with the types from the `typing` package was deprecated. This causes `ruff` to now fail, as we won't support any versions of python that require the older style type hints. So this PR also updates all the type hints, this was done with `ruff check . --fix --unsafe-fixes`. 