### PR TITLE
:bug: fetch tags for versioning in docker build

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -33,6 +33,11 @@ jobs:
     steps:
     - name: "Checkout"
       uses: actions/checkout@v4
+      # We need to fetch history and tags so that we can correctly version the
+      # vllm_spyre package, since it uses setuptools_scm to version based on
+      # git tags.
+      with:
+        fetch-depth: 0
 
     - name: "Set up QEMU"
       uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
The docker images don't have a correct version for the package, they all report:
```
$ pip3 list | grep spyre
vllm-spyre                               0.1.dev1
```
This is because we don't have tag info to version from if we don't fetch any history on checkout in the docker build workflow. Fetch-depth 0 should fetch all tags: https://github.com/actions/checkout?tab=readme-ov-file#fetch-all-history-for-all-tags-and-branches
