### PR TITLE
Update warmup log messages and comments

### DIFF
--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -68,7 +68,7 @@ class SpyreWorker(WorkerBaseV1):
 
         num_shape_combinations = len(self.spyre_warmup_shapes)
         logger.info(
-            "[WARMUP] Starting warmup for %d "
+            "[WARMUP] Starting for %d "
             "prompt/decode/batchsize-shape combinations...",
             len(self.spyre_warmup_shapes))
         all_warmup_start_t = time.time()
@@ -594,7 +594,7 @@ class SpyreWorker(WorkerBaseV1):
                               max_tokens=num_decode_tokens,
                               prompt_len=prompt_len)
         logger.info(
-            "[WARMUP] Warmup for prompt length %d and max output tokens %d "
+            "[WARMUP] Prompt length %d and max output tokens %d "
             "finished in %.3fs", warmup_total_t, prompt_len, num_decode_tokens)
         maybe_override_signals_handler()
 

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -68,8 +68,8 @@ class SpyreWorker(WorkerBaseV1):
 
         num_shape_combinations = len(self.spyre_warmup_shapes)
         logger.info(
-            "Start warming up %d different "
-            "prompt/decode/batchsize-shape combinations.",
+            "[WARMUP] Starting warmup for %d "
+            "prompt/decode/batchsize-shape combinations...",
             len(self.spyre_warmup_shapes))
         all_warmup_start_t = time.time()
         for i, (prompt_len, num_decode_tokens, batch_size) in enumerate([
@@ -84,11 +84,9 @@ class SpyreWorker(WorkerBaseV1):
                     "at least 3 (spyre requirement).")
             # warmup individual combination
             logger.info(
-                "Warmup %d/%d prompt/decode/batchsize-shape "
-                "combinations...", i + 1, num_shape_combinations)
-            logger.info(
-                "Warming up for prompt length %d, decoding %d tokens with "
-                "batch size %d", prompt_len, num_decode_tokens, batch_size)
+                "[WARMUP] (%d/%d) for prompt length %d, decoding %d tokens "
+                "with batch size %d...", i + 1, num_shape_combinations,
+                prompt_len, num_decode_tokens, batch_size)
             self._warmup_spyre_fixed_size(prompt_len, num_decode_tokens,
                                           self.restricted_tokens, batch_size)
         all_warmup_end_t = time.time()
@@ -97,9 +95,9 @@ class SpyreWorker(WorkerBaseV1):
         # No more perf metric are captured (so far) after warmup, cleanup now.
         del self.perf_metrics
         logger.info(
-            "All warmups for %d different prompt/decode/batchsize-shape "
-            "combinations finished. Total warmup time %.3fs.",
-            num_shape_combinations, all_warmup_total_t)
+            "[WARMUP] All %d prompt/decode/batchsize-shape "
+            "combinations finished in %.3fs", num_shape_combinations,
+            all_warmup_total_t)
         self.model_runner.complete_warmup()
 
     def check_health(self) -> None:
@@ -356,10 +354,10 @@ class SpyreWorker(WorkerBaseV1):
                     structured_output_request_ids={},
                     grammar_bitmask=None,
                 )
-                logger.info("Warmup prefill %d/%d...", i + 1, batch_size)
+                logger.info("[WARMUP] Prefill %d/%d...", i + 1, batch_size)
                 self.execute_model(scheduler_output)
 
-            # one decode iteration across both sequences
+            # one decode iteration across all sequences
             cached_requests = [
                 CachedRequestData(
                     req_id=req.req_id,
@@ -389,12 +387,14 @@ class SpyreWorker(WorkerBaseV1):
                 structured_output_request_ids={},
                 grammar_bitmask=None,
             )
-            logger.info("Warmup decode 1/1...")
+            logger.info("[WARMUP] Decode...")
             self.execute_model(scheduler_output)
             self._cleanup_model_runner(request=dummy_requests)
 
-        # doing one additional prefill outside the warmup_context seems to be
-        # necessary to have reasonable TTFT for the first prefill after warmup
+        # warmup_mode completes the graph compilation, but we need to do
+        # one additional prefill to deploy the compiled program to the device,
+        # the necessary operations are included in the graph and will be removed
+        # after this execution
         scheduler_output = SchedulerOutput(
             scheduled_new_reqs=[add_dummy_request],
             scheduled_cached_reqs=[],
@@ -408,7 +408,7 @@ class SpyreWorker(WorkerBaseV1):
             structured_output_request_ids={},
             grammar_bitmask=None,
         )
-        logger.info("Warmup additional prefill...")
+        logger.info("[WARMUP] Deploying to device...")
         self.execute_model(scheduler_output)
         self._cleanup_model_runner(request=[add_dummy_request])
 
@@ -421,8 +421,7 @@ class SpyreWorker(WorkerBaseV1):
 
         warmup_end_t = time.time()
         warmup_total_t = warmup_end_t - warmup_start_t
-        logger.info("Warmup finished.")
-        logger.info("Warmup took %.3fs", warmup_total_t)
+        logger.info("[WARMUP] Finished in %.3fs", warmup_total_t)
 
         maybe_override_signals_handler()
 
@@ -570,7 +569,7 @@ class SpyreWorker(WorkerBaseV1):
         )
 
         # First full forward pass
-        logger.info("Warmup forward pass 1/2...")
+        logger.info("[WARMUP] Compiling graphs...")
         # The fixed size warmup needs to happen only in here
         with _maybe_warmup_context():
             self._warmup_model_forward_pass(scheduler_output, dummy_requests,
@@ -582,7 +581,7 @@ class SpyreWorker(WorkerBaseV1):
                               prompt_len=prompt_len)
 
         # Second full forward pass
-        logger.info("Warmup forward pass 2/2...")
+        logger.info("[WARMUP] Deploying to device...")
         warmup2_start_t = time.time()
         self._warmup_model_forward_pass(scheduler_output, dummy_requests,
                                         cached_requests, num_decode_tokens)
@@ -594,10 +593,9 @@ class SpyreWorker(WorkerBaseV1):
                               batch_size=batch_size,
                               max_tokens=num_decode_tokens,
                               prompt_len=prompt_len)
-        logger.info("Warmup finished.")
         logger.info(
-            "Warmup took %.3fs (for prompt length %d and max output tokens %d)",
-            warmup_total_t, prompt_len, num_decode_tokens)
+            "[WARMUP] Warmup for prompt length %d and max output tokens %d "
+            "finished in %.3fs", warmup_total_t, prompt_len, num_decode_tokens)
         maybe_override_signals_handler()
 
     def _warmup_model_forward_pass(


### PR DESCRIPTION
# Description

This came out of a follow up to https://github.com/vllm-project/vllm-spyre/pull/270 to determine why an extra Prefill was necessary after using `warmup_mode`. I learned that the extra Prefill is required to deploy the compiled graph to the Spyre device. This PR does not change any functionality, but updates logging and documentation around warmup to make this clearer.
