### PR TITLE
remove `VLLM_ENABLE_V1_MULTIPROCESSING` disabling

### DIFF
--- a/tests/e2e/test_spyre_basic.py
+++ b/tests/e2e/test_spyre_basic.py
@@ -228,9 +228,6 @@ def test_full_batch_scheduling(model: str, backend: str, monkeypatch):
                        f"{max_batched_tokens}")
     monkeypatch.setenv("VLLM_SPYRE_WARMUP_NEW_TOKENS", "20")
 
-    # So we can access the engine and scheduler in this process
-    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
-
     monkeypatch.setenv("VLLM_USE_V1", "1")
     monkeypatch.setenv("VLLM_SPYRE_DYNAMO_BACKEND", backend)
 

--- a/tests/e2e/test_spyre_cb.py
+++ b/tests/e2e/test_spyre_cb.py
@@ -650,10 +650,6 @@ def test_scheduler_cb_steps_tkv(
     monkeypatch.setenv("VLLM_USE_V1", "1")
     monkeypatch.setenv("VLLM_SPYRE_DYNAMO_BACKEND", backend)
 
-    # To get deterministic execution in V1
-    # and to enable InprocClient
-    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
-
     max_model_len = 256
 
     # Input parameters sanity check, not actual testing


### PR DESCRIPTION
Re-enabling `VLLM_ENABLE_V1_MULTIPROCESSING` because it interferes with tests concurrency. 