### PR TITLE
removing legacy backward compatibility

### DIFF
--- a/tests/spyre_util.py
+++ b/tests/spyre_util.py
@@ -555,6 +555,8 @@ def create_random_request(
                              eos_token_id=None,
                              arrival_time=0,
                              lora_request=None,
+                             data_parallel_rank=None,
+                             pooling_params=None,
                              cache_salt=None)
 
 

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -441,6 +441,7 @@ class SpyreModelRunner:
             logprobs=(output.logprobs_tensors.tolists()
                       if output.logprobs_tensors else None),
             prompt_logprobs_dict=prompt_logprobs_dicts,
+            pooler_output=None,
         )
 
         return model_output

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -329,7 +329,9 @@ class SpyreWorker(WorkerBaseV1):
                 sampling_params=SamplingParams(max_tokens=num_decode_tokens),
                 block_ids=[0],  # not actually used
                 num_computed_tokens=0,
-                lora_request=None) for i in range(batch_size + 1)
+                lora_request=None,
+                pooling_params=None,
+            ) for i in range(batch_size + 1)
         ]
         add_dummy_request = dummy_requests.pop(-1)
 
@@ -478,7 +480,8 @@ class SpyreWorker(WorkerBaseV1):
                 sampling_params=SamplingParams(max_tokens=num_decode_tokens),
                 block_ids=[0],
                 num_computed_tokens=0,
-                lora_request=None) for i in range(batch_size)
+                lora_request=None,
+                pooling_params=None) for i in range(batch_size)
         ]
 
         # Set up dummy cached_requests for decode steps


### PR DESCRIPTION
### removing legacy backward compatibility
due to the requirement `vllm>=0.9.2` we can safely revert some changes by #245 . 