### PR TITLE
:bug: fix tensor parallel

### DIFF
--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -397,10 +397,6 @@ class SpyreModelRunner:
                                        masks=model_input.input_masks,
                                        is_prompt=model_input.is_prompt)
 
-        # Only perform sampling in the driver worker.
-        if not self.is_driver_worker:
-            return EMPTY_MODEL_RUNNER_OUTPUT
-
         # Compute the logits.
         logits = self.model.compute_logits(hidden_states, None)
 
@@ -433,6 +429,10 @@ class SpyreModelRunner:
 
         prompt_logprobs_dicts = self._get_prompt_logprobs_dict(
             logits=logits, model_inputs=model_input)
+
+        # Only return outputs from the driver worker
+        if not self.is_driver_worker:
+            return EMPTY_MODEL_RUNNER_OUTPUT
 
         model_output = ModelRunnerOutput(
             req_ids=list(req_id_to_index.keys()),


### PR DESCRIPTION
# Description

Fixes a bug introduced in #283 where the non-driver workers did not cache the output tokens for the next decode iteration
