### PR TITLE
🐛 set default value for tkv

### DIFF
--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -54,7 +54,7 @@ class ModelForwardInputs:
 @dataclass
 class CBSpyreModelRunnerOutput(ModelRunnerOutput):
     # Add the current tkv to the output
-    tkv: int
+    tkv: int = 0
 
 
 class SpyreModelRunner:


### PR DESCRIPTION
since upstream PR introduced a default param in `ModelRunnerOutput`

https://github.com/vllm-project/vllm/pull/17751/files#diff-267e8bc1629d4ae978c28eea04881c9934449a35c1f74c6214636f213bde8ccdR104-R105