### PR TITLE
[FIX] lazy import of SpyreCausalLM to avoid issues with pytest-forked

### DIFF
--- a/tests/e2e/test_spyre_warmup_shapes.py
+++ b/tests/e2e/test_spyre_warmup_shapes.py
@@ -3,8 +3,6 @@
 Run `python -m pytest tests/test_spyre_warmup_shapes.py`.
 """
 
-import os
-
 import pytest
 from spyre_util import (compare_results, generate_hf_output,
                         generate_spyre_vllm_output, get_spyre_backend_list,
@@ -12,10 +10,6 @@ from spyre_util import (compare_results, generate_hf_output,
 from vllm import SamplingParams
 
 
-# temporary for filtering until bug with caching gets fixed
-@pytest.mark.skipif(
-    os.environ.get("TORCH_SENDNN_CACHE_ENABLE") == "1",
-    reason="torch_sendnn caching is currently broken with this configuration")
 @pytest.mark.parametrize("model", get_spyre_model_list())
 @pytest.mark.parametrize("prompts", [
     7 * [

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -13,7 +13,7 @@ from vllm.utils import is_pin_memory_available
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec
 from vllm.v1.outputs import SamplerOutput
 
-# from vllm_spyre.model_executor.model_loader.spyre import SpyreCausalLM
+from vllm_spyre.model_executor.model_loader.spyre import SpyreCausalLM
 from vllm_spyre.platform import SpyrePlatform
 from vllm_spyre.v1.worker.spyre_input_batch import (CachedRequestState,
                                                     InputBatch)
@@ -109,11 +109,6 @@ class SpyreModelRunner:
 
     def load_model(self, prompt_lens: Iterable[int],
                    num_decode_tokens: Iterable[int]) -> None:
-        # Lazy import to avoid load torch_sendnn runtime before it is really
-        # necessary. This solve issues of running forked tests that share
-        # some resources from parent to children which can have problems
-        # of caching even though the test run in isolated subprocesses.
-        from vllm_spyre.model_executor.model_loader.spyre import SpyreCausalLM
         max_pad_length = max(prompt_lens)
         max_decode_length = max(num_decode_tokens)
         self.model = SpyreCausalLM(

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -13,7 +13,7 @@ from vllm.utils import is_pin_memory_available
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec
 from vllm.v1.outputs import SamplerOutput
 
-from vllm_spyre.model_executor.model_loader.spyre import SpyreCausalLM
+# from vllm_spyre.model_executor.model_loader.spyre import SpyreCausalLM
 from vllm_spyre.platform import SpyrePlatform
 from vllm_spyre.v1.worker.spyre_input_batch import (CachedRequestState,
                                                     InputBatch)
@@ -109,6 +109,11 @@ class SpyreModelRunner:
 
     def load_model(self, prompt_lens: Iterable[int],
                    num_decode_tokens: Iterable[int]) -> None:
+        # Lazy import to avoid load torch_sendnn runtime before it is really
+        # necessary. This solve issues of running forked tests that share
+        # some resources from parent to children which can have problems
+        # of caching even though the test run in isolated subprocesses.
+        from vllm_spyre.model_executor.model_loader.spyre import SpyreCausalLM
         max_pad_length = max(prompt_lens)
         max_decode_length = max(num_decode_tokens)
         self.model = SpyreCausalLM(


### PR DESCRIPTION

# Description

We were having problems with pytest-forked and cache. After some investigation and debugging I figure it out that we were importing torch_sendnn before it was necessary, so pytest already initialize the runtime and the forking inherit it, which I believe it was the cause of the problems with the cache.

Also I re-enabled a test that was skipped because of this known issue.

## Related Issues

Potentially fix: #150 