### PR TITLE
🐛 ignore shell script files within .venv for shellcheck command

### DIFF
--- a/tools/shellcheck.sh
+++ b/tools/shellcheck.sh
@@ -18,5 +18,8 @@ if ! [ -x "$(command -v shellcheck)" ]; then
     export PATH="$PATH:$(pwd)/shellcheck-${scversion}"
 fi
 
-# TODO - fix warnings in .buildkite/run-amd-test.sh
-find . -name "*.sh" -not -path "./.buildkite/run-amd-test.sh" -not -path "./.venv/*" -print0 | xargs -0 -I {} sh -c 'git check-ignore -q "{}" || shellcheck "{}"'
+# Lists all files currently tracked by Git
+# outputs results separated by a null character
+# matches any filename ending with .sh
+# run shellcheck on every .sh file tracked by Git.
+git ls-files -z | grep -z '\.sh$' | xargs -0 -n 1 shellcheck

--- a/tools/shellcheck.sh
+++ b/tools/shellcheck.sh
@@ -19,4 +19,4 @@ if ! [ -x "$(command -v shellcheck)" ]; then
 fi
 
 # TODO - fix warnings in .buildkite/run-amd-test.sh
-find . -name "*.sh" -not -path "./.buildkite/run-amd-test.sh" -print0 | xargs -0 -I {} sh -c 'git check-ignore -q "{}" || shellcheck "{}"'
+find . -name "*.sh" -not -path "./.buildkite/run-amd-test.sh" -not -path "./.venv/*" -print0 | xargs -0 -I {} sh -c 'git check-ignore -q "{}" || shellcheck "{}"'


### PR DESCRIPTION
Allowing the `shellcheck` command to run against all shell script files within `.venv` gives the error: 

```
xargs: command line cannot be assembled, too long
```

This PR only checks the shell scripts that are git committed.

After ignoring:
```
❯ git ls-files -z | grep -z '\.sh$' | xargs -0 -n 1 printf "%s\n"

format.sh
tools/actionlint.sh
tools/check_repo.sh
tools/doc-lint.sh
tools/mypy.sh
tools/shellcheck.sh
```

Before:
```
❯ find . -name "*.sh"
./tools/shellcheck.sh
./tools/doc-lint.sh
./tools/check_repo.sh
./tools/actionlint.sh
./tools/mypy.sh
./.venv/lib/python3.12/site-packages/bleach/_vendor/vendor_install.sh
./.venv/lib/python3.12/site-packages/debugpy/_vendored/pydevd/pydevd_attach_to_process/linux_and_mac/compile_mac.sh
./.venv/lib/python3.12/site-packages/debugpy/_vendored/pydevd/pydevd_attach_to_process/linux_and_mac/compile_linux.sh
./.venv/lib/python3.12/site-packages/pexpect/bashrc.sh
./.venv/lib/python3.12/site-packages/tqdm/completion.sh
./.venv/lib/python3.12/site-packages/ray/autoscaler/aws/cloudwatch/ray_prometheus_waiter.sh
./format.sh
```