### PR TITLE
[CB] remove reference to outdated fms feature branch

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -103,16 +103,7 @@ Here is a list of `pytest` markers you can use to filter them:
 
 ### Testing Continuous Batching
 
-!!! attention
-    Continuous batching currently requires the custom installation described below until the FMS custom branch is merged to main.
-
-After completing the setup steps above, install custom FMS branch to enable support for continuous batching:
-
-```sh
-uv pip install git+https://github.com/foundation-model-stack/foundation-model-stack.git@paged_attn_mock --force-reinstall
-```
-
-Then, run the continuous batching tests:
+Run the continuous batching tests:
 
 ```sh
 python -m pytest -v -x tests/e2e -m cb

--- a/examples/offline_inference/cb_spyre_inference.py
+++ b/examples/offline_inference/cb_spyre_inference.py
@@ -10,9 +10,6 @@ import time
 
 from vllm import LLM, SamplingParams
 
-# Continuous batching currently requires installing the branch
-# https://github.com/foundation-model-stack/foundation-model-stack/tree/paged_attn_mock
-
 parser = argparse.ArgumentParser()
 parser.add_argument("--model",
                     type=str,


### PR DESCRIPTION
### [CB] remove reference to outdated fms feature branch

`paged_attn_mock` branch of fms is no longer needed and API on `main` supports both, static and continuous batching simultaneously #162 
