### PR TITLE
🐛 fix runtime msg

### DIFF
--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -214,10 +214,10 @@ class SpyrePlatform(Platform):
             if max_seq_len > max_model_len:
                 raise RuntimeError(
                     f"Warmup shape [{shape['batch_size']},"
-                    " {shape['prompt_length']}, {shape['new_tokens']}]"
-                    " results in a maximum sequence length of "
-                    "{max_seq_len} which is longer that what the model "
-                    "supports ({max_model_len})")
+                    f" {shape['prompt_length']}, {shape['new_tokens']}]"
+                    f" results in a maximum sequence length of "
+                    f"{max_seq_len} which is longer that what the model "
+                    f"supports ({max_model_len})")
         return cls._warmup_shapes
 
     @classmethod


### PR DESCRIPTION
# Description

Earlier, the error showed up as
```
RuntimeError: Warmup shape [4, {shape['prompt_length']}, {shape['new_tokens']}] results in a maximum sequence length of {max_seq_len} which is longer that what the model supports ({max_model_len})
```
After this fix, it shows up correctly:
```
RuntimeError: Warmup shape [4, 128, 20] results in a maximum sequence length of 148 which is longer that what the model supports (128)
```