### PR TITLE
:bookmark: Add release trigger for docker build

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -12,6 +12,8 @@ on:
       - "main"
     paths-ignore:
       - "**.md"
+  release:
+    types: [published]
 
 defaults:
   run:


### PR DESCRIPTION
Whoops, I forgot to set up the release trigger for docker builds so I had to manually tag the 0.3.0 image