### PR TITLE
:white_check_mark: add more TP sizes to tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ if "VLLM_USE_V1" in os.environ:
 
 import pytest
 import torch
-from spyre_util import RemoteOpenAIServer
+from spyre_util import RemoteOpenAIServer, skip_unsupported_tp_size
 from vllm.connections import global_http_connection
 from vllm.distributed import cleanup_dist_env_and_memory
 
@@ -93,6 +93,7 @@ def remote_openai_server(request):
     server_args = ["--quantization", quantization] if quantization else []
     if 'tensor_parallel_size' in params:
         tp_size = params['tensor_parallel_size']
+        skip_unsupported_tp_size(int(tp_size))
         server_args.extend(["--tensor-parallel-size", str(tp_size)])
 
     try:

--- a/tests/e2e/test_spyre_online.py
+++ b/tests/e2e/test_spyre_online.py
@@ -1,8 +1,7 @@
 import openai
 import pytest
-
-from tests.spyre_util import (VLLM_VERSIONS, get_spyre_backend_list,
-                              get_spyre_model_list)
+from spyre_util import (VLLM_VERSIONS, get_spyre_backend_list,
+                        get_spyre_model_list)
 
 
 @pytest.mark.parametrize("model", get_spyre_model_list())

--- a/tests/e2e/test_spyre_online_multi.py
+++ b/tests/e2e/test_spyre_online_multi.py
@@ -11,7 +11,7 @@ from tests.spyre_util import (VLLM_VERSIONS, get_spyre_backend_list,
 ]])
 @pytest.mark.parametrize(
     "backend", [b for b in get_spyre_backend_list() if "eager" not in str(b)])
-@pytest.mark.parametrize("tensor_parallel_size", ["2"])
+@pytest.mark.parametrize("tensor_parallel_size", ["2", "4", "8"])
 @pytest.mark.parametrize("vllm_version", VLLM_VERSIONS)
 def test_openai_tp_serving(remote_openai_server, model, warmup_shape, backend,
                            vllm_version, tensor_parallel_size):

--- a/tests/e2e/test_spyre_online_multi.py
+++ b/tests/e2e/test_spyre_online_multi.py
@@ -1,7 +1,6 @@
 import pytest
-
-from tests.spyre_util import (VLLM_VERSIONS, get_spyre_backend_list,
-                              get_spyre_model_list)
+from spyre_util import (VLLM_VERSIONS, get_spyre_backend_list,
+                        get_spyre_model_list)
 
 
 @pytest.mark.multi

--- a/tests/e2e/test_spyre_tensor_parallel.py
+++ b/tests/e2e/test_spyre_tensor_parallel.py
@@ -6,7 +6,7 @@ Run `python -m pytest tests/test_spyre_tensor_parallel.py`.
 import pytest
 from spyre_util import (VLLM_VERSIONS, compare_results, generate_hf_output,
                         generate_spyre_vllm_output, get_spyre_backend_list,
-                        get_spyre_model_list)
+                        get_spyre_model_list, skip_unsupported_tp_size)
 from vllm import SamplingParams
 
 
@@ -21,7 +21,7 @@ from vllm import SamplingParams
     "warmup_shapes",
     [[(64, 20, 4)]])  #,[(64,20,8)],[(128,20,4)],[(128,20,8)]])
 # (prompt_length/new_tokens/batch_size)
-@pytest.mark.parametrize("tp_size", [2])
+@pytest.mark.parametrize("tp_size", [2, 4, 8])
 @pytest.mark.parametrize(
     "backend", [b for b in get_spyre_backend_list() if "eager" not in str(b)])
 @pytest.mark.parametrize("vllm_version", VLLM_VERSIONS)
@@ -46,6 +46,7 @@ def test_output(
     test using 'pytest --capture=no tests/spyre/test_spyre_tensore_parallel.py'
     After debugging, DISABLE_ASSERTS should be reset to 'False'.
     '''
+    skip_unsupported_tp_size(tp_size)
 
     max_new_tokens = max([t[1] for t in warmup_shapes])
 

--- a/tests/spyre_util.py
+++ b/tests/spyre_util.py
@@ -537,3 +537,10 @@ def create_text_prompt(model: str, min_tokens: int, max_tokens: int) -> str:
     assert min_tokens < len(tokenizer.encode(prompt)) < max_tokens
 
     return prompt
+
+
+def skip_unsupported_tp_size(size: int):
+    cards = int(os.getenv("AIU_WORLD_SIZE", "0"))
+    if cards < size:
+        pytest.skip(f"Cannot run TP size {size}: "
+                    f"only {cards} cards are available")


### PR DESCRIPTION
This PR adds more TP sizes to the tests marked `multi`, and skips them if the required cards are not available