### PR TITLE
Add options to torch.compile

### DIFF
--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -261,7 +261,8 @@ class FmsModelBase(nn.Module):
             self.model = torch.compile(
                 self.model,
                 mode=compile_mode,
-                backend=envs_spyre.VLLM_SPYRE_DYNAMO_BACKEND)
+                backend=envs_spyre.VLLM_SPYRE_DYNAMO_BACKEND,
+                options=self.options)
 
 
 class ContinuousBatchingFmsModel(FmsModelBase):
@@ -316,6 +317,10 @@ class ContinuousBatchingFmsModel(FmsModelBase):
                                                    dtype=self.dtype))
                                       for _ in range(num_layers)]
 
+        self.options = {
+            'sendnn.dynamic': True
+        }
+
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -364,6 +369,7 @@ class StaticBatchingFmsModel(FmsModelBase):
 
         # dynamic KV cache
         self.past_key_value_states = None
+        self.options = {}
 
     def forward(
         self,

--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -260,12 +260,7 @@ class FmsModelBase(nn.Module):
 
         if envs_spyre.VLLM_SPYRE_DYNAMO_BACKEND in BACKEND_LIST:
 
-            if sendnn_dynamic:
-                options = {
-                    'sendnn.dynamic': True,
-                }
-            else:
-                options = {}
+            options = {"sendnn.dynamic": True} if sendnn_dynamic else {}
 
             self.model = torch.compile(
                 self.model,
@@ -293,8 +288,11 @@ class ContinuousBatchingFmsModel(FmsModelBase):
         # can produce 1 token with prefill plus rest of model length
         max_decode_length = max_model_len - BLOCK_SIZE + 1
 
-        super().__init__(model_config, parallel_config, max_prompt_length,
-                         max_decode_length, sendnn_dynamic=True)
+        super().__init__(model_config,
+                         parallel_config,
+                         max_prompt_length,
+                         max_decode_length,
+                         sendnn_dynamic=True)
 
         # physical KV cache on AIU Spyre: will eventually not live in this class
         num_kv_heads = model_config.get_num_kv_heads(parallel_config)
@@ -326,7 +324,6 @@ class ContinuousBatchingFmsModel(FmsModelBase):
                                                    head_dim,
                                                    dtype=self.dtype))
                                       for _ in range(num_layers)]
-
 
     def forward(
         self,
@@ -371,8 +368,11 @@ class StaticBatchingFmsModel(FmsModelBase):
         max_prompt_length: int,
         max_decode_length: int,
     ) -> None:
-        super().__init__(model_config, parallel_config, max_prompt_length,
-                         max_decode_length, sendnn_dynamic=False)
+        super().__init__(model_config,
+                         parallel_config,
+                         max_prompt_length,
+                         max_decode_length,
+                         sendnn_dynamic=False)
 
         # dynamic KV cache
         self.past_key_value_states = None

--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -227,8 +227,6 @@ class FmsModelBase(nn.Module):
                                fused_weights=fused_weights,
                                linear_config=linear_config)
 
-        compile_mode = "default"
-
         self.model.eval()
         torch.set_grad_enabled(False)
 
@@ -271,7 +269,6 @@ class FmsModelBase(nn.Module):
 
             self.model = torch.compile(
                 self.model,
-                mode=compile_mode,
                 backend=envs_spyre.VLLM_SPYRE_DYNAMO_BACKEND,
                 options=options,
             )

--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -147,6 +147,7 @@ class FmsModelBase(nn.Module):
         parallel_config: ParallelConfig,
         max_prompt_length: int,
         max_decode_length: int,
+        sendnn_dynamic: bool,
     ) -> None:
         super().__init__()
 
@@ -162,7 +163,8 @@ class FmsModelBase(nn.Module):
                           max_prompt_length=max_prompt_length,
                           max_decode_length=max_decode_length,
                           distributed_strategy="tp"
-                          if parallel_config.world_size > 1 else None)
+                          if parallel_config.world_size > 1 else None,
+                          sendnn_dynamic=sendnn_dynamic)
 
     def load_weights(
         self,
@@ -170,6 +172,7 @@ class FmsModelBase(nn.Module):
         max_prompt_length: int,
         max_decode_length: int,
         distributed_strategy: Optional[str],
+        sendnn_dynamic: bool,
         **kwargs,
     ) -> None:
 
@@ -258,11 +261,20 @@ class FmsModelBase(nn.Module):
                 max_prompt_length, max_decode_length)
 
         if envs_spyre.VLLM_SPYRE_DYNAMO_BACKEND in BACKEND_LIST:
+
+            if sendnn_dynamic:
+                options = {
+                    'sendnn.dynamic': True,
+                }
+            else:
+                options = {}
+
             self.model = torch.compile(
                 self.model,
                 mode=compile_mode,
                 backend=envs_spyre.VLLM_SPYRE_DYNAMO_BACKEND,
-                options=self.options)
+                options=options,
+            )
 
 
 class ContinuousBatchingFmsModel(FmsModelBase):
@@ -283,8 +295,9 @@ class ContinuousBatchingFmsModel(FmsModelBase):
         # edge case: prompt will be padded to first block:
         # can produce 1 token with prefill plus rest of model length
         max_decode_length = max_model_len - BLOCK_SIZE + 1
+
         super().__init__(model_config, parallel_config, max_prompt_length,
-                         max_decode_length)
+                         max_decode_length, sendnn_dynamic=True)
 
         # physical KV cache on AIU Spyre: will eventually not live in this class
         num_kv_heads = model_config.get_num_kv_heads(parallel_config)
@@ -317,9 +330,6 @@ class ContinuousBatchingFmsModel(FmsModelBase):
                                                    dtype=self.dtype))
                                       for _ in range(num_layers)]
 
-        self.options = {
-            'sendnn.dynamic': True
-        }
 
     def forward(
         self,
@@ -365,11 +375,10 @@ class StaticBatchingFmsModel(FmsModelBase):
         max_decode_length: int,
     ) -> None:
         super().__init__(model_config, parallel_config, max_prompt_length,
-                         max_decode_length)
+                         max_decode_length, sendnn_dynamic=False)
 
         # dynamic KV cache
         self.past_key_value_states = None
-        self.options = {}
 
     def forward(
         self,


### PR DESCRIPTION
We need to pass additional options to torch.compile to ensure that symbols get added to the graph. 