### PR TITLE
:zap: consolidate tensor marking for static batch runner

### DIFF
--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -374,10 +374,4 @@ class StaticBatchingFmsModel(FmsModelBase):
         logits, past_key_value_states = output
         self.past_key_value_states = past_key_value_states
 
-        # mark dynamic
-        if self.past_key_value_states is not None:
-            for layer in self.past_key_value_states:
-                for tensor in layer:
-                    torch._dynamo.mark_dynamic(tensor, 2)
-
         return logits

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -564,13 +564,14 @@ class StaticBatchingSpyreModelRunner(SpyreModelRunner):
         else:
             # we always want the decode to be dynamic on sequence
             torch._dynamo.mark_dynamic(model_input.input_tokens, 1)
-            torch._dynamo.mark_dynamic(model_input.input_masks, 1)
             torch._dynamo.mark_dynamic(model_input.input_masks, 2)
 
             # here self.model.model is a StaticBatchingFmsModel
             for layer in self.model.model.past_key_value_states:
                 for tensor in layer:
                     torch._dynamo.mark_static(tensor, 0)
+                    # This used to be baked into the model's forward pass
+                    torch._dynamo.mark_dynamic(tensor, 2)
 
 
 class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):


### PR DESCRIPTION
Two small changes:
- @yannicks1 is right that `model_input.input_masks, 1` is always gonna be size 1, so we don't have to mark it dynamic in the decode passes on warmup
- Marking dimension 2 of each `past_key_value_states` tensor as dynamic only needs to be done at warmup time, we don't need to do it on every forward pass