### PR TITLE
:bug: fixup installs for future fms-mo versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,16 @@ namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
 # Never install torch, so that no dependencies can override it.
 # This requires that torch is installed separately in the target environment.
 # Triton >3.1 breaks tests against vllm/main and fms-mo requires it.
+# Triton also cannot be installed on macs.
 override-dependencies = [
     "torch; sys_platform == 'never'",
     "torchaudio; sys_platform == 'never'",
     "torchvision; sys_platform == 'never'",
-    "triton>=3.0,<3.2",
+    "triton>=3.0,<3.2; sys_platform != 'darwin'",
+]
+# fms-mo doesn't support python 3.9, so don't have UV try to resolve it
+environments = [
+    "python_version > '3.9'"
 ]
 
 [tool.uv.sources]


### PR DESCRIPTION
Our builds against fms-mo@main are failing now because fms-mo doesn't support python 3.9 and `uv sync` attempts to find a solution for all python versions we support, which includes python 3.9. After reading the literature, it seems like the solution is _not_ to mark 3.9 as unsupported by our library, but rather just configure uv to not try to solve for python 3.9.

This change fixes the uv sync error:
```
% uv add git+https://github.com/foundation-model-stack/fms-model-optimizer.git@main
    Updated https://github.com/foundation-model-stack/fms-model-optimizer.git (acbff2df0703919fceeb4c63776c747a43d08898)
  × No solution found when resolving dependencies for split (python_full_version == '3.9.*' and platform_machine == 'arm64' and sys_platform == 'darwin'):
  ╰─▶ Because the requested Python version (>=3.9) does not satisfy Python>3.9,<3.13 and fms-model-optimizer==0.2.1.dev201 depends on Python>3.9,<3.13, we can conclude
      that fms-model-optimizer==0.2.1.dev201 cannot be used.
      And because only fms-model-optimizer==0.2.1.dev201 is available and your project depends on fms-model-optimizer, we can conclude that your project's requirements
      are unsatisfiable.

      hint: The `requires-python` value (>=3.9) includes Python versions that are not supported by your dependencies (e.g., fms-model-optimizer==0.2.1.dev201 only
      supports >3.9, <3.13). Consider using a more restrictive `requires-python` value (like >3.9, <3.13).
  help: If you want to add the package regardless of the failed resolution, provide the `--frozen` flag to skip locking and syncing.
```

Also, since fms-mo now depends on triton, I configured uv to not install it on macs so that it doesn't break local installs for those of us with macs.