### PR TITLE
[CI] Only build docker image on source changes

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -10,8 +10,12 @@ on:
   pull_request:
     branches:
       - "main"
-    paths-ignore:
-      - "**.md"
+    paths:
+      - ".github/workflows/build_docker.yml"
+      - "docker/**"
+      - "vllm_spyre/**/*.py"
+      - "pyproject.toml"
+      - "uv.lock"
   release:
     types: [published]
 


### PR DESCRIPTION
The `Build Docker` workflow is one of the biggest consumers of Github Action minutes.

To preserve our GHA quota, only run Docker image build on PRs that change relevant files:

- `.github/workflows/build_docker.yml`
- `docker/**`
- `vllm_spyre/**/*.py`
- `pyproject.toml`
- `uv.lock`