### PR TITLE
Fix test pypi publications

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - fix-test-pypi
 
 jobs:
   build:
@@ -19,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:

--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - fix-test-pypi
 
 jobs:
   build:
@@ -21,6 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+            # Fetch all history for setuptools_scm to work correctly
             fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
Currently the publications on main to test pypi are broken, because the job doesn't checkout the main branch history to calculate the correct semantic version to push based on the last tag. This fixes that, so we should have green deployments to test pypi again, and for any failures we can investigate the actual packaging failure.

Here's a test run of the changes: https://github.com/vllm-project/vllm-spyre/actions/runs/14892371588/job/41827331149