### PR TITLE
:bug: Workaround ray issue in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,10 +70,10 @@ jobs:
             tests/**/*.py
             vllm_spyre/**/*.py
 
-      - name: "Install PyTorch 2.7.0"
-        if: (steps.changed-src-files.outputs.any_changed == 'true' && !matrix.vllm_version.repo)
+      - name: "Install PyTorch 2.7.1"
+        if: (steps.changed-src-files.outputs.any_changed == 'true')
         run: |
-          pip install torch=="2.7.0+cpu" --index-url https://download.pytorch.org/whl/cpu
+          pip install torch=="2.7.1+cpu" --index-url https://download.pytorch.org/whl/cpu
 
       - name: "Install uv"
         if: steps.changed-src-files.outputs.any_changed == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,13 +70,8 @@ jobs:
             tests/**/*.py
             vllm_spyre/**/*.py
 
-      - name: "Install PyTorch 2.5.1"
-        if: (steps.changed-src-files.outputs.any_changed == 'true' && !matrix.vllm_version.repo)
-        run: |
-          pip install torch=="2.5.1+cpu" --index-url https://download.pytorch.org/whl/cpu
-
       - name: "Install PyTorch 2.7.0"
-        if: (steps.changed-src-files.outputs.any_changed == 'true' && matrix.vllm_version.repo)
+        if: (steps.changed-src-files.outputs.any_changed == 'true' && !matrix.vllm_version.repo)
         run: |
           pip install torch=="2.7.0+cpu" --index-url https://download.pytorch.org/whl/cpu
 

--- a/tests/e2e/test_spyre_prompt_logprobs.py
+++ b/tests/e2e/test_spyre_prompt_logprobs.py
@@ -7,8 +7,9 @@ import math
 import pytest
 import torch
 import torch.nn.functional
-from spyre_util import (get_chicken_soup_prompts, get_spyre_backend_list,
-                        get_spyre_model_list, skip_unsupported_tp_size)
+from spyre_util import (force_engine_shutdown, get_chicken_soup_prompts,
+                        get_spyre_backend_list, get_spyre_model_list,
+                        skip_unsupported_tp_size)
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from vllm import LLM, RequestOutput, SamplingParams
 from vllm.config import ModelConfig, VllmConfig
@@ -58,8 +59,7 @@ def test_prompt_logprobs(
                                  actual_logprobs,
                                  max_different_tokens=1,
                                  relative_tolerance=0.15)
-
-    llm.llm_engine.engine_core.shutdown()
+    force_engine_shutdown(llm)
 
 
 @pytest.mark.cpu

--- a/tests/e2e/test_spyre_prompt_logprobs.py
+++ b/tests/e2e/test_spyre_prompt_logprobs.py
@@ -59,6 +59,8 @@ def test_prompt_logprobs(
                                  max_different_tokens=1,
                                  relative_tolerance=0.15)
 
+    llm.llm_engine.engine_core.shutdown()
+
 
 @pytest.mark.cpu
 @pytest.mark.decoder

--- a/tests/e2e/test_spyre_static_batching_limits.py
+++ b/tests/e2e/test_spyre_static_batching_limits.py
@@ -56,3 +56,5 @@ def test_max_prompt_len_and_new_tokens(model: str,
         results = llm.generate(prompts=[prompt],
                                sampling_params=sampling_params)
         assert results[0].outputs[0].text == ""
+
+    llm.llm_engine.engine_core.shutdown()

--- a/tests/e2e/test_spyre_static_batching_limits.py
+++ b/tests/e2e/test_spyre_static_batching_limits.py
@@ -4,8 +4,9 @@ Run `python -m pytest tests/e2e/test_spyre_max_prompt_length.py`.
 """
 
 import pytest
-from spyre_util import (create_text_prompt, get_spyre_backend_list,
-                        get_spyre_model_list, patch_warmup_shapes)
+from spyre_util import (create_text_prompt, force_engine_shutdown,
+                        get_spyre_backend_list, get_spyre_model_list,
+                        patch_warmup_shapes)
 from vllm import LLM, SamplingParams
 
 
@@ -57,4 +58,4 @@ def test_max_prompt_len_and_new_tokens(model: str,
                                sampling_params=sampling_params)
         assert results[0].outputs[0].text == ""
 
-    llm.llm_engine.engine_core.shutdown()
+    force_engine_shutdown(llm)

--- a/tests/spyre_util.py
+++ b/tests/spyre_util.py
@@ -217,6 +217,8 @@ def generate_spyre_vllm_output(
         ])
         results.append(result)
 
+    vllm_model.llm_engine.engine_core.shutdown()
+
     return results
 
 
@@ -391,6 +393,8 @@ def spyre_vllm_embeddings(model: str, prompts: list[str],
         result = {}
         result["embeddings"] = req_output.outputs.embedding
         results.append(result)
+
+    vllm_model.llm_engine.engine_core.shutdown()
 
     return results
 


### PR DESCRIPTION
~~Testing whether or not torch 2.7 will cause the EADDRINUSE failures on vllm 0.9.2~~

Edit: The issue appears to be with the shutdown logic in vllm, with TP running the model executor is not shut down when an `LLM` is garbage collected. This is caused by a circular reference in vllm.executor.ray_utils when ray is not installed. This PR adds a temporary workaround to force the engine shutdowns after each test.

Also updating to torch 2.7.1 everywhere since our next release will have 2.7.1 in the base image as well.