### PR TITLE
[Fix][Tests] TP param used in tests unconditionally

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,7 +126,7 @@ def remote_openai_server(request):
         if 'tp_size' in params:
             tp_size = params['tp_size']
             skip_unsupported_tp_size(int(tp_size), backend)
-        server_args.extend(["--tensor-parallel-size", str(tp_size)])
+            server_args.extend(["--tensor-parallel-size", str(tp_size)])
 
     try:
         with RemoteOpenAIServer(model, server_args,


### PR DESCRIPTION
# Description

`--tensor-parallel-size` and `tp_size` flag being used regardless of the the block checking if `tp_size` exists.