### PR TITLE
:fire: remove v0 from static batching test

### DIFF
--- a/tests/e2e/test_spyre_static_batching_limits.py
+++ b/tests/e2e/test_spyre_static_batching_limits.py
@@ -15,7 +15,8 @@ from vllm import LLM, SamplingParams
     [[(64, 20, 4)], [(64, 20, 4),
                      (128, 20, 4)]])  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend", get_spyre_backend_list())
-@pytest.mark.parametrize("vllm_version", ["V0", "V1"])
+@pytest.mark.parametrize("vllm_version",
+                         ["V1"])  # v0 doesn't support multiple shapes
 def test_max_prompt_len_and_new_tokens(model: str,
                                        warmup_shapes: list[tuple[int, int,
                                                                  int]],


### PR DESCRIPTION
We don't have v0 support for multiple warmup shapes on spyre cards, so this removes v0 from the static batching tests