### PR TITLE
Fixes to get things working with upstream main

### DIFF
--- a/tests/v1/worker/test_spyre_input_batch.py
+++ b/tests/v1/worker/test_spyre_input_batch.py
@@ -166,7 +166,6 @@ def _construct_cached_request_state(req_id_suffix: int):
     return CachedRequestState(
         req_id=f"req_id_{req_id_suffix}",
         prompt_token_ids=prompt_token_ids,
-        prompt=None,
         sampling_params=_create_sampling_params(),
         generator=None,
         output_token_ids=output_token_ids,

--- a/vllm_spyre/core/scheduler.py
+++ b/vllm_spyre/core/scheduler.py
@@ -1267,7 +1267,6 @@ class SpyreScheduler:
                     multi_modal_placeholders=(
                         seq_group.multi_modal_placeholders
                         if scheduler_outputs.num_prefill_groups > 0 else None),
-                    mm_processor_kwargs=seq_group.mm_processor_kwargs,
                     prompt_adapter_request=seq_group.prompt_adapter_request,
                 )
             else:

--- a/vllm_spyre/v1/compat/__init__.py
+++ b/vllm_spyre/v1/compat/__init__.py
@@ -2,9 +2,9 @@
 try:
     # vllm v0.8.2+
     from vllm.v1.core.sched.output import CachedRequestData  # noqa: F401
-    from vllm.v1.core.sched.output import NewRequestData  # noqa: F401
     from vllm.v1.core.sched.output import SchedulerOutput  # noqa: F401
 except ImportError:
     from vllm.v1.core.scheduler import CachedRequestData  # noqa: F401
-    from vllm.v1.core.scheduler import NewRequestData  # noqa: F401
     from vllm.v1.core.scheduler import SchedulerOutput  # noqa: F401
+
+from .output import NewRequestData  # noqa: F401

--- a/vllm_spyre/v1/compat/__init__.py
+++ b/vllm_spyre/v1/compat/__init__.py
@@ -1,5 +1,4 @@
 # This import wraps the importing of some vLLM classes based on the version
-
 try:
     # vllm v0.8.2+
     from vllm.v1.core.sched.output import CachedRequestData  # noqa: F401

--- a/vllm_spyre/v1/compat/output.py
+++ b/vllm_spyre/v1/compat/output.py
@@ -3,12 +3,15 @@ import inspect
 from dataclasses import dataclass
 from typing import ClassVar
 
+# yapf conflicts with ruff for this block
+# yapf: disable
 try:
     # vllm v0.8.2+
     from vllm.v1.core.sched.output import (
         NewRequestData as UpstreamNewRequestData)
 except ImportError:
     from vllm.v1.core.scheduler import NewRequestData as UpstreamNewRequestData
+# yapf: enable
 
 
 @dataclass

--- a/vllm_spyre/v1/compat/output.py
+++ b/vllm_spyre/v1/compat/output.py
@@ -1,0 +1,28 @@
+# This import wraps the importing of some vLLM classes based on the version
+import inspect
+from dataclasses import dataclass
+from typing import ClassVar
+
+try:
+    # vllm v0.8.2+
+    from vllm.v1.core.sched.output import (
+        NewRequestData as UpstreamNewRequestData)
+except ImportError:
+    from vllm.v1.core.scheduler import NewRequestData as UpstreamNewRequestData
+
+
+@dataclass
+class NewRequestData(UpstreamNewRequestData):
+    _legacy_signature: ClassVar[bool] = False
+
+    def __init__(self, *args, **kwargs):
+        # The prompt field was removed in https://github.com/vllm-project/vllm/pull/17214/files#diff-cafd89ce8a698a56acb24ada62831cbc7a980782f78a52d1742ba238031f296cL25
+        # NB: this assumes kwargs are used at the call site
+        if self._legacy_signature:
+            kwargs['prompt'] = None
+
+        super().__init__(*args, **kwargs)
+
+
+if 'prompt' in inspect.signature(UpstreamNewRequestData.__init__).parameters:
+    NewRequestData._legacy_signature = True

--- a/vllm_spyre/v1/worker/spyre_input_batch.py
+++ b/vllm_spyre/v1/worker/spyre_input_batch.py
@@ -19,7 +19,6 @@ class CachedRequestState:
 
     req_id: str
     prompt_token_ids: list[int]
-    prompt: Optional[str]
     sampling_params: SamplingParams
     generator: Optional[torch.Generator]
 

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -26,9 +26,8 @@ if TYPE_CHECKING:
     from vllm.attention.backends.abstract import AttentionBackend
     from vllm.model_executor.pooling_metadata import PoolingMetadata
 
-    from vllm_spyre.v1.core.sched.output import (CachedRequestData,
-                                                 NewRequestData,
-                                                 SchedulerOutput)
+    from vllm_spyre.v1.compat import (CachedRequestData, NewRequestData,
+                                      SchedulerOutput)
 else:
     CachedRequestData = None
     SchedulerOutput = None

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -294,7 +294,6 @@ class StaticBatchingSpyreModelRunner(SpyreModelRunner):
             req_state = CachedRequestState(
                 req_id=req_id,
                 prompt_token_ids=request_data.prompt_token_ids,
-                prompt=request_data.prompt,
                 sampling_params=sampling_params,
                 generator=generator,
                 output_token_ids=[],

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -23,8 +23,8 @@ import vllm_spyre.envs as envs_spyre
 import vllm_spyre.perf_metrics as perf_metrics
 from vllm_spyre.model_executor.model_loader import spyre_setup
 from vllm_spyre.platform import SpyrePlatform
-from vllm_spyre.v1.core.sched.output import (CachedRequestData, NewRequestData,
-                                             SchedulerOutput)
+from vllm_spyre.v1.compat import (CachedRequestData, NewRequestData,
+                                  SchedulerOutput)
 from vllm_spyre.v1.worker.spyre_model_runner import (
     ContinuousBatchingSpyreModelRunner, StaticBatchingSpyreModelRunner)
 

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -282,7 +282,6 @@ class SpyreWorker(WorkerBaseV1):
             NewRequestData(
                 req_id="warmup-%d" % (i),
                 prompt_token_ids=warmup_tokens_tensor[i].tolist(),
-                prompt="test",
                 mm_inputs=[],
                 mm_hashes=[],
                 mm_positions=[],
@@ -398,7 +397,6 @@ class SpyreWorker(WorkerBaseV1):
             NewRequestData(
                 req_id="warmup",
                 prompt_token_ids=warmup_tokens_tensor[i].tolist(),
-                prompt="test",
                 mm_inputs=[],
                 mm_hashes=[],
                 mm_positions=[],


### PR DESCRIPTION
Updates to get vllm-spyre working with vLLM `main` after some recent changes.

For V1, the optional `prompt` field was removed from some ouptut classes in vLLM. Since these were optional anyways (and just used in our warmup requests), there isn't any backwards compatibility issue.
https://github.com/vllm-project/vllm/pull/17214/files#diff-cafd89ce8a698a56acb24ada62831cbc7a980782f78a52d1742ba238031f296cL25

For V0, mulitmodal input processing has gone through an overhaul, the part that matters here is the removal of `mm_processor_kwargs` from `SequenceGroup`. This field was also optional before it was removed.
https://github.com/vllm-project/vllm/pull/15686/files#diff-0e64e07127ff20fc01be18cc95c0f58e0ff818e0dbabd5e8d2e07ca27943a7e4L1599

FIX https://github.com/vllm-project/vllm-spyre/issues/121 https://github.com/vllm-project/vllm-spyre/issues/118