### PR TITLE
:bug: add required ignore modules for tensor parallel

### DIFF
--- a/docker/Dockerfile.amd64
+++ b/docker/Dockerfile.amd64
@@ -65,6 +65,7 @@ COPY --from=builder /opt/vllm /opt/vllm
 
 # Required Spyre environment configuration
 ENV COMPILATION_MODE=offline_decoder \
+    DISTRIBUTED_STRATEGY_IGNORE_MODULES=WordEmbedding,Embedding \
     DTLOG_LEVEL=error \
     DT_DEEPRT_VERBOSE=-1 \
     DT_OPT=varsub=1,lxopt=1,opfusion=1,arithfold=1,dataopt=1,patchinit=1,patchprog=1,autopilot=1,weipreload=0,kvcacheopt=1,progshareopt=1,dtversion=2 \


### PR DESCRIPTION
Missed this on internal testing for 0.3.0 with TP support :(

These modules are required to be ignored for graph compilation to function in tensor parallel mode