### PR TITLE
[CI] Ignore docs for tests

### DIFF
--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
   push:
     branches:
       - main

--- a/.github/workflows/lint_scripts.yml
+++ b/.github/workflows/lint_scripts.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
   push:
     branches:
       - "main"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
   push:
     branches:
       - main


### PR DESCRIPTION
Accordingly to this documentation: https://docs.github.com/es/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpaths. This should be the way to not run tests when we only update docs.

```
on:
  push:
    paths-ignore:
      - 'docs/**'
```