### PR TITLE
Create CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 # See https://help.github.com/articles/about-codeowners/
 # for more info about CODEOWNERS file
 
-# These owners will be the default owners for everything in
-# the repo unless a later match takes precedence, and will be
-# requested for review when someone opens a pull request
+# These owners will be the default owners for everything in the repo
+# and will be requested for review when someone opens a pull request
+# unless a later match takes precedence
 * @joerunde @yannicks1 @tdoublep @sducouedic
 
 # This lists cover the "core" components of vLLM that require careful review

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,11 @@
 
 # This lists cover the "core" components of vLLM that require careful review
 /vllm_spyre @joerunde @prashantgupta24
+
+# Tests
 /tests @rafvasq @prashantgupta24
+
+# Examples
 /examples @yannicks1 @prashantgupta24
 
 # Docs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,8 @@
 
 # This lists cover the "core" components of vLLM that require careful review
 /vllm_spyre @joerunde
+/tests @joerunde
+/examples @joerunde
 
 # Docs
 /docs @rafvasq

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,19 +4,25 @@
 # These owners will be the default owners for everything in the repo
 # and will be requested for review when someone opens a pull request
 # unless a later match takes precedence
-* @joerunde @yannicks1 @tdoublep @sducouedic
+* @joerunde @prashantgupta24
 
 # This lists cover the "core" components of vLLM-Spyre that require careful review
-/vllm_spyre @joerunde @prashantgupta24
+/vllm_spyre @yannicks1 @tdoublep @nikolaospapandreou @sducouedic
+
+# TODO: separate code into different packages:
+#   /vllm_spyre/v1/worker/continuous_batching @nikolaospapandreou
+#   /vllm_spyre/v1/worker/static_batching ...
 
 # Tests
-/tests @rafvasq @prashantgupta24
+/tests @rafvasq @prashantgupta24 @sducouedic
 
 # Examples
-/examples @yannicks1 @prashantgupta24
+/examples @yannicks1 @prashantgupta24 @sducouedic
 
 # Docs
 /docs @rafvasq
+.readthedocs.yaml @rafvasq
+mkdocs.yaml @rafvasq
 
 # CI
 /.github @joerunde @ckadner

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# See https://help.github.com/articles/about-codeowners/
+# for more info about CODEOWNERS file
+
+# This lists cover the "core" components of vLLM that require careful review
+/vllm_spyre @joerunde
+
+# Docs
+/docs @rafvasq

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 # unless a later match takes precedence
 * @joerunde @yannicks1 @tdoublep @sducouedic
 
-# This lists cover the "core" components of vLLM that require careful review
+# This lists cover the "core" components of vLLM-Spyre that require careful review
 /vllm_spyre @joerunde @prashantgupta24
 
 # Tests

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,6 @@
 
 # Docs
 /docs @rafvasq
+
+# CI
+/.github @joerunde @ckadner

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,15 @@
 # See https://help.github.com/articles/about-codeowners/
 # for more info about CODEOWNERS file
 
+# These owners will be the default owners for everything in
+# the repo unless a later match takes precedence, and will be
+# requested for review when someone opens a pull request
+* @joerunde @yannicks1 @tdoublep @sducouedic
+
 # This lists cover the "core" components of vLLM that require careful review
-/vllm_spyre @joerunde
-/tests @joerunde
-/examples @joerunde
+/vllm_spyre @joerunde @prashantgupta24
+/tests @rafvasq @prashantgupta24
+/examples @yannicks1 @prashantgupta24
 
 # Docs
 /docs @rafvasq


### PR DESCRIPTION
Create initial set of code owners to facilitate reviews and (auto) merge process. Following the precedence of vllm main: https://github.com/vllm-project/vllm/blob/main/.github/CODEOWNERS. Ideally we should assign teams to areas of code/expertise as captured in the folder structure of the repo, but short of proper teams, in a small community we can assign individual contributors.

For a more general process, we probably should follow what more established OS communities do and create a process to promote new reviewers/committers periodically after a first pass, where maintainers are chosen from the initial set of project creators. As the community grows, there should be periodic reviews of who is active in reviewing PRs, who makes good code contributions etc. and the current project maintainers nominate new maintainers (committers/reviewers) and then the existing maintainers have a up/down vote to confirm new maintainers. At the same time, maintainers who are no longer active can get put on a emeritus list. Most Apache projects have well thought-out processes https://infra.apache.org/new-committers-guide.html#becoming-a-committer