### PR TITLE
[CB] renaming env variables used by AIU Spyre compiler

### DIFF
--- a/examples/offline_inference_spyre_cb_test.py
+++ b/examples/offline_inference_spyre_cb_test.py
@@ -16,8 +16,8 @@ os.environ['VLLM_SPYRE_DYNAMO_BACKEND'] = 'eager'
 os.environ['VLLM_SPYRE_USE_CB'] = '1'
 os.environ['VLLM_USE_V1'] = '1'
 
-os.environ['VLLM_SPYRE_MAX_CONTEXT_LENGTH'] = '2048'
-os.environ['VLLM_SPYRE_MAX_BATCH_SIZE'] = str(max_num_seqs)
+os.environ['VLLM_DT_MAX_CONTEXT_LEN'] = '2048'
+os.environ['VLLM_DT_MAX_BATCH_SIZE'] = str(max_num_seqs)
 
 # Sample prompts.
 template = (

--- a/vllm_spyre/envs.py
+++ b/vllm_spyre/envs.py
@@ -7,8 +7,8 @@ if TYPE_CHECKING:
     VLLM_SPYRE_WARMUP_NEW_TOKENS: Optional[list[int]] = None
     VLLM_SPYRE_WARMUP_BATCH_SIZES: Optional[list[int]] = None
     VLLM_SPYRE_USE_CB: bool = False
-    VLLM_SPYRE_MAX_BATCH_SIZE: int = 0
-    VLLM_SPYRE_MAX_CONTEXT_LENGTH: int = 0
+    VLLM_DT_MAX_BATCH_SIZE: int = 0
+    VLLM_DT_MAX_CONTEXT_LEN: int = 0
     VLLM_SPYRE_RM_PADDED_BLOCKS: bool = False
     VLLM_SPYRE_PERF_METRIC_LOGGING_ENABLED: int = 0
     VLLM_SPYRE_PERF_METRIC_LOGGING_DIR: str = "/tmp"
@@ -52,12 +52,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: bool(int(os.getenv("VLLM_SPYRE_USE_CB", "0"))),
 
     # Maximal supported batch size
-    "VLLM_SPYRE_MAX_BATCH_SIZE":
-    lambda: int(os.getenv("VLLM_SPYRE_MAX_BATCH_SIZE", "0")),
+    "VLLM_DT_MAX_BATCH_SIZE":
+    lambda: int(os.getenv("VLLM_DT_MAX_BATCH_SIZE", "0")),
 
     # Maximal supported context length
-    "VLLM_SPYRE_MAX_CONTEXT_LENGTH":
-    lambda: int(os.getenv("VLLM_SPYRE_MAX_CONTEXT_LENGTH", "0")),
+    "VLLM_DT_MAX_CONTEXT_LEN":
+    lambda: int(os.getenv("VLLM_DT_MAX_CONTEXT_LEN", "0")),
 
     # If set, remove redundant (left) padded blocks
     "VLLM_SPYRE_RM_PADDED_BLOCKS":

--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -267,8 +267,8 @@ class ContinuousBatchingFmsModel(FmsModelBase):
                  parallel_config: ParallelConfig) -> None:
 
         BLOCK_SIZE = 64
-        max_batch = envs_spyre.VLLM_SPYRE_MAX_BATCH_SIZE
-        max_model_len = envs_spyre.VLLM_SPYRE_MAX_CONTEXT_LENGTH
+        max_batch = envs_spyre.VLLM_DT_MAX_BATCH_SIZE
+        max_model_len = envs_spyre.VLLM_DT_MAX_CONTEXT_LEN
 
         # edge case: prompt fills model length: can produce 1 token with prefill
         max_prompt_length = max_model_len

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -96,7 +96,7 @@ class SpyrePlatform(Platform):
                 # For continuous batching we use max_num_seqs to control
                 # the max batch size respecting AIU Spyre KV cache size
                 scheduler_config.max_num_seqs =\
-                    envs_spyre.VLLM_SPYRE_MAX_BATCH_SIZE
+                    envs_spyre.VLLM_DT_MAX_BATCH_SIZE
                 # ToDo: this function check_and_update_config is called twice:
                 # 1st time scheduler_config.max_num_seqs is what user sets
                 # 2nd time scheduler_config.max_num_seqs is 128
@@ -226,13 +226,13 @@ class SpyrePlatform(Platform):
             d = 64  # hardcoded AIU Spyre block size
             prompt_padding_len = ((n + d - 1) // d) * d
             if (prompt_padding_len + max_tokens
-                    > envs_spyre.VLLM_SPYRE_MAX_CONTEXT_LENGTH):
+                    > envs_spyre.VLLM_DT_MAX_CONTEXT_LEN):
                 raise ValueError(
                     "Could not add request: prompt length is "
                     f"{prompt_len} tokens, which gets padded to "
                     f"{prompt_padding_len} tokens, maximum number of output "
                     f"tokens is {max_tokens} tokens, but max model context "
-                    f"length is {envs_spyre.VLLM_SPYRE_MAX_CONTEXT_LENGTH}.")
+                    f"length is {envs_spyre.VLLM_DT_MAX_CONTEXT_LEN}.")
         else:
             # For non-continuous batching, check if the request matches a warmup
             # shape

--- a/vllm_spyre/v1/core/scheduler.py
+++ b/vllm_spyre/v1/core/scheduler.py
@@ -210,7 +210,7 @@ class ContinuousBatchingSpyreScheduler(SpyreScheduler):
 
     def can_schedule(self, request) -> bool:
         max_prompt_batch_size = 1
-        max_context_len = envs_spyre.VLLM_SPYRE_MAX_CONTEXT_LENGTH
+        max_context_len = envs_spyre.VLLM_DT_MAX_CONTEXT_LEN
 
         # running and waiting queues are both empty -> start new batch
         start_new_batch = len(self.running) + len(self.waiting) == 0

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -569,8 +569,8 @@ class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):
         super().__init__(vllm_config=vllm_config,
                          is_driver_worker=is_driver_worker)
 
-        max_batch_size = envs_spyre.VLLM_SPYRE_MAX_BATCH_SIZE
-        max_model_len = envs_spyre.VLLM_SPYRE_MAX_CONTEXT_LENGTH
+        max_batch_size = envs_spyre.VLLM_DT_MAX_BATCH_SIZE
+        max_model_len = envs_spyre.VLLM_DT_MAX_CONTEXT_LEN
 
         self.BLOCK_SIZE = 64
         NUM_BLOCKS = max_batch_size * max_model_len // self.BLOCK_SIZE  # 64


### PR DESCRIPTION
### renaming env variables used by AIU Spyre compiler (continuous batching) 

It has been agreed to use these names for the environmental variables consumed by the AIU Spyre compiler: 

- `VLLM_DT_MAX_CONTEXT_LEN`
- `VLLM_DT_MAX_BATCH_SIZE`

Note: these variables will not be used in vLLM after #114 is merged, but have to be set for the compiler. @joerunde @prashantgupta24 