### PR TITLE
[V1] Decoupling static and continuous batching 

### DIFF
--- a/examples/offline_inference_spyre_cb_test.py
+++ b/examples/offline_inference_spyre_cb_test.py
@@ -12,9 +12,6 @@ max_tokens3 = 7
 max_tokens = max([max_tokens1, max_tokens2, max_tokens3])
 max_num_seqs = 2  # defines max batch size
 
-os.environ["VLLM_SPYRE_WARMUP_PROMPT_LENS"] = '64'
-os.environ["VLLM_SPYRE_WARMUP_NEW_TOKENS"] = str(max_tokens)
-
 # defining here to be able to run/debug directly from VSC (not via terminal)
 os.environ['VLLM_SPYRE_DYNAMO_BACKEND'] = 'eager'
 os.environ['VLLM_SPYRE_USE_CB'] = '1'

--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -58,14 +58,16 @@ class SpyreCausalLM(nn.Module):
         self.n_pads_right = 0
 
         # FMS Model
-        fms_model = ContinuousBatchingFmsModel if envs_spyre.VLLM_SPYRE_USE_CB\
-            else StaticBatchingFmsModel
-        self.model = fms_model(
-            model_config,
-            parallel_config,
-            max_prompt_length,
-            max_decode_length,
-        )
+        if envs_spyre.VLLM_SPYRE_USE_CB:
+            self.model = ContinuousBatchingFmsModel(model_config,
+                                                    parallel_config)
+        else:
+            self.model = StaticBatchingFmsModel(
+                model_config,
+                parallel_config,
+                max_prompt_length,
+                max_decode_length,
+            )
 
     def forward(
         self,
@@ -80,7 +82,7 @@ class SpyreCausalLM(nn.Module):
     ) -> torch.Tensor:
 
         if is_prompt and not envs_spyre.VLLM_SPYRE_USE_CB:
-            self.model.past_key_value_states = None
+            self.model.past_key_value_states = None  # type: ignore
 
         extra_kwargs: dict[str, Any] = {}
         if envs_spyre.VLLM_SPYRE_DYNAMO_BACKEND != "sendnn_decoder":
@@ -261,19 +263,22 @@ class FmsModelBase(nn.Module):
 
 class ContinuousBatchingFmsModel(FmsModelBase):
 
-    def __init__(
-        self,
-        model_config: ModelConfig,
-        parallel_config: ParallelConfig,
-        max_prompt_length: int,
-        max_decode_length: int,
-    ) -> None:
+    def __init__(self, model_config: ModelConfig,
+                 parallel_config: ParallelConfig) -> None:
+
+        BLOCK_SIZE = 64
+        max_batch = envs_spyre.VLLM_SPYRE_MAX_BATCH_SIZE
+        max_model_len = envs_spyre.VLLM_SPYRE_MAX_CONTEXT_LENGTH
+
+        # edge case: prompt fills model length: can produce 1 token with prefil,
+        max_prompt_length = max_model_len
+        # edge case: prompt will be padded to first block:
+        # can produce 1 token with prefill plus rest of model length
+        max_decode_length = max_model_len - BLOCK_SIZE + 1
         super().__init__(model_config, parallel_config, max_prompt_length,
                          max_decode_length)
 
         # physical KV cache on AIU Spyre: will eventually not live in this class
-        max_batch = envs_spyre.VLLM_SPYRE_MAX_BATCH_SIZE
-        max_model_len = envs_spyre.VLLM_SPYRE_MAX_CONTEXT_LENGTH
         num_kv_heads = model_config.get_num_kv_heads(parallel_config)
 
         if self.config.model_type in {'llama', 'granite'}:
@@ -287,17 +292,16 @@ class ContinuousBatchingFmsModel(FmsModelBase):
             print(f"[SpyreCausalLM] model type {self.config.model_type} "
                   f"not supported in ContinuousBatchingFmsModel")
 
-        BLOCK_SIZE = 64
-        NUM_BLOCKS = max_batch * max_model_len // BLOCK_SIZE  # 64
+        num_blocks = max_batch * max_model_len // BLOCK_SIZE  # 64
 
         # List[layers] of Tuple[k,v] of
-        # Tensor[NUM_BLOCKS, BLOCK_SIZE, num_kv_heads, max_model_len, head_dim]
-        self.past_key_value_states = [(torch.zeros(NUM_BLOCKS,
+        # Tensor[num_blocks, BLOCK_SIZE, num_kv_heads, max_model_len, head_dim]
+        self.past_key_value_states = [(torch.zeros(num_blocks,
                                                    BLOCK_SIZE,
                                                    num_kv_heads,
                                                    head_dim,
                                                    dtype=self.dtype),
-                                       torch.zeros(NUM_BLOCKS,
+                                       torch.zeros(num_blocks,
                                                    BLOCK_SIZE,
                                                    num_kv_heads,
                                                    head_dim,

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -69,7 +69,7 @@ class SpyrePlatform(Platform):
                     "vllm_spyre.v1.core.scheduler.ContinuousBatchingSpyreScheduler"
             else:
                 scheduler_config.scheduler_cls = \
-                    "vllm_spyre.v1.core.scheduler.SpyreScheduler"
+                    "vllm_spyre.v1.core.scheduler.StaticBatchingSpyreScheduler"
         else:
             scheduler_config.scheduler_cls = \
                 "vllm_spyre.core.scheduler.SpyreScheduler"

--- a/vllm_spyre/v1/core/scheduler.py
+++ b/vllm_spyre/v1/core/scheduler.py
@@ -28,20 +28,12 @@ NO_WARMUP_FIT_STOP_REASON = "Request did not fit any warmup shape"
 
 
 class SpyreScheduler(Scheduler):
-    """Small extension of the V1 scheduler that adds constraints for Sypre:
-    - No continuous batching
-    - Only schedules batches of requests that fit a common warmup shape
-    """
+    """Base class inheriting from the V1 scheduler to support static 
+    and continuous batching respecting AIU Spyre constraints."""
 
     def __init__(self, *args, **kwargs) -> None:
         # Initialize vLLM scheduler
         super().__init__(*args, **kwargs)
-
-        # Add our own state for handling Spyre constraints
-
-        # All warmup shapes that we can support
-        self.spyre_warmup_shapes: tuple[dict[str, int], ...] = \
-            SpyrePlatform.get_warmup_shapes(self.scheduler_config)
 
         # Requests are temporarily moved to this queue so that the base
         # scheduler does not see them. This lets us ensure that the set of
@@ -49,6 +41,74 @@ class SpyreScheduler(Scheduler):
         self.holdback_queue: deque[Request] = deque()
 
         self.rejected_requests: set[str] = set()
+
+    def update_from_output(
+        self,
+        scheduler_output: SchedulerOutput,
+        model_runner_output: ModelRunnerOutput,
+    ) -> EngineCoreOutputs:
+        """Temporary override to handle rejected requests that were too large
+        to schedule."""
+        reject_outputs = self._handle_rejects()
+        outputs = super().update_from_output(scheduler_output,
+                                             model_runner_output)
+        outputs.outputs.extend(reject_outputs)
+        return outputs
+
+    def _handle_rejects(self) -> list[EngineCoreOutput]:
+        """Temporary solution to reject requests that were too large to
+        schedule. This removes the rejected requests from the scheduler, and 
+        returns empty outputs for them with finish reason `abort`.
+        """
+        if len(self.rejected_requests) == 0:
+            return []
+
+        # Remove rejected requests from all queues
+        reject_outputs = self._reject_from_queue(self.running)
+        reject_outputs.extend(self._reject_from_queue(self.waiting))
+        reject_outputs.extend(self._reject_from_queue(self.holdback_queue))
+        self.rejected_requests.clear()
+
+        return reject_outputs
+
+    def _reject_from_queue(self,
+                           queue: deque[Request]) -> list[EngineCoreOutput]:
+        """Remove rejected requests from a given queue and return a list of 
+        engine core outputs to return for them"""
+        reject_outputs: list[EngineCoreOutput] = []
+        rejected_requests: list[Request] = [
+            request for request in queue
+            if request.request_id in self.rejected_requests
+        ]
+
+        for request in rejected_requests:
+            queue.remove(request)
+            reject_outputs.append(
+                EngineCoreOutput(
+                    request.request_id,
+                    # TODO: FIXME
+                    # Dummy token prevent stats collection crash
+                    new_token_ids=[-1],
+                    finish_reason=FinishReason.ABORT,
+                    stop_reason=NO_WARMUP_FIT_STOP_REASON))
+            request.status = RequestStatus.FINISHED_ABORTED
+            self._free_request(request)
+            self.rejected_requests.remove(request.request_id)
+
+        return reject_outputs
+
+
+class StaticBatchingSpyreScheduler(SpyreScheduler):
+    """ Support of static batching """
+
+    def __init__(self, *args, **kwargs) -> None:
+        # Initialize SpyreScheduler
+        super().__init__(*args, **kwargs)
+
+        # Add our own state for handling Spyre constraints:
+        # all warmup shapes that we can support
+        self.spyre_warmup_shapes: tuple[dict[str, int], ...] = \
+            SpyrePlatform.get_warmup_shapes(self.scheduler_config)
 
     def add_request(self, request: Request) -> None:
         """This override rejects requests that fit no warmup shape"""
@@ -77,21 +137,8 @@ class SpyreScheduler(Scheduler):
             request.num_prompt_tokens = 1
             request.sampling_params = SamplingParams(max_tokens=1)
 
-        # delegate to super
-        super().add_request(request=request)
-
-    def update_from_output(
-        self,
-        scheduler_output: SchedulerOutput,
-        model_runner_output: ModelRunnerOutput,
-    ) -> EngineCoreOutputs:
-        """Temporary override to handle rejected requests that were too large
-        to schedule."""
-        reject_outputs = self._handle_rejects()
-        outputs = super().update_from_output(scheduler_output,
-                                             model_runner_output)
-        outputs.outputs.extend(reject_outputs)
-        return outputs
+        # delegate to super of SpyreScheduler: base V1 Scheduler
+        super(SpyreScheduler, self).add_request(request=request)
 
     def schedule(self) -> SchedulerOutput:
         """This override adds constraints and then delegates most of the work
@@ -151,7 +198,8 @@ class SpyreScheduler(Scheduler):
             logger.debug("Scheduling a running batch of %d requests",
                          len(self.running))
 
-        outputs = super().schedule()
+        # delegate to super of SpyreScheduler: base V1 Scheduler
+        outputs = super(SpyreScheduler, self).schedule()
 
         # first move skipped and then unscheduled requests back
         # to the waiting queue, preserving priority
@@ -178,48 +226,6 @@ class SpyreScheduler(Scheduler):
             and max_tokens <= shape['new_tokens']
             and current_batch_size < shape['batch_size']
         ]
-
-    def _handle_rejects(self) -> list[EngineCoreOutput]:
-        """Temporary solution to reject requests that were too large to
-        schedule. This removes the rejected requests from the scheduler, and 
-        returns empty outputs for them with finish reason `abort`.
-        """
-        if len(self.rejected_requests) == 0:
-            return []
-
-        # Remove rejected requests from all queues
-        reject_outputs = self._reject_from_queue(self.running)
-        reject_outputs.extend(self._reject_from_queue(self.waiting))
-        reject_outputs.extend(self._reject_from_queue(self.holdback_queue))
-        self.rejected_requests.clear()
-
-        return reject_outputs
-
-    def _reject_from_queue(self,
-                           queue: deque[Request]) -> list[EngineCoreOutput]:
-        """Remove rejected requests from a given queue and return a list of 
-        engine core outputs to return for them"""
-        reject_outputs: list[EngineCoreOutput] = []
-        rejected_requests: list[Request] = [
-            request for request in queue
-            if request.request_id in self.rejected_requests
-        ]
-
-        for request in rejected_requests:
-            queue.remove(request)
-            reject_outputs.append(
-                EngineCoreOutput(
-                    request.request_id,
-                    # TODO: FIXME
-                    # Dummy token prevent stats collection crash
-                    new_token_ids=[-1],
-                    finish_reason=FinishReason.ABORT,
-                    stop_reason=NO_WARMUP_FIT_STOP_REASON))
-            request.status = RequestStatus.FINISHED_ABORTED
-            self._free_request(request)
-            self.rejected_requests.remove(request.request_id)
-
-        return reject_outputs
 
 
 class ContinuousBatchingSpyreScheduler(SpyreScheduler):

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -593,10 +593,6 @@ class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):
                          is_driver_worker=is_driver_worker)
 
         max_batch_size = envs_spyre.VLLM_SPYRE_MAX_BATCH_SIZE
-        # this is just to pass formatting bc type is Optional[list[int]]
-        if envs_spyre.VLLM_SPYRE_WARMUP_PROMPT_LENS:
-            max_prompt_length = envs_spyre.VLLM_SPYRE_WARMUP_PROMPT_LENS[0]
-
         max_model_len = envs_spyre.VLLM_SPYRE_MAX_CONTEXT_LENGTH
 
         self.BLOCK_SIZE = 64
@@ -607,7 +603,6 @@ class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):
         self.req_ids2left_pads: dict[str, int] = {}
         self.tkv = 0
         self.free_blocks = [i for i in range(NUM_BLOCKS)]
-        self.min_pad_length_batch = max_prompt_length
 
     def _prepare_prompt(
         self,
@@ -618,7 +613,7 @@ class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):
         input_token_list: list[torch.Tensor] = []
 
         if len(self.req_ids2blocks) == 0:
-            self.tkv = self.min_pad_length_batch
+            self.tkv = self.BLOCK_SIZE
 
         # ceil division to pad to next block boundary
         n = self.tkv


### PR DESCRIPTION
### Decoupling static and continuous batching 

- Introducing base class `SpyreScheduler` and inherit from it to have a decoupled `StaticBatchingSpyreScheduler` and `ContinuousBatchingSpyreScheduler`
- ensuring warmup shapes are only consumed in the static batching path
- remove static batching warmup envs from `offline_inference_spyre_cb_test.py` (without having it failing:)
- allocate meaningful dynamo cache for continuous batching

closes #98