### PR TITLE
[Fix] Tests breaking with vLLM:Main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,10 +70,15 @@ jobs:
             tests/**/*.py
             vllm_spyre/**/*.py
 
-      - name: "Install PyTorch"
-        if: steps.changed-src-files.outputs.any_changed == 'true'
+      - name: "Install PyTorch 2.5.1"
+        if: (steps.changed-src-files.outputs.any_changed == 'true' && !matrix.vllm_version.repo)
         run: |
           pip install torch=="2.5.1+cpu" --index-url https://download.pytorch.org/whl/cpu
+
+      - name: "Install PyTorch 2.7.0"
+        if: (steps.changed-src-files.outputs.any_changed == 'true' && matrix.vllm_version.repo)
+        run: |
+          pip install torch=="2.7.0+cpu" --index-url https://download.pytorch.org/whl/cpu
 
       - name: "Install uv"
         if: steps.changed-src-files.outputs.any_changed == 'true'

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -67,6 +67,9 @@ class SpyrePlatform(Platform):
 
         is_decoder = model_config.task == "generate"
         is_embedding = model_config.task == "embed"
+        if model_config.task == "auto":
+            is_embedding = "embed" in model_config.supported_tasks
+            is_decoder = "generate" in model_config.supported_tasks
 
         # v0 is only supported for embedding models, and embedding models must
         # be run on v0


### PR DESCRIPTION
Closes #305 

The changes in upstream that are breaking tests with vLLM:main branch are twofolds:
1. [This PR](https://github.com/vllm-project/vllm/pull/20061) introduces[ an import](https://github.com/vllm-project/vllm/blob/8020e98c9f033e76c97eb8261f772d59eba49c9a/vllm/model_executor/model_loader/bitsandbytes_loader.py#L23) which is incompatible with torch 2.5.1
2. Previously, when `model_config.task` was set to `auto`, the task could be automatically resolved in vLLM: after the post-init method of `ModelConfig`, the `task` field was automatically replaced from `auto` to .e.g. `generate` or `embed`). With the changes in [This PR](https://github.com/vllm-project/vllm/commit/020f58abcdea65302225663130d08fd8f4dd755a), the task in `model_config`, cannot be automatically resolved anymore when it is `generate`. This doesn't look like it is intended, but rather a side effect of adding new supported tasks. A cleaner (but longer) way would be to do a PR to vLLM to fix that and reintroduce the automatic resolution of `auto` task field. 

This PR addresses both of the breaking changes: 
* for 1. it installs pytorch==2.7.0 in github workflows when vLLM:main branch is used
* for 2: it infers the task through `model_config.supported_tasks` rather than `model_config.task` now