### PR TITLE
:fire: remove dynamic mark on input_tokens[1]

### DIFF
--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -563,7 +563,6 @@ class StaticBatchingSpyreModelRunner(SpyreModelRunner):
             torch._dynamo.mark_static(model_input.input_positions, 1)
         else:
             # we always want the decode to be dynamic on sequence
-            torch._dynamo.mark_dynamic(model_input.input_tokens, 1)
             torch._dynamo.mark_dynamic(model_input.input_masks, 2)
 
             # here self.model.model is a StaticBatchingFmsModel


### PR DESCRIPTION
Following up on https://github.com/vllm-project/vllm-spyre/pull/110#discussion_r2059737772 because sometimes my reading comprehension is less than stellar