### PR TITLE
Respect vllm logging configs in vllm_spyre

### DIFF
--- a/vllm_spyre/__init__.py
+++ b/vllm_spyre/__init__.py
@@ -3,8 +3,8 @@ import json
 from logging.config import dictConfig
 from typing import Any
 
-from vllm.logger import DEFAULT_LOGGING_CONFIG
 from vllm.envs import VLLM_CONFIGURE_LOGGING, VLLM_LOGGING_CONFIG_PATH
+from vllm.logger import DEFAULT_LOGGING_CONFIG
 
 __version__ = importlib.metadata.version("vllm_spyre")
 
@@ -34,7 +34,7 @@ def _init_logging():
                     "vllm"]
             else:
                 config["formatters"]["vllm_spyre"] = DEFAULT_LOGGING_CONFIG[
-                    "formatters"][ "vllm"]
+                    "formatters"]["vllm"]
 
         if "vllm_spyre" not in config["handlers"]:
             if "vllm" in config["handlers"]:

--- a/vllm_spyre/__init__.py
+++ b/vllm_spyre/__init__.py
@@ -1,7 +1,10 @@
 import importlib.metadata
+import json
 from logging.config import dictConfig
+from typing import Any
 
 from vllm.logger import DEFAULT_LOGGING_CONFIG
+from vllm.envs import VLLM_CONFIGURE_LOGGING, VLLM_LOGGING_CONFIG_PATH
 
 __version__ = importlib.metadata.version("vllm_spyre")
 
@@ -13,19 +16,39 @@ def register():
 
 def _init_logging():
     """Setup logging, extending from the vLLM logging config"""
-    config = {**DEFAULT_LOGGING_CONFIG}
+    config = dict[str, Any]()
 
-    # Copy the vLLM logging configurations for our package
-    config["formatters"]["vllm_spyre"] = DEFAULT_LOGGING_CONFIG["formatters"][
-        "vllm"]
+    if VLLM_CONFIGURE_LOGGING:
+        config = {**DEFAULT_LOGGING_CONFIG}
 
-    handler_config = DEFAULT_LOGGING_CONFIG["handlers"]["vllm"]
-    handler_config["formatter"] = "vllm_spyre"
-    config["handlers"]["vllm_spyre"] = handler_config
+    if VLLM_LOGGING_CONFIG_PATH:
+        # Error checks must be done already in vllm.logger.py
+        with open(VLLM_LOGGING_CONFIG_PATH, encoding="utf-8") as file:
+            config = json.loads(file.read())
 
-    logger_config = DEFAULT_LOGGING_CONFIG["loggers"]["vllm"]
-    logger_config["handlers"] = ["vllm_spyre"]
-    config["loggers"]["vllm_spyre"] = logger_config
+    if VLLM_CONFIGURE_LOGGING:
+        # Copy the vLLM logging configurations for our package
+        if "vllm_spyre" not in config["formatters"]:
+            if "vllm" in config["formatters"]:
+                config["formatters"]["vllm_spyre"] = config["formatters"]["vllm"]
+            else:
+                config["formatters"]["vllm_spyre"] = DEFAULT_LOGGING_CONFIG["formatters"][ "vllm"]
+
+        if "vllm_spyre" not in config["handlers"]:
+            if "vllm" in config["handlers"]:
+                handler_config = config["handlers"]["vllm"]
+            else:
+                handler_config = DEFAULT_LOGGING_CONFIG["handlers"]["vllm"]
+            handler_config["formatter"] = "vllm_spyre"
+            config["handlers"]["vllm_spyre"] = handler_config
+
+        if "vllm_spyre" not in config["loggers"]:
+            if "vllm" in config["loggers"]:
+                logger_config = config["loggers"]["vllm"]
+            else:
+                logger_config = DEFAULT_LOGGING_CONFIG["loggers"]["vllm"]
+            logger_config["handlers"] = ["vllm_spyre"]
+            config["loggers"]["vllm_spyre"] = logger_config
 
     dictConfig(config)
 

--- a/vllm_spyre/__init__.py
+++ b/vllm_spyre/__init__.py
@@ -30,9 +30,11 @@ def _init_logging():
         # Copy the vLLM logging configurations for our package
         if "vllm_spyre" not in config["formatters"]:
             if "vllm" in config["formatters"]:
-                config["formatters"]["vllm_spyre"] = config["formatters"]["vllm"]
+                config["formatters"]["vllm_spyre"] = config["formatters"][
+                    "vllm"]
             else:
-                config["formatters"]["vllm_spyre"] = DEFAULT_LOGGING_CONFIG["formatters"][ "vllm"]
+                config["formatters"]["vllm_spyre"] = DEFAULT_LOGGING_CONFIG[
+                    "formatters"][ "vllm"]
 
         if "vllm_spyre" not in config["handlers"]:
             if "vllm" in config["handlers"]:


### PR DESCRIPTION
# Description

vLLM has mechanism to change [logging configuration](https://docs.vllm.ai/en/v0.7.2/getting_started/examples/logging_configuration.html) by using environment variables.  However, vllm_spyre does not refers to these environment variables, but it always configure python logging based on the hard coded default of vLLM.  As a result, changing logging configuration results in mixing log messages of different configurations and generates inconsistent logs.

This PR updates initialization of python logger in vllm_spyer to respect the logging configs and use the same logging configuration as vllm.
