### PR TITLE
✅ add assertions for warmup mode context

### DIFF
--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -513,7 +513,12 @@ class SpyreWorker(WorkerBaseV1):
         prompt_len: int,
         batch_size: int,
         valid_token_ids_tensor: torch.Tensor,
-    ):
+    ) -> None:
+
+        assert (
+            _inside_warmup_mode
+        ), "it looks like you are outside the warmup context for warmup"
+
         for i, req in enumerate(dummy_requests):
             scheduler_output = SchedulerOutput(
                 scheduled_new_reqs=[req],
@@ -529,8 +534,7 @@ class SpyreWorker(WorkerBaseV1):
                 grammar_bitmask=None,
             )
             logger.info("[WARMUP] Prefill %d/%d...", i + 1, batch_size)
-            assert _inside_warmup_mode, \
-                "it looks like you are outside the warmup context for prefill"
+
             self.execute_model(scheduler_output)
 
         # one decode iteration across all sequences
@@ -569,8 +573,6 @@ class SpyreWorker(WorkerBaseV1):
             grammar_bitmask=None,
         )
         logger.info("[WARMUP] Decode...")
-        assert _inside_warmup_mode, \
-            "it looks like you are outside the warmup context for decode"
         self.execute_model(scheduler_output)
         self._cleanup_model_runner(request=dummy_requests)
 

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -325,7 +325,7 @@ class SpyreWorker(WorkerBaseV1):
         warmup_tokens_tensor = valid_token_ids_tensor[torch.randint(
             0, len(valid_token_ids_tensor), (batch_size + 1, prompt_len))]
 
-        dummy_requests = [
+        dummy_requests: list[NewRequestData] = [
             NewRequestData(
                 req_id="warmup-%d" % (i),
                 prompt_token_ids=warmup_tokens_tensor[i].tolist(),
@@ -342,67 +342,10 @@ class SpyreWorker(WorkerBaseV1):
         add_dummy_request = dummy_requests.pop(-1)
 
         with _maybe_warmup_context():
-            for i, req in enumerate(dummy_requests):
-                scheduler_output = SchedulerOutput(
-                    scheduled_new_reqs=[req],
-                    scheduled_cached_reqs=CachedRequestData.make_empty(),
-                    num_scheduled_tokens={req.req_id: prompt_len},
-                    total_num_scheduled_tokens=prompt_len,
-                    scheduled_spec_decode_tokens={},
-                    scheduled_encoder_inputs={},
-                    num_common_prefix_blocks=0,
-                    finished_req_ids=set(),
-                    free_encoder_input_ids=[],
-                    structured_output_request_ids={},
-                    grammar_bitmask=None,
-                )
-                logger.info("[WARMUP] Prefill %d/%d...", i + 1, batch_size)
-                assert _inside_warmup_mode, \
-                "it looks like you are outside the warmup context for prefill"
-                self.execute_model(scheduler_output)
-
-            # one decode iteration across all sequences
-            req_ids = []
-            new_token_ids = []
-            new_block_ids = []
-            num_computed_tokens = []
-            for req in dummy_requests:
-                req_ids.append(req.req_id)
-                new_token_ids.append([
-                    valid_token_ids_tensor[torch.randint(
-                        0, len(valid_token_ids_tensor), (1, )).item()]
-                ])  # placeholder token
-                new_block_ids.append([req.block_ids])
-                num_computed_tokens.append(prompt_len)
-            cached_request_data = CachedRequestData(
-                req_ids=req_ids,
-                resumed_from_preemption=False,
-                new_token_ids=new_token_ids,
-                new_block_ids=new_block_ids,
-                num_computed_tokens=num_computed_tokens,
-            )
-
-            scheduler_output = SchedulerOutput(
-                scheduled_new_reqs=[],
-                scheduled_cached_reqs=cached_request_data,
-                num_scheduled_tokens={
-                    f"warmup-{i}": 1
-                    for i in range(batch_size)
-                },
-                total_num_scheduled_tokens=batch_size,
-                scheduled_spec_decode_tokens={},
-                scheduled_encoder_inputs={},
-                num_common_prefix_blocks=0,
-                finished_req_ids=set(),
-                free_encoder_input_ids=[],
-                structured_output_request_ids={},
-                grammar_bitmask=None,
-            )
-            logger.info("[WARMUP] Decode...")
-            assert _inside_warmup_mode, \
-                "it looks like you are outside the warmup context for decode"
-            self.execute_model(scheduler_output)
-            self._cleanup_model_runner(request=dummy_requests)
+            self._dynamic_warmup(dummy_requests=dummy_requests,
+                                 prompt_len=prompt_len,
+                                 batch_size=batch_size,
+                                 valid_token_ids_tensor=valid_token_ids_tensor)
 
         # warmup_mode completes the graph compilation, but we need to do
         # one additional prefill to deploy the compiled program to the device,
@@ -563,6 +506,73 @@ class SpyreWorker(WorkerBaseV1):
             "[WARMUP] Prompt length %d and max output tokens %d "
             "finished in %.3fs", prompt_len, num_decode_tokens, warmup_total_t)
         maybe_override_signals_handler()
+
+    def _dynamic_warmup(
+        self,
+        dummy_requests: list[NewRequestData],
+        prompt_len: int,
+        batch_size: int,
+        valid_token_ids_tensor: torch.Tensor,
+    ):
+        for i, req in enumerate(dummy_requests):
+            scheduler_output = SchedulerOutput(
+                scheduled_new_reqs=[req],
+                scheduled_cached_reqs=CachedRequestData.make_empty(),
+                num_scheduled_tokens={req.req_id: prompt_len},
+                total_num_scheduled_tokens=prompt_len,
+                scheduled_spec_decode_tokens={},
+                scheduled_encoder_inputs={},
+                num_common_prefix_blocks=0,
+                finished_req_ids=set(),
+                free_encoder_input_ids=[],
+                structured_output_request_ids={},
+                grammar_bitmask=None,
+            )
+            logger.info("[WARMUP] Prefill %d/%d...", i + 1, batch_size)
+            assert _inside_warmup_mode, \
+                "it looks like you are outside the warmup context for prefill"
+            self.execute_model(scheduler_output)
+
+        # one decode iteration across all sequences
+        req_ids = []
+        new_token_ids = []
+        new_block_ids = []
+        num_computed_tokens = []
+        for req in dummy_requests:
+            req_ids.append(req.req_id)
+            new_token_ids.append([
+                valid_token_ids_tensor[torch.randint(
+                    0, len(valid_token_ids_tensor), (1, )).item()]
+            ])  # placeholder token
+            new_block_ids.append([req.block_ids])
+            num_computed_tokens.append(prompt_len)
+        cached_request_data = CachedRequestData(
+            req_ids=req_ids,
+            resumed_from_preemption=False,
+            new_token_ids=new_token_ids,
+            new_block_ids=new_block_ids,
+            num_computed_tokens=num_computed_tokens,
+        )
+
+        scheduler_output = SchedulerOutput(
+            scheduled_new_reqs=[],
+            scheduled_cached_reqs=cached_request_data,
+            num_scheduled_tokens={f"warmup-{i}": 1
+                                  for i in range(batch_size)},
+            total_num_scheduled_tokens=batch_size,
+            scheduled_spec_decode_tokens={},
+            scheduled_encoder_inputs={},
+            num_common_prefix_blocks=0,
+            finished_req_ids=set(),
+            free_encoder_input_ids=[],
+            structured_output_request_ids={},
+            grammar_bitmask=None,
+        )
+        logger.info("[WARMUP] Decode...")
+        assert _inside_warmup_mode, \
+            "it looks like you are outside the warmup context for decode"
+        self.execute_model(scheduler_output)
+        self._cleanup_model_runner(request=dummy_requests)
 
     def _warmup_model_forward_pass(
         self,


### PR DESCRIPTION
# Description

This PR adds assertions for operations done within the `warmup context`. Earlier we saw a bug in which the `decode` warmup was moved outside the warmup context because of one simple indentation issue and it caused a segmentation fault with no clue as to why it was happening.

These assertions should catch the error when running even on CPU.

