### PR TITLE
[CB] Fix Tensor Parallelism Error

### DIFF
--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -276,17 +276,14 @@ class ContinuousBatchingFmsModel(FmsModelBase):
         max_batch = envs_spyre.VLLM_SPYRE_MAX_BATCH_SIZE
         max_model_len = envs_spyre.VLLM_SPYRE_MAX_CONTEXT_LENGTH
 
+        num_kv_heads = model_config.get_num_kv_heads(parallel_config)
+
         if self.config.model_type == 'llama':
             num_layers = self.config.num_hidden_layers
-            num_kv_heads = max(
-                1, self.config.num_key_value_heads //
-                parallel_config.tensor_parallel_size)
             head_dim = self.config.hidden_size // \
                 self.config.num_attention_heads
         elif self.config.model_type == 'gpt_bigcode':
             num_layers = self.config.n_layer
-            num_kv_heads = 1 if self.config.multi_query else max(
-                1, self.config.n_head // parallel_config.tensor_parallel_size)
             head_dim = self.config.n_embd // self.config.n_head
         else:
             print(f"[SpyreCausalLM] model type {self.config.model_type} "

--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -278,12 +278,15 @@ class ContinuousBatchingFmsModel(FmsModelBase):
 
         if self.config.model_type == 'llama':
             num_layers = self.config.num_hidden_layers
-            num_kv_heads = self.config.num_key_value_heads
+            num_kv_heads = max(
+                1, self.config.num_key_value_heads //
+                parallel_config.tensor_parallel_size)
             head_dim = self.config.hidden_size // \
                 self.config.num_attention_heads
         elif self.config.model_type == 'gpt_bigcode':
             num_layers = self.config.n_layer
-            num_kv_heads = 1 if self.config.multi_query else self.config.n_head
+            num_kv_heads = 1 if self.config.multi_query else max(
+                1, self.config.n_head // parallel_config.tensor_parallel_size)
             head_dim = self.config.n_embd // self.config.n_head
         else:
             print(f"[SpyreCausalLM] model type {self.config.model_type} "


### PR DESCRIPTION
This fixes tensor parallelism error when using the new FMS API by adapting the tensor shape of `self.past_key_value_states` using the built-in function `get_num_kv_heads` of vLLM. 
* Closes #99 