### PR TITLE
[CB] bug fix: account for prefill token 

### DIFF
--- a/examples/offline_inference/long_context.py
+++ b/examples/offline_inference/long_context.py
@@ -122,7 +122,7 @@ def round_up(t):
 
 
 tokens_to_generate = [
-    args.max_model_len + 1 - round_up(plen) for plen in prompt_lens
+    args.max_model_len + 1 - round_up(prompt_len) for prompt_len in prompt_lens
 ]
 
 sampling_params = [

--- a/examples/offline_inference/long_context.py
+++ b/examples/offline_inference/long_context.py
@@ -56,7 +56,7 @@ args = parser.parse_args()
 trunc = args.trunc_print_len
 
 max_num_seqs = args.max_num_seqs  # defines the max batch size
-assert args.max_prompt_len < args.max_model_len
+assert args.max_prompt_len <= args.max_model_len
 
 if platform.machine() == "arm64":
     print("Detected arm64 running environment. "
@@ -122,7 +122,7 @@ def round_up(t):
 
 
 tokens_to_generate = [
-    args.max_model_len - round_up(plen) for plen in prompt_lens
+    args.max_model_len + 1 - round_up(plen) for plen in prompt_lens
 ]
 
 sampling_params = [

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -284,7 +284,8 @@ class SpyrePlatform(Platform):
             # ceil division to pad to next block boundary
             prompt_padding_len = math.ceil(
                 prompt_len / cls._block_size) * cls._block_size
-            if (prompt_padding_len + max_tokens
+            # we have to account for the token generated during prefill (-1)
+            if (prompt_padding_len + max_tokens - 1
                     > cls._config.scheduler_config.max_model_len):
                 raise ValueError(
                     "Could not add request: prompt length is "


### PR DESCRIPTION
### [CB] bug fix: account for prefill token when asserting context length

Prefill already provides one new token (without requiring any KV cache for it). 

Example: for max model length 2048 it is possible to do a prefill on a prompt of size 2048 to (32 blocks in Spyre) when only requesting 1 token. A 33rd block is only needed if a 2nd output token was requested and that would violate the max model length. 

changes:
- correct assertion in platform.py: allow any requests that satisfy: `prompt_padding_len + max_tokens - 1 <= max_model_len`
- correct long_context.py: allowing `prompt_len <= max_model_len` while setting 
`new_tokens = max_model_len + 1 - prompt_padding_len`