### PR TITLE
[profiler] support PyTorch profiler enablement

### DIFF
--- a/vllm_spyre/worker/spyre_worker.py
+++ b/vllm_spyre/worker/spyre_worker.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import torch
 import torch.distributed as dist
+import vllm.envs as envs
 from huggingface_hub import hf_hub_download
 from vllm.config import VllmConfig
 from vllm.distributed import (ensure_model_parallel_initialized,
@@ -75,6 +76,41 @@ class SpyreWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
         self._env_initialized = False
         self.spyre_warmup_shapes = SpyrePlatform.get_warmup_shapes(
             self.scheduler_config)
+        # Torch profiler. Enabled and configured through env vars:
+        # VLLM_TORCH_PROFILER_DIR=/path/to/save/trace
+        if envs.VLLM_TORCH_PROFILER_DIR:
+            torch_profiler_trace_dir = envs.VLLM_TORCH_PROFILER_DIR
+            activities = [torch.profiler.ProfilerActivity.CPU]
+
+            if envs_spyre.VLLM_SPYRE_DYNAMO_BACKEND == "sendnn_decoder":
+                from torch_sendnn import torch_sendnn
+                torch.utils.rename_privateuse1_backend("aiu")
+                torch._register_device_module("aiu",
+                                              torch_sendnn.sendnn_backend)
+                torch.utils.generate_methods_for_privateuse1_backend()
+                activities.append(torch.profiler.ProfilerActivity.PrivateUse1)
+
+            self.profiler = torch.profiler.profile(
+                activities=activities,
+                record_shapes=True,
+                with_stack=True,
+                on_trace_ready=torch.profiler.tensorboard_trace_handler(
+                    torch_profiler_trace_dir, use_gzip=True))
+            print(
+                "[SpyreWorker] Profiling enabled. Traces will be saved to: %s",
+                torch_profiler_trace_dir)
+        else:
+            self.profiler = None
+
+    def start_profile(self):
+        if self.profiler is None:
+            raise RuntimeError("Profiler is not enabled.")
+        self.profiler.start()
+
+    def stop_profile(self):
+        if self.profiler is None:
+            raise RuntimeError("Profiler is not enabled.")
+        self.profiler.stop()
 
     def init_distributed_environment(self) -> None:
         """Initialize the distributed environment."""


### PR DESCRIPTION
This PR implements the required methods to support [profiling vLLM with PyTorch Profiler](https://docs.vllm.ai/en/latest/contributing/profiling/profiling_index.html#profile-with-pytorch-profiler).

## Using PyTorch Profiler with vLLM
### Offline profiling
Enable torch profiler, can also be set on cmd line:
```
os.environ["VLLM_TORCH_PROFILER_DIR"] = "./vllm_profile"
```

Start and stop profiling:
```
llm.start_profile()
outputs = llm.generate(prompts, sampling_params)
llm.stop_profile()
```

### Online profiling
Start **server** with profiling enabled:
```
VLLM_RPC_TIMEOUT=1800000 VLLM_TORCH_PROFILER_DIR=./vllm_profile python3 -m vllm.entrypoints.openai.api_server --model /models/llama-7b-chat --max-model-len=2048 --block-size=128
```

Start and stop profiler on the **client** side:
```
requests.post("http://0.0.0.0:8000/start_profile")
client.completions.create(...)
requests.post("http://0.0.0.0:8000/stop_profile")
```