### PR TITLE
fix off by one error

### DIFF
--- a/tests/spyre_util.py
+++ b/tests/spyre_util.py
@@ -530,7 +530,7 @@ def create_text_prompt(model: str, min_tokens: int, max_tokens: int) -> str:
     prompt = pepper * (min_tokens // pepper_tokens + 1)
 
     # And add more until we're over the minimum token length
-    while len(tokenizer.encode(prompt)) < min_tokens:
+    while len(tokenizer.encode(prompt)) <= min_tokens:
         prompt += pepper
 
     # Make sure this prompt is within the specified range


### PR DESCRIPTION
In `create_text_prompt()`, the following `while` loop can result in `len(tokenizer.encode(prompt)) < min_tokens` causing the assert to fail.
```
    # And add more until we're over the minimum token length
    while len(tokenizer.encode(prompt)) < min_tokens:
        prompt += pepper

    # Make sure this prompt is within the specified range
    assert min_tokens < len(tokenizer.encode(prompt)) < max_tokens
```

The comment in the place where the function is called shows that the intention is for the generated prompt to be strictly larger than `min_tokens`:
```
    # Craft a request with a prompt that is slightly too long for the warmup
    # shape
    prompt = create_text_prompt(model,
                                min_tokens=max_prompt_length,
                                max_tokens=max_prompt_length + max_new_tokens -
                                1)
```
