### PR TITLE
[CI/CD] mark current tests that are failing when compile cache is enabled

### DIFF
--- a/tests/e2e/test_spyre_warmup_shapes.py
+++ b/tests/e2e/test_spyre_warmup_shapes.py
@@ -3,6 +3,8 @@
 Run `python -m pytest tests/test_spyre_warmup_shapes.py`.
 """
 
+import os
+
 import pytest
 from spyre_util import (compare_results, generate_hf_output,
                         generate_spyre_vllm_output, get_spyre_backend_list,
@@ -11,7 +13,9 @@ from vllm import SamplingParams
 
 
 # temporary for filtering until bug with caching gets fixed
-@pytest.mark.compile_cache_failing
+@pytest.mark.skipif(
+    os.environ.get("TORCH_SENDNN_CACHE_ENABLE") == "1",
+    reason="torch_sendnn caching is currently broken with this configuration")
 @pytest.mark.parametrize("model", get_spyre_model_list())
 @pytest.mark.parametrize("prompts", [
     7 * [

--- a/tests/e2e/test_spyre_warmup_shapes.py
+++ b/tests/e2e/test_spyre_warmup_shapes.py
@@ -10,6 +10,8 @@ from spyre_util import (compare_results, generate_hf_output,
 from vllm import SamplingParams
 
 
+# temporary for filtering until bug with caching gets fixed
+@pytest.mark.compile_cache_failing
 @pytest.mark.parametrize("model", get_spyre_model_list())
 @pytest.mark.parametrize("prompts", [
     7 * [


### PR DESCRIPTION
This PR mark the current tests that are currently failing when compile cache is enabled. It will allow to run the CI/CD pipeline with compile cache, while filtering out the tests that fail. 

Goes along with [this PR](https://github.ibm.com/ai-foundation/aiu-tests/pull/257)