### PR TITLE
:bug: use right attention name

### DIFF
--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -416,7 +416,7 @@ class StaticBatchingFmsModel(FmsModelBase):
         **extra_kwargs,
     ) -> torch.Tensor:
         # specify attention type for static batching
-        extra_kwargs['attn_name'] = "sdpa_bidirectional"
+        extra_kwargs['attn_name'] = "sdpa_causal"
 
         if envs_spyre.VLLM_SPYRE_ENABLE_PROMPT_LOGPROBS:
             # In order to calculate prompt logprobs, we have to return the


### PR DESCRIPTION
@JRosenkranz says this should be sdpa_causal, but it doesn't matter since we always pass a mask