### PR TITLE
:bug: Fix static batching with multiple shapes

### DIFF
--- a/tests/e2e/test_spyre_warmup_shapes.py
+++ b/tests/e2e/test_spyre_warmup_shapes.py
@@ -26,7 +26,7 @@ from vllm import SamplingParams
     "warmup_shapes", [[(64, 20, 8),
                        (128, 20, 4)]])  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend", get_spyre_backend_list())
-@pytest.mark.parametrize("vllm_version", ["V0", "V1"])
+@pytest.mark.parametrize("vllm_version", ["V1"])
 def test_output(
     model: str,
     prompts: list[str],

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -423,6 +423,7 @@ class StaticBatchingSpyreModelRunner(SpyreModelRunner):
         self._update_states(scheduler_output)
 
         model_input = self.prepare_model_input(scheduler_output)
+        self._mark_input_tensors(model_input)
 
         # TODO(Wallas): I think it would be better move the indices as argument
         # of the forward rather than set as an attribute of the model. I'm not
@@ -533,6 +534,32 @@ class StaticBatchingSpyreModelRunner(SpyreModelRunner):
             'prompt_length']
         padded_batch_size = applicable_spyre_warmup_shapes[0]['batch_size']
         return padded_batch_size, min_pad_length_batch
+
+    def _mark_input_tensors(self, model_input: ModelInputForSpyre) -> None:
+        """Yoinked from 
+        https://github.com/foundation-model-stack/aiu-fms-testing-utils/pull/13
+        """
+        # To produce like graphs during pre-fill, we mark the prefill
+        # batch x seq as static, but relax this for decode for the seq
+        if model_input.is_prompt:
+            # we always want prefill to be static to produce same-like graph
+            torch._dynamo.mark_static(model_input.input_tokens, 0)
+            torch._dynamo.mark_static(model_input.input_tokens, 1)
+            torch._dynamo.mark_static(model_input.input_masks, 0)
+            torch._dynamo.mark_static(model_input.input_masks, 1)
+            torch._dynamo.mark_static(model_input.input_masks, 2)
+            torch._dynamo.mark_static(model_input.input_positions, 0)
+            torch._dynamo.mark_static(model_input.input_positions, 1)
+        else:
+            # we always want the decode to be dynamic on sequence
+            torch._dynamo.mark_dynamic(model_input.input_tokens, 1)
+            torch._dynamo.mark_dynamic(model_input.input_masks, 1)
+            torch._dynamo.mark_dynamic(model_input.input_masks, 2)
+
+            # here self.model.model is a StaticBatchingFmsModel
+            for layer in self.model.model.past_key_value_states:
+                for tensor in layer:
+                    torch._dynamo.mark_static(tensor, 0)
 
 
 class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -88,6 +88,7 @@ class SpyreWorker(WorkerBaseV1):
             "All warmups for %d different prompt/decode/batchsize-shape "
             "combinations finished. Total warmup time %.3fs.",
             len(wup_new_tokens), all_warmup_total_t)
+        self.model_runner.complete_warmup()
 
     def check_health(self) -> None:
         """Basic health check (override for device-specific checks)."""


### PR DESCRIPTION
Closes #20 

This pulls over some code from https://github.com/foundation-model-stack/aiu-fms-testing-utils/pull/13 that properly marks tensors as static/dynamic for prefill and decode when doing static batching. I've tested on a spyre card and confirmed that I can compile multiple warmup shapes (with batch sizes > 1) and run batches of requests