### PR TITLE
fix: avoid KeyError when cancelling requests that have not been processed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ plugins.md007.indent = 4
 [dependency-groups]
 dev = [
     "pytest==8.3.4",
+    "pytest-asyncio>=1.0.0",
     "pytest-forked==1.6.0",
     "pytest-timeout==2.3.1",
     "requests==2.32.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ skip_gitignore = true
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
+asyncio_default_fixture_loop_scope = "function"
 
 # --8<-- [start:test-markers-definition]
 markers = [

--- a/tests/e2e/test_spyre_async_llm.py
+++ b/tests/e2e/test_spyre_async_llm.py
@@ -46,7 +46,7 @@ async def generate(
         if cancel_after is not None and count >= cancel_after:
             return count, request_id
 
-        await asyncio.sleep(0.0)
+        await asyncio.sleep(0.01)
 
     return count, request_id
 

--- a/tests/e2e/test_spyre_async_llm.py
+++ b/tests/e2e/test_spyre_async_llm.py
@@ -1,6 +1,5 @@
 import asyncio
 from contextlib import ExitStack
-from typing import Optional
 
 import pytest
 from spyre_util import get_spyre_backend_list, get_spyre_model_list
@@ -18,8 +17,6 @@ async def generate(
     output_kind: RequestOutputKind,
     max_tokens: int,
     n: int = 1,
-    prompt_logprobs: Optional[int] = None,
-    cancel_after: Optional[int] = None,
 ) -> tuple[int, str]:
     # Ensure generate doesn't complete too fast for cancellation test.
     await asyncio.sleep(0.2)
@@ -31,7 +28,6 @@ async def generate(
         output_kind=output_kind,
         seed=42,
         n=n,
-        prompt_logprobs=prompt_logprobs,
     )
     async for out in engine.generate(request_id=request_id,
                                      prompt=prompt,
@@ -42,9 +38,6 @@ async def generate(
             count += num_tokens
         else:
             count = num_tokens
-
-        if cancel_after is not None and count >= cancel_after:
-            return count, request_id
 
         await asyncio.sleep(0.01)
 

--- a/tests/e2e/test_spyre_async_llm.py
+++ b/tests/e2e/test_spyre_async_llm.py
@@ -1,0 +1,170 @@
+import asyncio
+import os
+from contextlib import ExitStack
+from typing import Optional
+
+import pytest
+from spyre_util import get_spyre_backend_list, get_spyre_model_list
+from vllm import PromptType, SamplingParams
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.engine.async_llm_engine import AsyncLLMEngine
+from vllm.sampling_params import RequestOutputKind
+from vllm.v1.engine.async_llm import AsyncLLM
+
+VLLM_VERSIONS = [
+    pytest.param("V0", marks=pytest.mark.v0, id="v0"),
+    pytest.param("V1", marks=pytest.mark.v1, id="v1"),
+]
+
+
+async def generate(
+    engine: AsyncLLM | AsyncLLMEngine,
+    request_id: str,
+    prompt: PromptType,
+    output_kind: RequestOutputKind,
+    max_tokens: int,
+    n: int = 1,
+    prompt_logprobs: Optional[int] = None,
+    cancel_after: Optional[int] = None,
+) -> tuple[int, str]:
+    # Ensure generate doesn't complete too fast for cancellation test.
+    await asyncio.sleep(0.2)
+
+    count = 0
+    sampling_params = SamplingParams(
+        max_tokens=max_tokens,
+        ignore_eos=True,
+        output_kind=output_kind,
+        seed=42,
+        n=n,
+        prompt_logprobs=prompt_logprobs,
+    )
+    async for out in engine.generate(request_id=request_id,
+                                     prompt=prompt,
+                                     sampling_params=sampling_params):
+
+        num_tokens = sum(len(output.token_ids) for output in out.outputs)
+        if output_kind == RequestOutputKind.DELTA:
+            count += num_tokens
+        else:
+            count = num_tokens
+
+        if cancel_after is not None and count >= cancel_after:
+            return count, request_id
+
+        await asyncio.sleep(0.0)
+
+    return count, request_id
+
+
+@pytest.mark.parametrize("model", get_spyre_model_list())
+@pytest.mark.parametrize("backend", get_spyre_backend_list())
+@pytest.mark.parametrize("vllm_version", VLLM_VERSIONS)
+@pytest.mark.parametrize("cb",
+                         [pytest.param(1, marks=pytest.mark.cb, id="cb"), 0])
+@pytest.mark.parametrize("warmup_shapes", [[
+    (64, 20, 4),
+]])
+@pytest.mark.parametrize(
+    "output_kind", [RequestOutputKind.DELTA, RequestOutputKind.FINAL_ONLY])
+@pytest.mark.asyncio
+async def test_abort(
+    model: str,
+    backend: str,
+    vllm_version: str,
+    cb: int,
+    warmup_shapes: list[list[int]],
+    output_kind: RequestOutputKind,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test handling of cancelled requests"""
+
+    if cb == 1:
+        if vllm_version != "V1":
+            pytest.skip("CB tests require V1")
+        if backend != "eager":
+            pytest.skip("CB requires eager")
+
+    with monkeypatch.context() as m, ExitStack() as after:
+        if cb == 1:
+            m.setenv("VLLM_SPYRE_USE_CB", "1")
+            m.setenv("VLLM_USE_V1", "1")
+            m.setenv("VLLM_SPYRE_DYNAMO_BACKEND", backend)
+        else:
+            warmup_prompt_length = [t[0] for t in warmup_shapes]
+            warmup_new_tokens = [t[1] for t in warmup_shapes]
+            warmup_batch_size = [t[2] for t in warmup_shapes]
+
+            m.setenv('VLLM_SPYRE_WARMUP_PROMPT_LENS',
+                     ','.join(str(val) for val in warmup_prompt_length))
+            m.setenv('VLLM_SPYRE_WARMUP_NEW_TOKENS',
+                     ','.join(str(val) for val in warmup_new_tokens))
+            m.setenv('VLLM_SPYRE_WARMUP_BATCH_SIZES',
+                     ','.join(str(val) for val in warmup_batch_size))
+            m.setenv('VLLM_SPYRE_DYNAMO_BACKEND', backend)
+            m.setenv('VLLM_USE_V1', "1" if vllm_version == "V1" else "0")
+
+        # Async LLM API is a little different between v0 and V1
+        EngineClass = AsyncLLM if os.environ[
+            "VLLM_USE_V1"] == 1 else AsyncLLMEngine
+        engine = EngineClass.from_engine_args(
+            AsyncEngineArgs(
+                model=model,
+                tokenizer=model,
+                max_model_len=128,
+                max_num_seqs=8,
+                block_size=2048,
+            ))
+        after.callback(engine.shutdown if isinstance(engine, AsyncLLM) else
+                       engine.shutdown_background_loop)
+
+        # Test structure here mirrors upstream vLLM test_abort:
+        # https://github.com/vllm-project/vllm/blob/e6aab5de2999187c6cf0206f2d63ab6d7a0b6964/tests/v1/engine/test_async_llm.py#L160
+        NUM_REQUESTS = 100
+        NUM_EXPECTED_TOKENS = 20
+        REQUEST_IDS_TO_ABORT = range(1, 100, 10)
+        PARALLEL_SAMPLE_REQ_IDS = range(1, 100, 15)
+
+        request_ids = [f"request-{i}" for i in range(NUM_REQUESTS)]
+
+        # Create concurrent requests
+        tasks: list[asyncio.Task] = []
+        prompt = "Provide a list of instructions for preparing chicken soup."
+        for idx, request_id in enumerate(request_ids):
+            max_tokens = NUM_EXPECTED_TOKENS
+            n = 3 if idx in PARALLEL_SAMPLE_REQ_IDS else 1
+            tasks.append(
+                asyncio.create_task(
+                    generate(engine, request_id, prompt, output_kind,
+                             max_tokens, n)))
+
+        # Simulate cancellation from API server client disconnect
+        for idx in REQUEST_IDS_TO_ABORT:
+            tasks[idx].cancel()
+            await asyncio.sleep(0.1)
+
+        # Confirm that requests actually cancelled and that the other requests
+        # are not impacted
+        for idx, task in enumerate(tasks):
+            if idx in REQUEST_IDS_TO_ABORT:
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+            else:
+                num_generated_tokens, request_id = await task
+                n = 3 if idx in PARALLEL_SAMPLE_REQ_IDS else 1
+                expected_tokens = NUM_EXPECTED_TOKENS * n
+                assert num_generated_tokens == expected_tokens, (
+                    f"{request_id} generated {num_generated_tokens} but "
+                    f"expected {expected_tokens}")
+
+        # Make sure all aborted requests were really aborted
+        assert not engine.output_processor.has_unfinished_requests()
+
+        # Confirm that the server is still up and functioning
+        request_id = f"request-{REQUEST_IDS_TO_ABORT[0]}"
+        task = asyncio.create_task(
+            generate(engine, request_id, prompt, output_kind,
+                     NUM_EXPECTED_TOKENS))
+        num_generated_tokens, request_id = await task
+        assert num_generated_tokens == NUM_EXPECTED_TOKENS
+        assert not engine.output_processor.has_unfinished_requests()

--- a/tests/e2e/test_spyre_async_llm.py
+++ b/tests/e2e/test_spyre_async_llm.py
@@ -115,6 +115,10 @@ async def test_abort(
                 max_num_seqs=8,
                 block_size=2048,
             ))
+        has_unfinished_requests = \
+            engine.output_processor.has_unfinished_requests \
+            if isinstance(engine, AsyncLLM) \
+            else engine.engine.has_unfinished_requests
         after.callback(engine.shutdown if isinstance(engine, AsyncLLM) else
                        engine.shutdown_background_loop)
 
@@ -158,7 +162,7 @@ async def test_abort(
                     f"expected {expected_tokens}")
 
         # Make sure all aborted requests were really aborted
-        assert not engine.output_processor.has_unfinished_requests()
+        assert not has_unfinished_requests()
 
         # Confirm that the server is still up and functioning
         request_id = f"request-{REQUEST_IDS_TO_ABORT[0]}"
@@ -167,4 +171,4 @@ async def test_abort(
                      NUM_EXPECTED_TOKENS))
         num_generated_tokens, request_id = await task
         assert num_generated_tokens == NUM_EXPECTED_TOKENS
-        assert not engine.output_processor.has_unfinished_requests()
+        assert not has_unfinished_requests()

--- a/tests/e2e/test_spyre_async_llm.py
+++ b/tests/e2e/test_spyre_async_llm.py
@@ -11,11 +11,6 @@ from vllm.engine.async_llm_engine import AsyncLLMEngine
 from vllm.sampling_params import RequestOutputKind
 from vllm.v1.engine.async_llm import AsyncLLM
 
-VLLM_VERSIONS = [
-    pytest.param("V0", marks=pytest.mark.v0, id="v0"),
-    pytest.param("V1", marks=pytest.mark.v1, id="v1"),
-]
-
 
 async def generate(
     engine: AsyncLLM | AsyncLLMEngine,
@@ -59,7 +54,7 @@ async def generate(
 
 @pytest.mark.parametrize("model", get_spyre_model_list())
 @pytest.mark.parametrize("backend", get_spyre_backend_list())
-@pytest.mark.parametrize("vllm_version", VLLM_VERSIONS)
+@pytest.mark.parametrize("vllm_version", ["V0", "V1"])
 @pytest.mark.parametrize("cb",
                          [pytest.param(1, marks=pytest.mark.cb, id="cb"), 0])
 @pytest.mark.parametrize("warmup_shapes", [[

--- a/uv.lock
+++ b/uv.lock
@@ -3405,6 +3405,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/d4/14f53324cb1a6381bef29d698987625d80052bb33932d8e7cbf9b337b17c/pytest_asyncio-1.0.0.tar.gz", hash = "sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f", size = 46960, upload-time = "2025-05-26T04:54:40.484Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/05/ce271016e351fddc8399e546f6e23761967ee09c8c568bbfbecb0c150171/pytest_asyncio-1.0.0-py3-none-any.whl", hash = "sha256:4f024da9f1ef945e680dc68610b52550e36590a67fd31bb3b4943979a1f90ef3", size = 15976, upload-time = "2025-05-26T04:54:39.035Z" },
+]
+
+[[package]]
 name = "pytest-forked"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4793,6 +4805,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest", marker = "python_full_version >= '3.10'" },
+    { name = "pytest-asyncio", marker = "python_full_version >= '3.10'" },
     { name = "pytest-forked", marker = "python_full_version >= '3.10'" },
     { name = "pytest-timeout", marker = "python_full_version >= '3.10'" },
     { name = "requests", marker = "python_full_version >= '3.10'" },
@@ -4823,6 +4836,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = "==8.3.4" },
+    { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "pytest-forked", specifier = "==1.6.0" },
     { name = "pytest-timeout", specifier = "==2.3.1" },
     { name = "requests", specifier = "==2.32.3" },

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -616,15 +616,15 @@ class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):
 
         # Continuous batching stuff
         for req_id in scheduler_output.finished_req_ids:
-            if req_id in self.req_ids2blocks:
+            # requests may be cancelled from the client side while in the queue
+            if req_id in self.requests:
                 logger.debug("Freeing request id: %s", req_id)
                 for freed_block in self.req_ids2blocks[req_id]:
                     self.free_blocks.append(freed_block)
                 del self.req_ids2blocks[req_id]
                 del self.req_ids2left_pads[req_id]
-
-            del self.requests[req_id]
-            self.input_batch.remove_request(req_id)
+                del self.requests[req_id]
+                self.input_batch.remove_request(req_id)
 
         # free the blocks used for padding to minimum decode batch size of 2
         if self.dummy_req_ids2blocks and \

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -616,9 +616,11 @@ class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):
 
         # Continuous batching stuff
         for req_id in scheduler_output.finished_req_ids:
-            logger.debug("Finishing request id: %s", req_id)
-            for block_id in self.req_ids2blocks.pop(req_id, []):
-                self.free_blocks.append(block_id)
+            if blocks_to_free := self.req_ids2blocks.pop(req_id, None):
+                logger.debug("Freeing request id: %s", req_id)
+                for block_id in blocks_to_free:
+                    logger.debug("Freeing block with id: %s", block_id)
+                    self.free_blocks.append(block_id)
             self.req_ids2left_pads.pop(req_id, None)
             self.requests.pop(req_id, None)
             self.input_batch.remove_request(req_id)

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -616,15 +616,12 @@ class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):
 
         # Continuous batching stuff
         for req_id in scheduler_output.finished_req_ids:
-            # requests may be cancelled from the client side while in the queue
-            if req_id in self.requests:
-                logger.debug("Freeing request id: %s", req_id)
-                for freed_block in self.req_ids2blocks[req_id]:
-                    self.free_blocks.append(freed_block)
-                del self.req_ids2blocks[req_id]
-                del self.req_ids2left_pads[req_id]
-                del self.requests[req_id]
-                self.input_batch.remove_request(req_id)
+            logger.debug("Finishing request id: %s", req_id)
+            for block_id in self.req_ids2blocks.pop(req_id, []):
+                self.free_blocks.append(block_id)
+            self.req_ids2left_pads.pop(req_id, None)
+            self.requests.pop(req_id, None)
+            self.input_batch.remove_request(req_id)
 
         # free the blocks used for padding to minimum decode batch size of 2
         if self.dummy_req_ids2blocks and \


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm-spyre/issues/225
