### PR TITLE
fix/refactor: remove last_running and total_running

### DIFF
--- a/vllm_spyre/v1/core/scheduler.py
+++ b/vllm_spyre/v1/core/scheduler.py
@@ -231,9 +231,6 @@ class ContinuousBatchingSpyreScheduler(SpyreScheduler):
     def __init__(self, *args, **kwargs) -> None:
         # Initialize SpyreScheduler
         super().__init__(*args, **kwargs)
-        # running queue of last decoding step
-        self.last_running: list[Request] = []
-        self.total_running: list[Request] = []
 
     def add_request(self, request: Request) -> None:
         """This override rejects requests that exceed max context length"""
@@ -273,14 +270,17 @@ class ContinuousBatchingSpyreScheduler(SpyreScheduler):
 
     def schedule(self) -> "SchedulerOutput":
         """This override adds constraints and then delegates most of the work
-        to the base scheduler"""
+        to the base scheduler
+
+        To avoid additional specialization, some requests are held back from the
+        base scheduler but are restored after.
+        """
         # First purge the full waiting queue into our holdback queue, preserving
         # priority
         while self.waiting:
             self.holdback_queue.append(self.waiting.popleft())
 
         # Check if new requests can be scheduled.
-        self.total_running = self.last_running + self.running
         while self.holdback_queue:
             if self.can_schedule():
                 # Add request to the waiting queue
@@ -290,27 +290,24 @@ class ContinuousBatchingSpyreScheduler(SpyreScheduler):
                 # can work with the batch we have
                 break
 
+        # Schedule Prefill and Decode separately
         if len(self.waiting) > 0:
-            # If prefill scheduled, save running queue for the next decode step.
-            # If previous step was also prefill, running queue contains the
-            # previous prefill sequence.
-            self.last_running = self.total_running
+            # For prefill, hide current decodes from the scheduler
+            running_holdback = self.running
             self.running = []
             logger.debug(
-                "Scheduling a prefil step of %d requests, holding back %d "
+                "Scheduling a prefill step of %d requests, holding back %d "
                 "requests", len(self.waiting), len(self.holdback_queue))
         else:
-            # If decode scheduled and previous step was prefil, update running
-            # queue
-            self.running = self.total_running
-            self.last_running = []
+            running_holdback = []
             logger.debug("Scheduling a decode step of %d requests",
                          len(self.running))
 
         # delegate to super of SpyreScheduler: base V1 Scheduler
         outputs = super(SpyreScheduler, self).schedule()
 
-        # move unscheduled requests back to the waiting queue
+        # restore holdbacks after running the base scheduler
+        self.running = self.running + running_holdback
         while self.holdback_queue:
             self.waiting.append(self.holdback_queue.popleft())
 
@@ -319,6 +316,6 @@ class ContinuousBatchingSpyreScheduler(SpyreScheduler):
     def can_schedule(self) -> bool:
         max_prompt_batch_size = 1
         # TODO: add additional checks, e.g. max_tokens
-        return len(self.total_running)+len(self.waiting) <\
+        return len(self.running)+len(self.waiting) <\
                 self.max_num_running_reqs and\
                 len(self.waiting) < max_prompt_batch_size


### PR DESCRIPTION
These changes from testing request cancellation with the continuous batching branch. In some cases, the cancellation would result in a crash:
```
ERROR 04-25 16:39:23 [core.py:387] EngineCore hit an exception: Traceback (most recent call last):
ERROR 04-25 16:39:23 [core.py:387]   File "/home/senuser/my-vllm/lib64/python3.11/site-packages/vllm/v1/engine/core.py", line 380, in run_engine_core
ERROR 04-25 16:39:23 [core.py:387]     engine_core.run_busy_loop()
ERROR 04-25 16:39:23 [core.py:387]   File "/home/senuser/my-vllm/lib64/python3.11/site-packages/vllm/v1/engine/core.py", line 400, in run_busy_loop
ERROR 04-25 16:39:23 [core.py:387]     self._process_input_queue()
ERROR 04-25 16:39:23 [core.py:387]   File "/home/senuser/my-vllm/lib64/python3.11/site-packages/vllm/v1/engine/core.py", line 425, in _process_input_queue
ERROR 04-25 16:39:23 [core.py:387]     self._handle_client_request(*req)
ERROR 04-25 16:39:23 [core.py:387]   File "/home/senuser/my-vllm/lib64/python3.11/site-packages/vllm/v1/engine/core.py", line 443, in _handle_client_request
ERROR 04-25 16:39:23 [core.py:387]     self.abort_requests(request)
ERROR 04-25 16:39:23 [core.py:387]   File "/home/senuser/my-vllm/lib64/python3.11/site-packages/vllm/v1/engine/core.py", line 193, in abort_requests
ERROR 04-25 16:39:23 [core.py:387]     self.scheduler.finish_requests(request_ids,
ERROR 04-25 16:39:23 [core.py:387]   File "/home/senuser/my-vllm/lib64/python3.11/site-packages/vllm/v1/core/sched/scheduler.py", line 724, in finish_requests
ERROR 04-25 16:39:23 [core.py:387]     self.running.remove(request)
ERROR 04-25 16:39:23 [core.py:387] ValueError: list.remove(x): x not in list
ERROR 04-25 16:39:23 [core.py:387] 
CRITICAL 04-25 16:39:23 [core_client.py:359] Got fatal signal from worker processes, shutting down. See stack trace above for root cause issue.
Killed
```

This is due to state being moved to `self.last_running` and `self.total_running` causing `self.running` to be empty even when requests are Running.
 
This PR makes some changes similar to what we did with the holdback_queue where state is hidden from the base scheduler but restored after the call to `schedule()`. This way, we can avoid specializing `finish_requests`