### PR TITLE
:arrow_up: upgrade base image for release

### DIFF
--- a/docker/Dockerfile.amd64
+++ b/docker/Dockerfile.amd64
@@ -1,6 +1,6 @@
 # This is a reference dockerfile for vLLM Spyre support on an x86 host
-ARG BASE_IMAGE_URL="quay.io/ibm-aiu/base"
-ARG BASE_IMAGE_TAG="2025_05_29.amd64"
+ARG BASE_IMAGE_URL="quay.io/ibm-aiu/spyre-base"
+ARG BASE_IMAGE_TAG="2025_06_18-amd64"
 
 ##############################################
 # Base


### PR DESCRIPTION
# Description

This updates the base image to the newest version. It's gone through a naming change from `base` -> `spyre-base`: https://quay.io/repository/ibm-aiu/spyre-base?tab=tags

