### PR TITLE
[Docs] Use mkdocstrings for CB tests

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -17,7 +17,8 @@ nav:
       - Supported Models: user_guide/supported_models.md
     - Developer Guide:
       - Contributing: contributing/README.md
-      - Continuous Batching API: developer_guide/continuous_batching_api.md
+      - Continuous Batching:
+        - Testing: contributing/continuous_batching/tests.md
 
   - Getting Started:
     - Installation: getting_started/installation.md
@@ -32,3 +33,5 @@ nav:
     - Supported Models: user_guide/supported_models.md
   - Developer Guide:
     - Contributing: contributing/README.md
+    - Continuous Batching:
+      - Testing: contributing/continuous_batching/tests.md

--- a/docs/contributing/continuous_batching/tests.md
+++ b/docs/contributing/continuous_batching/tests.md
@@ -1,0 +1,3 @@
+# Tests
+
+::: tests.e2e.test_spyre_cb

--- a/docs/contributing/continuous_batching_api.md
+++ b/docs/contributing/continuous_batching_api.md
@@ -1,3 +1,0 @@
-# Continuous Batching Test Usage
-
-::: tests.e2e.test_spyre_cb.py


### PR DESCRIPTION
# Description

Uses `mkdocstrings` to create a doc outlining CB tests and parameters.

Related to #300 