### PR TITLE
Update vllm dependency to >=v0.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = {text = "Apache 2"}
 dependencies = [
     "fms-model-optimizer>=0.2.0",
     "ibm-fms==1.0.0",
-    "vllm>=0.8.5",
+    "vllm>=0.9.0",
 ]
 requires-python = ">=3.9"
 dynamic = ["version"]

--- a/tests/e2e/test_spyre_cb.py
+++ b/tests/e2e/test_spyre_cb.py
@@ -4,7 +4,6 @@ Run `python -m pytest tests/test_spyre_cb.py`.
 """
 
 import copy
-import inspect
 from collections import deque
 from typing import Any
 
@@ -96,31 +95,16 @@ def create_random_request(
         request_id: int, num_tokens: int,
         sampling_params: SamplingParams) -> EngineCoreRequest:
 
-    # Temporary until 'cache_salt' parameter makes it to a release version
-    # in vllm
-    if 'cache_salt' in [x[0] for x in inspect.getmembers(EngineCoreRequest)]:
-        return EngineCoreRequest(request_id=str(request_id),
-                                 prompt_token_ids=[request_id] * num_tokens,
-                                 mm_inputs=None,
-                                 mm_hashes=None,
-                                 mm_placeholders=None,
-                                 sampling_params=sampling_params,
-                                 eos_token_id=None,
-                                 arrival_time=0,
-                                 lora_request=None,
-                                 cache_salt=None)
-    else:
-        return EngineCoreRequest(
-            request_id=str(request_id),
-            prompt_token_ids=[request_id] * num_tokens,
-            mm_inputs=None,
-            mm_hashes=None,
-            mm_placeholders=None,
-            sampling_params=sampling_params,
-            eos_token_id=None,
-            arrival_time=0,
-            lora_request=None,
-        )
+    return EngineCoreRequest(request_id=str(request_id),
+                             prompt_token_ids=[request_id] * num_tokens,
+                             mm_inputs=None,
+                             mm_hashes=None,
+                             mm_placeholders=None,
+                             sampling_params=sampling_params,
+                             eos_token_id=None,
+                             arrival_time=0,
+                             lora_request=None,
+                             cache_salt=None)
 
 
 def get_params_test_blocks_borders_aligned_prompts():


### PR DESCRIPTION
Update vllm dependency to >=v0.9.0, this allows to cleanup some code that was required to maintain compatibility with older vllm version. 