### PR TITLE
:bug: ignore V1 environment setting when testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,15 @@
+# 🌶️🌶️🌶️ Hack to allow testing of both engines
+import os
+
+# If `VLLM_USE_V1=1` is set upon first vLLM import, then there are side-effects
+# in vLLM that will cause the V1 engine to always be used even if our tests
+# update this variable later before constructing each engine.
+# Deleting it here before importing vLLM allows us to continue testing both
+# engines.
+if "VLLM_USE_V1" in os.environ:
+    del os.environ["VLLM_USE_V1"]
+# 🌶️🌶️🌶️ end hack
+
 import pytest
 import torch
 from spyre_util import RemoteOpenAIServer
@@ -10,23 +22,6 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "tests/e2e" in str(item.nodeid):
             item.add_marker(pytest.mark.e2e)
-
-
-@pytest.fixture(params=[True, False])
-def run_with_both_engines(request, monkeypatch):
-    # Automatically runs tests twice, once with V1 and once without
-    use_v1 = request.param
-    # Tests decorated with `@skip_v1` are only run without v1
-    skip_v1 = request.node.get_closest_marker("skip_v1")
-
-    if use_v1:
-        if skip_v1:
-            pytest.skip("Skipping test on vllm V1")
-        monkeypatch.setenv('VLLM_USE_V1', '1')
-    else:
-        monkeypatch.setenv('VLLM_USE_V1', '0')
-
-    yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,14 @@
 # 🌶️🌶️🌶️ Hack to allow testing of both engines
 import os
 
-# If `VLLM_USE_V1=1` is set upon first vLLM import, then there are side-effects
-# in vLLM that will cause the V1 engine to always be used even if our tests
-# update this variable later before constructing each engine.
-# Deleting it here before importing vLLM allows us to continue testing both
-# engines.
+# If `VLLM_USE_V1=1` is set upon first vLLM import, then there is a side effect
+# that will cause the V1 engine to always be selected. This is intentionally
+# done for backwards-compatibility of code that was using the AsyncLLMEngine
+# constructor directly, instead of using the `.from_engine_args` construction
+# methods that will select the appropriate v0 or v1 engine. See:
+# https://github.com/vllm-project/vllm/blob/v0.8.4/vllm/engine/llm_engine.py#L2169-L2171
+# Deleting VLLM_USE_V1 here before importing vLLM allows us to continue testing
+# both engines.
 if "VLLM_USE_V1" in os.environ:
     del os.environ["VLLM_USE_V1"]
 # 🌶️🌶️🌶️ end hack


### PR DESCRIPTION
Currently, when running tests with `VLLM_USE_V1=1` set in the shell results in all v0 tests failing with the error:

```
self = <vllm.v1.engine.llm_engine.LLMEngine object at 0x7f3b23c5ad90>
vllm_config = VllmConfig(model_config=<vllm.config.ModelConfig object at 0x7f3b23c5a350>, cache_config=<vllm.config.CacheConfig obje...,48,40,32,24,16,8,4,2,1],"max_capture_size":256}, kv_transfer_config=None, additional_config=None, instance_id='f6f6e')
executor_class = <class 'vllm.v1.executor.abstract.UniProcExecutor'>, log_stats = False
usage_context = <UsageContext.LLM_CLASS: 'LLM_CLASS'>, stat_loggers = None
mm_registry = <vllm.multimodal.registry.MultiModalRegistry object at 0x7f3b89bf92d0>, use_cached_outputs = False
multiprocess_mode = True

    def __init__(
        self,
        vllm_config: VllmConfig,
        executor_class: type[Executor],
        log_stats: bool,
        usage_context: UsageContext = UsageContext.ENGINE_CONTEXT,
        stat_loggers: Optional[dict[str, StatLoggerBase]] = None,
        mm_registry: MultiModalRegistry = MULTIMODAL_REGISTRY,
        use_cached_outputs: bool = False,
        multiprocess_mode: bool = False,
    ) -> None:
        if not envs.VLLM_USE_V1:
>           raise ValueError(
                "Using V1 LLMEngine, but envs.VLLM_USE_V1=False. "
                "This should not happen. As a workaround, try using "
                "LLMEngine.from_vllm_config(...) or explicitly set "
                "VLLM_USE_V1=0 or 1 and report this issue on Github.")
E           ValueError: Using V1 LLMEngine, but envs.VLLM_USE_V1=False. This should not happen. As a workaround, try using LLMEngine.from_vllm_config(...) or explicitly set VLLM_USE_V1=0 or 1 and report this issue on Github.

my-vllm/lib64/python3.11/site-packages/vllm/v1/engine/llm_engine.py:53: ValueError
```

This seems to happen if `vllm` is imported with `VLLM_USE_V1=1` set, even if that's updated to `VLLM_USE_V1=0` before constructing a `vllm.LLM`. I'm digging in a bit to see why that is, but this hack does fix the problem in the meantime.