### PR TITLE
[CI] Don't skip tests when `uv.lock` is updated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,7 @@ jobs:
           files: |
             .github/workflows/test.yml
             pyproject.toml
+            uv.lock
             tests/**/*.py
             vllm_spyre/**/*.py
 


### PR DESCRIPTION
Currently, the tests workflow runs on every PR but skips actually running the install and test steps when no source code was changed (PR #193) in order to complete PR checks more quickly and preserve GHA minutes, while allowing tests to be required PR check.

However, as witnessed in PR #213, https://github.com/vllm-project/vllm-spyre/actions/runs/15474000691/job/43565048121, tests don't run when only Python package versions are updated.

This PR changes that. Running full tests on `uv.lock` updates.