### PR TITLE
[ppc64le] Add bare metal benchmarking and start scripts

### DIFF
--- a/examples/online_inference/spyre_vllm_benchmark.py
+++ b/examples/online_inference/spyre_vllm_benchmark.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+
+"""
+Example usage:
+python3 container-scripts/spyre_vllm_benchmark.py --prompt-dir $HOME/prompts/ --tokenizer-dir $HOME/models/granite-3.3-8b-instruct --output-dir $HOME/output/ --port 8000 --max-tokens 64 --min-tokens 64
+"""
+
+# Imports
+import argparse
+import requests
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import NamedTuple
+from openai import OpenAI, APIConnectionError
+from transformers import AutoTokenizer, PreTrainedTokenizer
+
+# Classes
+class InferenceResults(NamedTuple):
+    outputs: list[str]
+    inference_time: float
+    inference_time_no_ttft: float
+    output_token_count: int
+    ttft: float
+    itl: float
+
+# Functions
+def parse_args():
+    parser = argparse.ArgumentParser(description="VLLM Spyre inference benchmarking script.")
+    parser.add_argument("--prompt-dir", required=True, type=str, help="Path to directory containing .txt files")
+    parser.add_argument("--tokenizer-dir", required=True, type=str, help="Path to a directory containing a tokenizer")
+    parser.add_argument("--port", required=False, help="Port of running container to connect to.", default=8000)
+    parser.add_argument("--max-tokens", required=False, type=int, help="Maximum number of tokens to generate", default=64)
+    parser.add_argument("--min-tokens", required=False, type=int, help="Minimum number of tokens to generate", default=0)
+    parser.add_argument("--output-dir", required=False, type=Path, help="Output directory to dump results and performance metrics", default=None)
+    return parser.parse_args()
+
+def create_client(api_key: str, base_url: str) -> OpenAI:
+    """
+    Creates and returns an OpenAI client.
+
+    Args:
+        api_key (str): The OpenAI API key. Often set to "EMPTY" for local inference setups.
+        base_url (str): The base URL of the OpenAI-compatible API, e.g., "http://localhost:8000/v1".
+
+    Returns:
+        OpenAI: An instance of the OpenAI client initialized with the provided API key and base URL.
+    """
+    client = OpenAI(
+        api_key=api_key,
+        base_url=base_url,
+    )
+    return client
+
+def test_server_connection(client: OpenAI, endpoint: str) -> bool:
+    """
+    Tests the connection to a specified endpoint of the OpenAI server.
+
+    Args:
+        client (OpenAI): The OpenAI client instance.
+        endpoint (str): The relative endpoint to test (e.g., "/models/").
+
+    Returns:
+        bool: True if the server responds with a 200 status code; False otherwise.
+    """
+    try:
+        base_url = str(client.base_url).rstrip("/")
+        response = requests.get(base_url + endpoint)
+        return response.status_code == 200
+    except requests.RequestException as e:
+        print(e)
+        return False
+
+def connect(client: OpenAI, endpoint: str, max_tries: int = 5) -> None:
+    """
+    Attempts to connect to the specified server endpoint max_tries times.
+
+    Args:
+        client (OpenAI): The OpenAI client instance.
+        endpoint (str): The relative endpoint to connect to (e.g., "/models").
+        max_tries (int): Maximum number of connection attempts. Default is 5.
+
+    Returns:
+        None
+
+    Raises:
+        RuntimeError: If connection fails after max_tries attempts.
+    """
+    tries = 0
+    while tries < max_tries:
+        try:
+            base_url = str(client.base_url).rstrip("/")
+            address = base_url + endpoint
+            response = requests.get(address)
+            if response.status_code == 200:
+                return
+        except requests.RequestException as e:
+            print(f"Connection attempt {tries + 1} failed: {e}")
+        time.sleep(1)
+        tries += 1
+    raise RuntimeError(f"Failed to connect to {endpoint} after {max_tries} attempts.")
+
+def get_tokenizer(model_path: str):
+    """
+    Loads and returns a tokenizer from the specified model path.
+
+    Args:
+        model_path (str): Path to the pretrained model directory or identifier from Hugging Face Hub.
+
+    Returns:
+        PreTrainedTokenizer: A tokenizer instance loaded from model_path.
+    """
+    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    return tokenizer
+
+def get_model_from_server(client: OpenAI) -> str:
+    """
+    Retrieves the first available model ID from the OpenAI-compatible server.
+
+    Args:
+        client (OpenAI): An instance of the OpenAI client.
+
+    Returns:
+        str: The ID of the first model returned by the server.
+
+    Raises:
+        SystemExit: If there is a connection error while fetching models.
+    """
+    model = None
+    try:
+        models = client.models.list()
+        model = models.data[0].id
+        print(f"Found Model: {model}")
+    except APIConnectionError as e:
+        print(f"Connection Error: {e}")
+        exit(1)
+    return model
+
+def process_input_prompts(prompt_dir: str) -> list[Path]:
+    """
+    Collects all `.txt` prompt files from the specified directory.
+
+    Args:
+        prompt_dir (str): Path to the directory containing prompt files.
+
+    Returns:
+        list[Path]: List of Paths to the `.txt` prompt files found in the directory.
+    """
+    prompt_list = list(Path(prompt_dir).glob("*.txt"))
+    if not prompt_list:
+        print(f"No .txt files found in {prompt_dir}.")
+        exit(1)
+    print(f"Found {len(prompt_list)} prompt files at {prompt_dir}")
+    return prompt_list
+
+def save_results(output_dir: Path, prompt_files: list[Path], model: str, results: InferenceResults):
+    """
+    Saves model inference outputs and performance metrics to the specified output directory.
+
+    Each prompt's generated output is written to a separate text file named after the prompt,
+    and performance metrics are written to a single `performance_metrics.txt` file.
+
+    Args:
+        output_dir (Path): The directory in which to save the output files. Created if it doesn't exist.
+        prompt_files (list[Path]): A list of prompt file paths that were used for inference.
+        results (InferenceResults): An object containing model outputs and performance metrics.
+
+    Returns:
+        None
+
+    Raises:
+        SystemExit: If the output directory could not be created.
+    """
+    # Attempt to create output directory
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        print(f"Failed to create output directory at {output_dir}: {e}")
+        exit(1)
+
+    # Write inference outputs
+    for file, result in zip(prompt_files, results.outputs):
+        with open(output_dir / f"{file.stem}.txt", "w") as f:
+            f.write(result)
+
+    # Generate timestamped filename
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    metrics_filename = output_dir / f"performance_metrics_{timestamp}.txt"
+
+    # Write performance metrics
+    with open(metrics_filename, "w") as f:
+        f.write(f"Results for inference with model: {model}\n")
+        f.write(f"Inference Time: {results.inference_time:.4f}s\n")
+        f.write(f"Inference Time w/o TTFT: {results.inference_time_no_ttft:.4f}s\n")
+        f.write(f"Output Token Count: {results.output_token_count}\n")
+        f.write(f"TTFT: {results.ttft:.4f}s\n")
+        f.write(f"ITL: {results.itl:.4f}s/token\n")
+
+    print(f"Saved results to {output_dir}")
+
+def run_inference(
+    client: OpenAI,
+    model: str,
+    tokenizer: PreTrainedTokenizer,
+    prompt_files: list[Path],
+    max_tokens: int,
+    min_tokens: int
+) -> InferenceResults:
+    """
+    Runs inference using an OpenAI-compatible client on a set of text prompts.
+
+    This function reads prompt files, tokenizes the inputs, sends them to the server for 
+    streamed completion, and calculates performance metrics such as inference time, 
+    time to first token (TTFT), and inter-token latency (ITL).
+
+    Args:
+        client (OpenAI): An instance of the OpenAI client.
+        model (str): The model ID to use for inference.
+        tokenizer (PreTrainedTokenizer): The tokenizer used to compute token counts.
+        prompt_files (list[Path]): A list of file paths pointing to `.txt` prompt files.
+        max_tokens (int): Maximum number of tokens to generate per prompt.
+        min_tokens (int): Minimum number of tokens to generate per prompt.
+
+    Returns:
+        InferenceMetrics:
+            - outputs (list[str]): Raw list of generated text completions for each prompt.
+            - inference_time (float): Total time taken for inference (seconds).
+            - inference_time_no_ttft (float): Time taken for inference excluding ttft (seconds).
+            - output_token_count (int): Total number of output tokens generated across all prompts.
+            - ttft (float): Time to first token (seconds).
+            - itl (float): Inter-token latency (seconds per token).
+    
+    Raises:
+        Exception: If error occurs during the inference process.
+    """
+    # Read text from each prompt file
+    prompts = [p.read_text() for p in prompt_files]
+    # Get token count for each prompt
+    for i, (prompt_text, prompt_file) in enumerate(zip(prompts, prompt_files)):
+            token_count = len(tokenizer(prompt_text)["input_ids"])
+            print(f"Prompt file: {prompt_file.name} | Prompt #{i} token count: {token_count}")
+
+    # Single prompt test run
+    print("Starting single prompt test run")
+    test_prompt = prompts[0]
+    try:
+        test_response = client.completions.create(
+            model=model,
+            prompt=test_prompt,
+            max_tokens=max_tokens,
+            stream=True,
+            temperature=0.0,
+            extra_body=dict(min_tokens=min_tokens)
+        )
+
+        output = [""]
+        for chunk in test_response:
+            idx = chunk.choices[0].index
+            output[idx] += chunk.choices[0].text
+    except Exception as e:
+        print(f"Error during single prompt test run:\n")
+        print(e)
+    print("Completed single prompt test run")
+    
+    print("Starting inference")
+    try:
+        # Submit inference payload
+        start_time = time.perf_counter()
+        response = client.completions.create(
+            model=model,
+            prompt=prompts,
+            max_tokens=max_tokens,
+            stream=True,
+            temperature=0.0,
+            extra_body=dict(min_tokens=min_tokens)
+        )
+        
+        # Collect streamed tokens
+        outputs = [""] * len(prompts)
+        first_token_time = None
+        for chunk in response:
+            if first_token_time is None:
+                    first_token_time = time.perf_counter()
+                    ttft = first_token_time - start_time
+            idx = chunk.choices[0].index
+            outputs[idx] += chunk.choices[0].text
+        end_time = time.perf_counter()
+        print("Inference complete")
+        
+        # Calculate results
+        inference_time = end_time - start_time
+        inference_time_no_ttft = inference_time - ttft
+        output_token_count = sum(len(tokenizer(output)["input_ids"]) for output in outputs)
+        inter_token_tokens = max(output_token_count - 1, 1)
+        itl = inference_time_no_ttft / inter_token_tokens
+    except Exception as e:
+        print(f"Error during inference:\n")
+        print(e)
+
+    return InferenceResults(outputs, inference_time, inference_time_no_ttft, output_token_count, ttft, itl)
+
+def main():
+    # Collect command line arguments
+    args = parse_args()
+    tokenizer_dir = args.tokenizer_dir
+    port = args.port
+    prompt_dir = args.prompt_dir
+    max_tokens = args.max_tokens
+    min_tokens = args.min_tokens
+    output_dir = args.output_dir
+
+    client = create_client("EMPTY", f"http://localhost:{port}/v1")
+
+    # If a server connection is made
+    if test_server_connection(client, "/models/"):
+        # Prepare model and prompts
+        prompt_list = process_input_prompts(prompt_dir)
+        tokenizer = get_tokenizer(tokenizer_dir)
+        model = get_model_from_server(client)
+
+        # Inference step
+        results = run_inference(client, model, tokenizer, prompt_list, max_tokens, min_tokens)
+
+        # Print results
+        for file, result in zip(prompt_list, results.outputs):
+            print(f"\n== Output for {file.name} ==\n{result}\n")
+        print("\n== Inference Performance Metrics ==")
+        print(f"Inference Time: {results.inference_time:.4f}s")
+        print(f"Inference Time w/o TTFT: {results.inference_time_no_ttft:.4f}s")
+        print(f"Number of Output Tokens Generated: {results.output_token_count} tokens")
+        print(f"Time to First Token: {results.ttft:.4f}s")
+        print(f"Inter-Token Latency: {results.itl:.4f}s/tok")
+
+        # Optionally save results
+        if output_dir:
+            save_results(output_dir, prompt_list, model, results)
+    else:
+        print("Server connection failed")
+        exit(1)
+
+if __name__ == "__main__":
+    main()
+

--- a/examples/online_inference/vllm_start_bare_metal.sh
+++ b/examples/online_inference/vllm_start_bare_metal.sh
@@ -1,0 +1,70 @@
+#!/bin/bash -e
+
+# This script sets up the runtime environment for launching a vLLM API server using Spyre AIU cards.
+# Used for local development and testing in tandem with podman run command.
+# Not for use on an openshift cluster.
+# 1. Validates Torch sendNN cache settings.
+# 2. Detects and configures available AIU devices.
+# 3. Activates the Python virtual environment if not already active.
+# 4. Launches the vLLM server with the computed arguments.
+
+if [ "$TORCH_SENDNN_CACHE_ENABLE" = "1" ]; then
+    if [ -z "$TORCH_SENDNN_CACHE_DIR" ]; then
+        echo "Error: TORCH_SENDNN_CACHE_DIR is not set."
+        exit 1
+    fi
+
+    if [ ! -d "$TORCH_SENDNN_CACHE_DIR" ]; then
+        echo "Error: Cache directory $TORCH_SENDNN_CACHE_DIR does not exist."
+        exit 1
+    fi
+
+    PERMS=$(stat -c "%a" "$TORCH_SENDNN_CACHE_DIR")
+    if [ "$PERMS" != "777" ]; then
+        echo "Error: Cache directory $TORCH_SENDNN_CACHE_DIR does not have 777 permissions. Current: $PERMS"
+        exit 1
+    fi
+fi
+
+# Ensure that a model path has been set
+if [ -z "${VLLM_MODEL_PATH}" ]; then
+    echo "VLLM_MODEL_PATH is not set. Exiting."
+    exit 1
+fi
+
+# Configure AIU cards, use all if none are specified.
+if [ -z "${VLLM_AIU_PCIE_IDS}" ] ; then
+	export VLLM_AIU_PCIE_IDS=$(lspci -n -d 1014:06a7 | cut -d ' ' -f 1)
+fi
+
+# Create a senlib_config.json to use only specified AIU id's.
+tmpfile=$(mktemp -t senlib_config_XXXXXXX.json)
+cat <<EOF | jq --argjson newValues "$(for i in ${VLLM_AIU_PCIE_IDS}; do echo $i; done | jq -R . | jq -s .)" '.GENERAL.sen_bus_id = $newValues' > $tmpfile
+{
+  "GENERAL": {
+    "target": "SOC",
+    "sen_bus_id": [
+    ]
+  },
+  "METRICS": {
+    "general": {
+      "enable": false
+    }
+  }
+}
+EOF
+sudo mv $tmpfile /etc/aiu/senlib_config.json
+
+# Reconfigure AIU's, and update the envvars to reflect changes
+. /etc/bashrc-sentient-env.sh
+setup_multi_aiu_env
+
+# Activate the vllm venv if not already active
+if [[ "x" == "x$VIRTUAL_ENV" ]] ; then
+    source /opt/vllm/bin/activate
+fi
+
+# Start the vllm server with given model and detected parallelism.
+DEFAULT_ARGS="--model ${VLLM_MODEL_PATH} -tp ${AIU_WORLD_SIZE}"
+exec python -m vllm.entrypoints.openai.api_server ${DEFAULT_ARGS} $@
+

--- a/examples/online_inference/vllm_start_bare_metal.sh
+++ b/examples/online_inference/vllm_start_bare_metal.sh
@@ -39,7 +39,7 @@ fi
 
 # Create a senlib_config.json to use only specified AIU id's.
 tmpfile=$(mktemp -t senlib_config_XXXXXXX.json)
-cat <<EOF | jq --argjson newValues "$(for i in ${VLLM_AIU_PCIE_IDS}; do echo $i; done | jq -R . | jq -s .)" '.GENERAL.sen_bus_id = $newValues' > $tmpfile
+cat <<EOF | jq --argjson newValues "$(for i in ${VLLM_AIU_PCIE_IDS}; do echo "$i"; done | jq -R . | jq -s .)" '.GENERAL.sen_bus_id = $newValues' > "$tmpfile"
 {
   "GENERAL": {
     "target": "SOC",
@@ -53,18 +53,18 @@ cat <<EOF | jq --argjson newValues "$(for i in ${VLLM_AIU_PCIE_IDS}; do echo $i;
   }
 }
 EOF
-sudo mv $tmpfile /etc/aiu/senlib_config.json
+sudo mv "$tmpfile" /etc/aiu/senlib_config.json
 
 # Reconfigure AIU's, and update the envvars to reflect changes
 . /etc/bashrc-sentient-env.sh
 setup_multi_aiu_env
 
 # Activate the vllm venv if not already active
-if [[ "x" == "x$VIRTUAL_ENV" ]] ; then
+if [[ -z "$VIRTUAL_ENV" ]] ; then
     source /opt/vllm/bin/activate
 fi
 
 # Start the vllm server with given model and detected parallelism.
 DEFAULT_ARGS="--model ${VLLM_MODEL_PATH} -tp ${AIU_WORLD_SIZE}"
-exec python -m vllm.entrypoints.openai.api_server ${DEFAULT_ARGS} $@
+exec python -m vllm.entrypoints.openai.api_server "${DEFAULT_ARGS}" "$@"
 


### PR DESCRIPTION
This PR adds two new files to vllm-spyre.

`vllm_start_bare_metal.sh` is a simple setup script that handles AIU device setup and starts the vllm server in containers/bare metal setups. This script is not to be used with openshift clusters.

`spyre_vllm_benchmark.py` is a simple benchmarking script to be used in tandem with `vllm_start_bare_metal.sh`. It allows for connection to a running vllm server and performs model inference with provided prompt files. Performance metrics and results are printed and optionally saved to an output directory.
