### PR TITLE
Add maybe_update_max_tokens for class SpyrePlatform 

### DIFF
--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -276,3 +276,12 @@ class SpyrePlatform(Platform):
             if prompt_len <= shape['prompt_length']
             and max_tokens <= shape['new_tokens']
         ]
+
+    @classmethod
+    def maybe_update_default_max_tokens(self, prompt_len: int, default_max_tokens: int) -> int:
+        max_new_tokens = 1
+        for shape in self._warmup_shapes:
+            if prompt_len <= shape['prompt_length']:
+                max_new_tokens = max(max_new_tokens, shape['new_tokens'])
+        
+        return max_new_tokens


### PR DESCRIPTION
FIX: https://github.com/vllm-project/vllm-spyre/issues/148

Currently the `class SpyrePlatform` uses the default `max_tokens` set in the OpenAI frontend code. This new method selects the warmup shape that fits the prompt and has the biggest `shape['new_tokens']`. This way `SpyrePlatform` will use the maximum number possible for token generation when `max_tokens` is not set in the request body.