### PR TITLE
:bug: fix cb online test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,13 +91,18 @@ def remote_openai_server(request):
             "Error setting up remote_openai_server params") from e
 
     if 'cb' in params:
-        max_num_seqs = params['max_num_seqs']
+        max_model_len = params["max_model_len"]
+        max_num_seqs = params["max_num_seqs"]
         env_dict = {
             "VLLM_SPYRE_USE_CB": "1",
             "VLLM_SPYRE_DYNAMO_BACKEND": backend,
             "VLLM_USE_V1": "1"
         }
-        server_args = ["--max_num_seqs", str(max_num_seqs)]
+        server_args = [
+            "--max_num_seqs",
+            str(max_num_seqs), "--max-model-len",
+            str(max_model_len)
+        ]
 
     else:
         warmup_shape = params['warmup_shape']

--- a/tests/e2e/test_spyre_online.py
+++ b/tests/e2e/test_spyre_online.py
@@ -87,9 +87,11 @@ def test_openai_serving_gptq(remote_openai_server, model, backend,
                          [pytest.param(1, marks=pytest.mark.cb, id="cb")])
 @pytest.mark.parametrize("max_num_seqs", [2],
                          ids=lambda val: f"max_num_seqs({val})")
+@pytest.mark.parametrize("max_model_len", [256],
+                         ids=lambda val: f"max_model_len({val})")
 @pytest.mark.parametrize("backend", get_spyre_backend_list())
 def test_openai_serving_cb(remote_openai_server, model, backend, cb,
-                           max_num_seqs):
+                           max_num_seqs, max_model_len):
     """Test online serving with CB using the `vllm serve` CLI"""
 
     client = remote_openai_server.get_client()


### PR DESCRIPTION
# Description

We have to override max-model-len since long contexts aren't supported yet