### PR TITLE
silence warning in pytest due to string conversion

### DIFF
--- a/tests/e2e/test_spyre_prompt_logprobs.py
+++ b/tests/e2e/test_spyre_prompt_logprobs.py
@@ -38,9 +38,9 @@ def test_prompt_logprobs(
 
     prompts = get_chicken_soup_prompts(4)
 
-    monkeypatch.setenv("VLLM_USE_V1", 1)
+    monkeypatch.setenv("VLLM_USE_V1", "1")
     monkeypatch.setenv("VLLM_SPYRE_DYNAMO_BACKEND", backend)
-    monkeypatch.setenv("VLLM_SPYRE_ENABLE_PROMPT_LOGPROBS", 1)
+    monkeypatch.setenv("VLLM_SPYRE_ENABLE_PROMPT_LOGPROBS", "1")
     llm = LLM(model, tensor_parallel_size=tp_size, tokenizer=model)
 
     responses: list[RequestOutput] = llm.generate(
@@ -63,7 +63,7 @@ def test_prompt_logprobs(
 @pytest.mark.decoder
 def test_prompt_logprobs_must_be_enabled(monkeypatch: pytest.MonkeyPatch):
     # If prompt logprobs is disabled, requests are rejected
-    monkeypatch.setenv("VLLM_SPYRE_ENABLE_PROMPT_LOGPROBS", 0)
+    monkeypatch.setenv("VLLM_SPYRE_ENABLE_PROMPT_LOGPROBS", "0")
     params = SamplingParams(prompt_logprobs=5)
 
     with pytest.raises(ValueError, match="VLLM_SPYRE_ENABLE_PROMPT_LOGPROBS"):
@@ -76,8 +76,8 @@ def test_prompt_logprobs_not_supported_with_cb(
         monkeypatch: pytest.MonkeyPatch):
     # Server shouldn't boot with both prompt logprobs and continuous batching
     # enabled
-    monkeypatch.setenv("VLLM_SPYRE_ENABLE_PROMPT_LOGPROBS", 1)
-    monkeypatch.setenv("VLLM_SPYRE_USE_CB", 1)
+    monkeypatch.setenv("VLLM_SPYRE_ENABLE_PROMPT_LOGPROBS", "1")
+    monkeypatch.setenv("VLLM_SPYRE_USE_CB", "1")
 
     with pytest.raises(ValueError, match="continuous batching"):
         VllmConfig(model_config=ModelConfig(task="generate"))
@@ -88,8 +88,8 @@ def test_prompt_logprobs_not_supported_with_cb(
 def test_prompt_logprobs_on_single_requests_only(
         monkeypatch: pytest.MonkeyPatch):
     # Only bs=1 is supported for prompt logprobs
-    monkeypatch.setenv("VLLM_SPYRE_ENABLE_PROMPT_LOGPROBS", 1)
-    monkeypatch.setenv("VLLM_SPYRE_WARMUP_BATCH_SIZES", 2)
+    monkeypatch.setenv("VLLM_SPYRE_ENABLE_PROMPT_LOGPROBS", "1")
+    monkeypatch.setenv("VLLM_SPYRE_WARMUP_BATCH_SIZES", "2")
 
     with pytest.raises(ValueError, match="batch size 1"):
         VllmConfig(model_config=ModelConfig(task="generate"))


### PR DESCRIPTION
### silence warning in pytest due to string conversion

silences warnings of this type: 
`PytestWarning: Value of environment variable x type should be str, but got 0 (type: int); converted to str implicitly`
