### PR TITLE
Exclude vllm v0.9.1 as an allowed version due to breaking bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = {text = "Apache 2"}
 dependencies = [
     "fms-model-optimizer>=0.2.0",
     "ibm-fms==1.0.0",
-    "vllm>=0.9.0",
+    "vllm>0.9.0,!=0.9.1",
 ]
 requires-python = ">=3.9"
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = {text = "Apache 2"}
 dependencies = [
     "fms-model-optimizer>=0.2.0",
     "ibm-fms==1.0.0",
-    "vllm>0.9.0,!=0.9.1",
+    "vllm>=0.9.0,!=0.9.1",
 ]
 requires-python = ">=3.9"
 dynamic = ["version"]

--- a/uv.lock
+++ b/uv.lock
@@ -4816,7 +4816,7 @@ lint = [
 requires-dist = [
     { name = "fms-model-optimizer", specifier = ">=0.2.0" },
     { name = "ibm-fms", specifier = "==1.0.0" },
-    { name = "vllm", specifier = ">0.9.0,!=0.9.1" },
+    { name = "vllm", specifier = ">=0.9.0,!=0.9.1" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -4816,7 +4816,7 @@ lint = [
 requires-dist = [
     { name = "fms-model-optimizer", specifier = ">=0.2.0" },
     { name = "ibm-fms", specifier = "==1.0.0" },
-    { name = "vllm", specifier = ">=0.9.0" },
+    { name = "vllm", specifier = ">0.9.0,!=0.9.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
vLLM v0.9.1 contains a bug that causes vllm-spyre to hang on boot-up.

The bug is not respecting `num_gpu_blocks_overrides`. It was introduced in https://github.com/vllm-project/vllm/pull/17996 and fixed in https://github.com/vllm-project/vllm/pull/19503.