### PR TITLE
[CB] Scheduling constraints regarding number of available blocks/pages

### DIFF
--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -17,6 +17,7 @@ from vllm.model_executor.model_loader.weight_utils import (
 from vllm.model_executor.sampling_metadata import SamplingMetadata
 
 import vllm_spyre.envs as envs_spyre
+from vllm_spyre.platform import SpyrePlatform
 
 try:
     import backends.dynamo_tracer  # noqa: F401
@@ -282,7 +283,7 @@ class ContinuousBatchingFmsModel(FmsModelBase):
         scheduler_config: SchedulerConfig,
     ) -> None:
 
-        BLOCK_SIZE = 64  # hardcoded Spyre constraint for now
+        BLOCK_SIZE = SpyrePlatform.get_block_size()
         max_model_len = scheduler_config.max_model_len
 
         # edge case: prompt fills model length: can produce 1 token with prefill

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -41,6 +41,7 @@ class SpyrePlatform(Platform):
     device_type: str = "cpu"
     supported_quantization: list[str] = ["gptq"]
     _warmup_shapes: Optional[tuple[dict[str, int], ...]] = None
+    _block_size: int = 64  # hardcoded Spyre constraint for now
     _config: VllmConfig = None
 
     @classmethod
@@ -221,6 +222,10 @@ class SpyrePlatform(Platform):
         return cls._warmup_shapes
 
     @classmethod
+    def get_block_size(cls) -> int:
+        return cls._block_size
+
+    @classmethod
     def supports_v1(cls, model_config: ModelConfig) -> bool:
         """Returns whether the current platform can support v1 for the supplied
         model configuration.
@@ -261,7 +266,7 @@ class SpyrePlatform(Platform):
 
             # ceil division to pad to next block boundary
             n = prompt_len
-            d = 64  # hardcoded AIU Spyre block size
+            d = cls._block_size
             prompt_padding_len = ((n + d - 1) // d) * d
             if (prompt_padding_len + max_tokens
                     > cls._config.scheduler_config.max_model_len):

--- a/vllm_spyre/v1/core/scheduler.py
+++ b/vllm_spyre/v1/core/scheduler.py
@@ -147,7 +147,7 @@ class ContinuousBatchingSpyreScheduler(SpyreScheduler):
         super().__init__(*args, **kwargs)
         self.tkv = 0
         self.n_free_blocks = 0
-        self.BLOCK_SIZE = 64  # hardcoded Spyre constraint for now
+        self.BLOCK_SIZE = SpyrePlatform.get_block_size()
 
     def update_from_output(
         self,

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -48,8 +48,9 @@ class ModelForwardInputs:
 
 @dataclass
 class CBSpyreModelRunnerOutput(ModelRunnerOutput):
-    # Add the current tkv to the output
+    # Add the current tkv and the number of free blocks to the output
     tkv: int = 0
+    n_free_blocks: int = 0
 
 
 class SpyreModelRunner:
@@ -965,6 +966,8 @@ class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):
                                             logprobs=None,
                                             prompt_logprobs_dict={},
                                             tkv=0,
+                                            n_free_blocks=len(
+                                                self.free_blocks),
                                             **extra_kwargs)
 
         model_input = self.prepare_model_input(scheduler_output)
@@ -1051,6 +1054,7 @@ class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):
                                   for req_id in req_ids
                                   },  # TODO(wallas?): prompt logprobs too
             tkv=self.tkv,
+            n_free_blocks=len(self.free_blocks),
             **extra_kwargs,
         )
         return model_output

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -579,7 +579,7 @@ class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):
         assert vllm_config.scheduler_config.max_num_seqs >= 2, "Currently, " \
             "continuous batching needs config to set batch_size >= 2"
 
-        self.BLOCK_SIZE = 64  # hardcoded Spyre constraint for now
+        self.BLOCK_SIZE = SpyrePlatform.get_block_size()
 
         # TO DO: move to InputBatch
         self.req_ids2blocks: dict[str, deque[int]] = {}


### PR DESCRIPTION
### [CB] Scheduling constraints regarding number of available blocks/pages

changes:
- [x] move hard coded `BLOCK_SIZE` (64) variable to Platform class and import it where needed instead of defining it in multiple different places. 
- [x] introduce scheduler constraints regarding number of available blocks/pages in `can_schedule()`
- [ ] write unit test for new scheduler constraint

closes #260 