### PR TITLE
[docs] Add install from PyPI to docs

### DIFF
--- a/.github/workflows/lint_docs.yml
+++ b/.github/workflows/lint_docs.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --only-group lint
       - name: Lint docs
-        run: tools/lint_docs.sh
+        run: pymarkdownlnt scan docs -r

--- a/.github/workflows/lint_docs.yml
+++ b/.github/workflows/lint_docs.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --only-group lint
       - name: Lint docs
-        run: pymarkdownlnt scan docs -r
+        run: tools/lint_docs.sh

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -18,6 +18,7 @@ nav:
     - Developer Guide:
       - Contributing: contributing/README.md
       - Continuous Batching:
+        - Overview: contributing/continuous_batching/overview.md
         - Tests:
           - Output Tests: contributing/continuous_batching/tests/output_tests.md
           - Scheduler Steps Tests: contributing/continuous_batching/tests/scheduler_steps_tests.md
@@ -37,6 +38,7 @@ nav:
   - Developer Guide:
     - Contributing: contributing/README.md
     - Continuous Batching:
+      - Overview: contributing/continuous_batching/overview.md
       - Tests:
         - Output Tests: contributing/continuous_batching/tests/output_tests.md
         - Scheduler Steps Tests: contributing/continuous_batching/tests/scheduler_steps_tests.md

--- a/docs/contributing/continuous_batching/overview.md
+++ b/docs/contributing/continuous_batching/overview.md
@@ -7,9 +7,10 @@ Brief overview of what has been implemented so far in VLLM to test / debug conti
 * **File paths:**
     * `examples/offline_inference/cb_spyre_inference.py`
     * `examples/offline_inference/long_context.py`
-* **Purpose:** Debugging (ie. using manual execution)
+* **Purpose:** Debugging (i.e. using manual execution)
 
 ### Description
+
 * Runs inference on a set of prompts with continuous batching enabled (number of prompts is parametrizable)
 * Prints the generated text for each sequence.
 * All the requested sequences are defined in the beginning, there is no requests joining the waiting queue while the decoding of some other request has already started.
@@ -17,6 +18,7 @@ Brief overview of what has been implemented so far in VLLM to test / debug conti
 * If `--compare-with-CPU` is set, then the output text is compared to the one of hugging face, running on CPU. Note that here the logprobs are not compared, only tokens.
 
 ### Parametrization
+
 For `cb_spyre_inference.py`
 
 * `--model`: the model

--- a/docs/contributing/continuous_batching/overview.md
+++ b/docs/contributing/continuous_batching/overview.md
@@ -51,6 +51,7 @@ For `long_context.py`: the same parameters, but with some differences:
     * Other Tests: various files including `vllm-spyre/tests/e2e/test_spyre_cb.py`
 
 <!-- markdownlint-disable MD031 MD046 -->
+
 ### Usage (when running locally)
 
 #### Commands

--- a/docs/contributing/continuous_batching/overview.md
+++ b/docs/contributing/continuous_batching/overview.md
@@ -1,0 +1,121 @@
+# Continuous Batching tests / inference scripts in vLLM
+
+Brief overview of what has been implemented so far in VLLM to test / debug continuous batching
+
+## Inference script
+
+* **File paths:**
+    * `examples/offline_inference/cb_spyre_inference.py`
+    * `examples/offline_inference/long_context.py`
+* **Purpose:** Debugging (ie. using manual execution)
+
+### Description
+* Runs inference on a set of prompts with continuous batching enabled (number of prompts is parametrizable)
+* Prints the generated text for each sequence.
+* All the requested sequences are defined in the beginning, there is no requests joining the waiting queue while the decoding of some other request has already started.
+* The exact sequence of prefill and decode steps depends on the parameter values `max_num_seqs`, `num-prompts`, `max-tokens`.
+* If `--compare-with-CPU` is set, then the output text is compared to the one of hugging face, running on CPU. Note that here the logprobs are not compared, only tokens.
+
+### Parametrization
+For `cb_spyre_inference.py`
+
+* `--model`: the model
+* `--max_model_len`: maximum length of a sequence (padded prompt plus decoded tokens) (cannot exceed model size)
+* `--max_num_seqs`: Max number of sequences processed in a single iteration (decode batch size)
+* `--tp`: Tensor parallelism (number of Spyre cards)
+* `--num-prompts`: Total number of requested prompts
+* `--max-tokens`: Number of tokens generated for each requested sequence
+* `--compare-with-CPU`: If set, compare the text output with CPU version running with Hugging Face instead of vLLM
+
+For `long_context.py`: the same parameters, but with some differences:
+
+* `--max_prompt_len`: max lengths of prompts (prompts will have length up to `max_prompt_len`)
+* doesn't allow to specify `--max-tokens`: number of tokens set automatically given `max_model_len` and prompts lengths
+
+## CB tests through unit tests
+
+!!! abstract "In Short"
+    See the detailed description of the individual unit tests for continuous batching in their respective files directly.
+
+    * [Output Tests](tests/output_tests.md): Check the correctness of end output logits/tokens of sequences ran with continuous batching enabled
+    * [Scheduler Steps Tests](tests/scheduler_steps_tests.md): Check the correctness of the step-by-step execution of continuous batching for different scenarios of prompt lengths and requested tokens
+    * [Other Tests](tests/other_tests.md): Other tests verifying the various behaviours of vLLM, when running with continuous batching enabled
+
+* **Purpose:** Automated execution to verify that a specific behaviour acts as expected (passing/failing)
+
+* **Files paths:**
+    * Output Tests: `vllm-spyre/tests/e2e/test_spyre_basic.py`
+    * Scheduler Steps Tests: `vllm-spyre/tests/e2e/test_spyre_cb_scheduler_steps.py`
+    * Other Tests: various files including `vllm-spyre/tests/e2e/test_spyre_cb.py`
+
+<!-- markdownlint-disable MD031 MD046 -->
+### Usage (when running locally)
+
+#### Commands
+
+    # Runs all the tests
+    python -m pytest -svx -m "spyre and cb" --forked tests
+    
+    # Runs specific test file
+    python -m pytest -svx -m "spyre and cb" --forked tests/e2e/test_spyre_cb_scheduler_steps.py
+    
+    # Runs specific test function
+    python -m pytest -svx -m "spyre and cb" --forked tests/e2e/test_spyre_basic.py::test_output
+
+<!-- markdownlint-enable MD031 MD046 -->
+
+#### Parameters description
+* `-x` option: stops the execution as soon as a test fails
+* `-s` option: show all the print statements in the code
+* `-v` option: verbose mode, make the test output more detailed: show name of each test function and whether it passed, failed or was skipped
+* `--forked` option: isolates the tests and avoid having one test crashing impacting the other tests
+* `-m "spyre and cb"`: runs the tests with configurations marked as "spyre" and "cb" only
+
+!!! tip
+    To run a test with a different model than the default `ibm-ai-platform/micro-g3.3-8b-instruct-1b`, you can run the test with `VLLM_SPYRE_TEST_MODEL_LIST` environment variable set to the target model, for example:
+    ```bash
+    VLLM_SPYRE_TEST_MODEL_LIST='tiny-granite-3.2-8b' python -m pytest -svx -m "spyre and cb" --forked tests/e2e/test_spyre_cb.py
+    ```
+
+### Description
+
+Unit tests are designed for automated and systematic execution to verify that CB behaves as expected for different scenarios. For each scenario (i.e. configuration of parameters), the test either passes or fails. When a test suite fails, identifying which specific test case failed is often more informative than the failure message itself. Below is a brief description of the different unit tests targeting CB. The description can also be found in the docstring of the different test functions:
+
+!!! caution
+    When adding new parametrization to a test, the parameters are typically combinatorial and number of executed tests can increase really fast. For example the following test function will run 2 x 2 = 4 different scenarios in total:
+    ```python
+    @pytest.mark.parametrize("model", ["micro-g3.3-8b-instruct-1b", "granite-3.3-8b-instruct"])
+    @pytest.mark.parametrize("max_tokens", [[10, 20], [60, 78]])
+    def test_function(model: str, max_tokens: list[int]):
+       ...
+    ```
+
+#### Output Tests
+
+See [Output Tests](tests/output_tests.md)
+
+Output tests checks the correctness of the output of CB on a set of prompts. For now, the number of prompts and the prompts themself are hardcoded, as well as the max requested tokens per prompt (constant and set to 20). The output from vllm is compared to this of Hugging Face on CPU.
+
+!!! note inline end
+    This applies for sendnn backend, on CPU the tokens need to additionally be exactly the same for the test to pass
+* The test passes if: the logprobs of HF on CPU and vLLM (on Spyre or CPU depending on the backend) are compared, and the test passes only if the pairwise relative differences of the values are all below a threshold: `math.isclose(hf_logprob, vllm_logprob, rel_tol=0.35)`. Otherwise it fails. There is no logic that takes into account the fact that the tokens might becomes different at some point, making the logits diverging.
+
+#### Scheduler Steps Tests
+
+See [Scheduler Steps Tests](tests/scheduler_steps_tests.md)
+
+!!! Question
+    For these tests, the final output is not checked, only the step-by-step execution correctness. Would it make sense to have output validation though?
+
+Checking the final output correctness alone is not enough to ensure that CB is correctly implemented (otherwise how can we differentiate with static batching for example). So the scheduler steps tests are meant to check the correctness of the step-by-step execution of continuous batching. It does so by comparing, at every engine step (i.e. prefill or decode iteration), a bunch of attributes. This is allows a finer testing of the padding and scheduling implementation.
+
+* **Checked attributes at each step:**
+    * `tkv`: after each step, the tkv is compared against the expected tkv value for that step
+    * `waiting`, `running`, `request_outputs`, `finished_requests` not really relevant in a compiler point of view, but after each iteration, we check that the list of running and waiting requests and those that have finished are correct. this tests the scheduler correctness.
+    * (waiting to be merged, PR #261): `n_reserved_blocks` and `n_used_blocks`
+
+#### Other Tests
+
+See [Other Tests](tests/other_tests.md)
+
+Most of the other tests primarily verify the correctness of various vLLM Spyre's plugin behaviors, such as launching the online server or enforcing scheduler constraints. While they don't always directly target the correctness of continuous batching, they ensure that the system functions as expected when continuous batching is enabled.

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -8,7 +8,7 @@ dependency resolution which is required to properly install dependencies like
 ## Install `uv` (Pre-requisite)
 
 You can [install `uv`](https://docs.astral.sh/uv/guides/install-python/) using `pip`:
-  
+
 ```sh
 pip install uv
 ```
@@ -16,7 +16,7 @@ pip install uv
 ## Create a Python Virtual Environment
 
 Now create and activate a new Python (3.12) [virtual environment](https://docs.astral.sh/uv/pip/environments/):
-  
+
 ```sh
 uv venv --python 3.12 --seed .venv
 source .venv/bin/activate
@@ -65,7 +65,6 @@ or you can install from source by cloning the [vllm-Spyre](https://github.com/vl
     
     !!! tip
         The `dev` group (i.e. `--group dev`) is enabled by default.
-
 
 ## Install PyTorch
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -29,8 +29,9 @@ packages is not required for GPU-only installations.
 
 ## Install vLLM with the vLLM-Spyre Plugin
 
-You can either install a released version of the vllm-Spyre plugin directly from [PyPI](https://pypi.org/project/vllm-spyre/)
-or you can install from source by cloning the [vllm-Spyre](https://github.com/vllm-project/vllm-spyre) repo from GitHub.
+You can either install a released version of the vllm-Spyre plugin directly from
+[PyPI](https://pypi.org/project/vllm-spyre/) or you can install from source by
+cloning the [vllm-Spyre](https://github.com/vllm-project/vllm-spyre) repo from GitHub.
 
 === "Release (PyPI)"
 
@@ -73,10 +74,11 @@ or you can install from source by cloning the [vllm-Spyre](https://github.com/vl
 
 ## Install PyTorch
 
-Finally, `torch` is needed to run examples and tests. If it is not already installed, install it using `pip`:
+Finally, `torch` is needed to run examples and tests. If it is not already installed,
+install it using `pip`:
 
 ```sh
-pip install torch==2.7.0
+pip install torch==2.7.1
 ```
 
 ## Trouble-Shooting
@@ -113,7 +115,7 @@ the (correct) Python Virtual Environment:
 RuntimeError: Device string must not be empty
 ```
 
-### No module named 'torch'
+### No module named `torch`
 
 You may have installed PyTorch into the system-wide Python environment but may
 have missed to install it into the virtual environment for vLLM-Spyre:

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -25,7 +25,7 @@ source .venv/bin/activate
 Since the full `torch_sendnn` stack is only available pre-installed in a base
 environment, we need to add the `--system-site-packages` to the new virtual
 environment to fully support the Spyre hardware. Pulling in the system site
-packages is not required for GPU-only installations.
+packages is not required for CPU-only installations.
 
 ## Install vLLM with the vLLM-Spyre Plugin
 
@@ -75,11 +75,24 @@ cloning the [vllm-Spyre](https://github.com/vllm-project/vllm-spyre) repo from G
 ## Install PyTorch
 
 Finally, `torch` is needed to run examples and tests. If it is not already installed,
-install it using `pip`:
+install it using `pip`.
 
-```sh
-pip install torch==2.7.1
-```
+Note, on Linux the `+cpu` package should be installed, since we don't need any of
+the `cuda` dependencies that are included by default on linux installs. This requires
+`--index-url https://download.pytorch.org/whl/cpu` on linux. On Windows and macOS
+the cpu package is the default one.
+
+=== "Linux"
+
+    ```sh
+    pip install torch=="2.7.1+cpu" --index-url "https://download.pytorch.org/whl/cpu"
+    ```
+
+=== "Windows/macOS"
+
+    ```sh
+    pip install torch=="2.7.1"
+    ```
 
 ## Trouble-Shooting
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -34,7 +34,6 @@ or you can install from source by cloning the [vllm-Spyre](https://github.com/vl
 
 === "Release (PyPI)"
 
-<!-- pyml disable-next-line code-block-style -->
     Note, to avoid any dependency resolution errors, we will install PyTorch
     separately and tell `uv` to ignore any of it's dependencies while installing
     the `vllm-spyre` plugin.
@@ -50,7 +49,6 @@ or you can install from source by cloning the [vllm-Spyre](https://github.com/vl
 
 === "Source (GitHub)"
 
-<!-- pyml disable-next-line code-block-style -->
     First, clone the `vllm-spyre` repo:
     
     ```sh

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -32,13 +32,13 @@ or you can install from source by cloning the [vllm-Spyre](https://github.com/vl
     Note, to avoid any dependency resolution errors, we will install PyTorch
     separately and tell `uv` to ignore any of it's dependencies while installing
     the `vllm-spyre` plugin.
-
+    
     ```sh
     echo "torch; sys_platform == 'never'
     torchaudio; sys_platform == 'never'
     torchvision; sys_platform == 'never'
     triton; sys_platform == 'never'" > overrides.txt
-
+    
     uv pip install vllm-spyre --overrides overrides.txt
     ```
 
@@ -82,7 +82,7 @@ pip install torch==2.7.0
 If you happen to have followed the pre-`uv` installation instructions, you might
 encounter an error like this:
 
-```
+```sh
 LookupError: setuptools-scm was unable to detect version for /home/senuser/multi-aiu-dev/_dev/sentient-ci-cd/_dev/sen_latest/vllm-spyre.
       
     Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata and will not work.
@@ -97,19 +97,18 @@ Make sure the follow the latest installation steps outlined above.
 If you encounter any of the following errors, it's likely you forgot to activate
 the (correct) Python Virtual Environment:
 
-```
+```sh
   File "/home/senuser/.local/lib/python3.12/site-packages/vllm/config.py", line 2260, in __post_init__
     self.device = torch.device(self.device_type)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 RuntimeError: Device string must not be empty
 ```
 
-```
+```sh
   File "/home/senuser/multi-aiu-dev/_dev/sentient-ci-cd/_dev/sen_latest/vllm-spyre/.venv/lib64/python3.12/site-packages/vllm/env_override.py", line 4, in <module>
     import torch
 ModuleNotFoundError: No module named 'torch'
 ```
-
 
 ### No module named 'torch'
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -128,7 +128,7 @@ ModuleNotFoundError: No module named 'torch'
 
 Make sure to activate the same virtual environment for installing `torch` that
 was used to install `vllm-spyre`. If you already have a system-wide `torch`
-installation and want to "re-use" that for your `vllm-spyre` environment, you can
+installation and want to reuse that for your `vllm-spyre` environment, you can
 create a new virtual environment and add the `--system-site-packages` flag to
 pull in the `torch` dependencies from the base Python environment:
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -5,7 +5,7 @@ installation of the plugin and its dependencies. `uv` provides advanced
 dependency resolution which is required to properly install dependencies like
 `vllm` without overwriting critical dependencies like `torch`.
 
-## Install `uv` (Pre-requisite)
+## Install `uv`
 
 You can [install `uv`](https://docs.astral.sh/uv/guides/install-python/) using `pip`:
 
@@ -22,23 +22,23 @@ uv venv --python 3.12 --seed .venv --system-site-packages
 source .venv/bin/activate
 ```
 
-Since the full `torch_sendnn` stack is only available pre-installed in a base
-environment, we need to add the `--system-site-packages` to the new virtual
-environment to fully support the Spyre hardware. Pulling in the system site
-packages is not required for CPU-only installations.
+??? question "Why do I want the `--system-site-packages`?"
+    Because the full `torch_sendnn` stack is only available pre-installed in a
+    base environment, we need to add the `--system-site-packages` to the new
+    virtual environment in order to fully support the Spyre hardware.
+
+    **Note**, pulling in the system site packages is not required for CPU-only
+    installations.
 
 ## Install vLLM with the vLLM-Spyre Plugin
 
-You can either install a released version of the vllm-Spyre plugin directly from
+You can either install a released version of the vLLM-Spyre plugin directly from
 [PyPI](https://pypi.org/project/vllm-spyre/) or you can install from source by
-cloning the [vllm-Spyre](https://github.com/vllm-project/vllm-spyre) repo from GitHub.
+cloning the [vLLM-Spyre](https://github.com/vllm-project/vllm-spyre) repo from
+GitHub.
 
 === "Release (PyPI)"
 
-    Note, to avoid any dependency resolution errors, we will install PyTorch
-    separately and tell `uv` to ignore any of it's dependencies while installing
-    the `vllm-spyre` plugin.
-    
     ```sh
     echo "torch; sys_platform == 'never'
     torchaudio; sys_platform == 'never'
@@ -47,6 +47,11 @@ cloning the [vllm-Spyre](https://github.com/vllm-project/vllm-spyre) repo from G
     
     uv pip install vllm-spyre --overrides overrides.txt
     ```
+
+    ??? question "Why do I need the `--overrides`?"
+        To avoid dependency resolution errors, we need to install `torch`
+        separately and tell `uv` to ignore any of it's dependencies while
+        installing the `vllm-spyre` plugin.
 
 === "Source (GitHub)"
 
@@ -77,11 +82,6 @@ cloning the [vllm-Spyre](https://github.com/vllm-project/vllm-spyre) repo from G
 Finally, `torch` is needed to run examples and tests. If it is not already installed,
 install it using `pip`.
 
-Note that on Linux the `+cpu` package should be installed, since we don't need any of
-the `cuda` dependencies that are included by default for Linux installs. This requires
-`--index-url https://download.pytorch.org/whl/cpu` on Linux. On Windows and macOS
-the CPU package is the default one.
-
 === "Linux"
 
     ```sh
@@ -94,7 +94,13 @@ the CPU package is the default one.
     pip install torch=="2.7.1"
     ```
 
-## Trouble-Shooting
+!!! note
+    On Linux the `+cpu` package should be installed, since we don't need any of
+    the `cuda` dependencies which are included by default for Linux installs.
+    This requires `--index-url https://download.pytorch.org/whl/cpu` on Linux.
+    On Windows and macOS the CPU package is the default one.
+
+## Troubleshooting
 
 As the installation process is evolving over time, you may have arrived here after
 following outdated installation steps. If you encountered any of the errors below,
@@ -130,8 +136,8 @@ RuntimeError: Device string must not be empty
 
 ### No module named `torch`
 
-You may have installed PyTorch into the system-wide Python environment but may
-have missed to install it into the virtual environment for vLLM-Spyre:
+You may have installed PyTorch into the system-wide Python environment, not into
+the virtual environment used for vLLM-Spyre:
 
 ```sh
   File "/home/senuser/multi-aiu-dev/_dev/sentient-ci-cd/_dev/sen_latest/vllm-spyre/.venv/lib64/python3.12/site-packages/vllm/env_override.py", line 4, in <module>
@@ -151,8 +157,8 @@ uv venv --python 3.12 --seed .venv --system-site-packages
 source .venv/bin/activate
 ```
 
-If you forget to override the torch dependencies when installing a released version
-from PyPI, you will likely see a dependency resolution error like this:
+If you forget to override the `torch` dependencies when installing a released
+version from PyPI, you will likely see a dependency resolution error like this:
 
 ```sh
 $ uv pip install vllm-spyre
@@ -184,11 +190,11 @@ Resolved 155 packages in 45ms
 ```
 
 To avoid this error, make sure to include the dependency `--overrides` as described
-in the installation from a release (PyPI) section above.
+in the installation from a [Release (PyPI)](#release-pypi) section.
 
 ### No solution found when resolving dependencies
 
-If you forget to override the torch dependencies when installing from PyPI you
+If you forget to override the `torch` dependencies when installing from PyPI you
 will likely see a dependency resolution error like this:
 
 ```sh
@@ -222,4 +228,4 @@ $ uv pip install vllm-spyre==0.4.1
 ```
 
 To avoid this error, make sure to include the dependency `--overrides` as described
-in the installation from source section above.
+in the installation from a [Release (PyPI)](#release-pypi) section.

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -68,7 +68,7 @@ or you can install from source by cloning the [vllm-Spyre](https://github.com/vl
 
 ## Install PyTorch
 
-Finally, the `torch` is needed to run examples and tests. If it is not already installed, install it using `pip`:
+Finally, `torch` is needed to run examples and tests. If it is not already installed, install it using `pip`:
 
 ```sh
 pip install torch==2.7.0

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -18,9 +18,14 @@ pip install uv
 Now create and activate a new Python (3.12) [virtual environment](https://docs.astral.sh/uv/pip/environments/):
 
 ```sh
-uv venv --python 3.12 --seed .venv
+uv venv --python 3.12 --seed .venv --system-site-packages
 source .venv/bin/activate
 ```
+
+Since the full `torch_sendnn` stack is only available pre-installed in a base
+environment, we need to add the `--system-site-packages` to the new virtual
+environment to fully support the Spyre hardware. Pulling in the system site
+packages is not required for GPU-only installations.
 
 ## Install vLLM with the vLLM-Spyre Plugin
 
@@ -78,6 +83,11 @@ pip install torch==2.7.0
 
 ## Trouble-Shooting
 
+As the installation process is evolving over time, you may have arrived here after
+following outdated installation steps. If you encountered any of the errors below,
+it may be easiest to start over with a new Python virtual environment (`.venv`)
+as outlined above.
+
 ### Installation using `pip` (instead of `uv`)
 
 If you happen to have followed the pre-`uv` installation instructions, you might
@@ -105,16 +115,31 @@ the (correct) Python Virtual Environment:
 RuntimeError: Device string must not be empty
 ```
 
+### No module named 'torch'
+
+You may have installed PyTorch into the system-wide Python environment but may
+have missed to install it into the virtual environment for vLLM-Spyre:
+
 ```sh
   File "/home/senuser/multi-aiu-dev/_dev/sentient-ci-cd/_dev/sen_latest/vllm-spyre/.venv/lib64/python3.12/site-packages/vllm/env_override.py", line 4, in <module>
     import torch
 ModuleNotFoundError: No module named 'torch'
 ```
 
-### No module named 'torch'
+Make sure to activate the same virtual environment for installing `torch` that
+was used to install `vllm-spyre`. If you already have a system-wide `torch`
+installation and want to "re-use" that for your `vllm-spyre` environment, you can
+create a new virtual environment and add the `--system-site-packages` flag to
+pull in the `torch` dependencies from the base Python environment:
 
-If you forget to override the torch dependencies when installing from PyPI you
-will likely see a dependency resolution error like this:
+```sh
+rm -rf .venv
+uv venv --python 3.12 --seed .venv --system-site-packages
+source .venv/bin/activate
+```
+
+If you forget to override the torch dependencies when installing a released version
+from PyPI, you will likely see a dependency resolution error like this:
 
 ```sh
 $ uv pip install vllm-spyre
@@ -145,8 +170,8 @@ Resolved 155 packages in 45ms
   help: `xformers` (v0.0.28.post1) was included because `vllm-spyre` (v0.1.0) depends on `vllm` (v0.2.5) which depends on `xformers`
 ```
 
-To avoid this error, make sure to include the dependency overrides as described
-in the installation from source section above.
+To avoid this error, make sure to include the dependency `--overrides` as described
+in the installation from a release (PyPI) section above.
 
 ### No solution found when resolving dependencies
 
@@ -183,5 +208,5 @@ $ uv pip install vllm-spyre==0.4.1
       and you require vllm-spyre==0.4.1, we can conclude that your requirements are unsatisfiable.
 ```
 
-To avoid this error, make sure to include the dependency overrides as described
+To avoid this error, make sure to include the dependency `--overrides` as described
 in the installation from source section above.

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -29,6 +29,7 @@ or you can install from source by cloning the [vllm-Spyre](https://github.com/vl
 
 === "Release (PyPI)"
 
+<!-- pyml disable-next-line code-block-style -->
     Note, to avoid any dependency resolution errors, we will install PyTorch
     separately and tell `uv` to ignore any of it's dependencies while installing
     the `vllm-spyre` plugin.
@@ -44,6 +45,7 @@ or you can install from source by cloning the [vllm-Spyre](https://github.com/vl
 
 === "Source (GitHub)"
 
+<!-- pyml disable-next-line code-block-style -->
     First, clone the `vllm-spyre` repo:
     
     ```sh

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -5,43 +5,183 @@ installation of the plugin and its dependencies. `uv` provides advanced
 dependency resolution which is required to properly install dependencies like
 `vllm` without overwriting critical dependencies like `torch`.
 
-First, clone the `vllm-spyre` repo:
+## Install `uv` (Pre-requisite)
 
-```sh
-git clone https://github.com/vllm-project/vllm-spyre.git
-cd vllm-spyre
-```
-
-Then, install `uv`:
+You can [install `uv`](https://docs.astral.sh/uv/guides/install-python/) using `pip`:
   
 ```sh
 pip install uv
 ```
 
-Now, create and activate a new [venv](https://docs.astral.sh/uv/pip/environments/):
+## Create a Python Virtual Environment
+
+Now create and activate a new Python (3.12) [virtual environment](https://docs.astral.sh/uv/pip/environments/):
   
 ```sh
 uv venv --python 3.12 --seed .venv
 source .venv/bin/activate
 ```
 
-To install `vllm-spyre` locally with development dependencies, use the following command:
+## Install vLLM with the vLLM-Spyre Plugin
 
-```sh
-uv sync --frozen --active --inexact
-```
+You can either install a released version of the vllm-Spyre plugin directly from [PyPI](https://pypi.org/project/vllm-spyre/)
+or you can install from source by cloning the [vllm-Spyre](https://github.com/vllm-project/vllm-spyre) repo from GitHub.
 
-To include optional linting dependencies, include `--group lint`:
+=== "Release (PyPI)"
 
-```sh
-uv sync --frozen --active --inexact --group lint
-```
+    Note, to avoid any dependency resolution errors, we will install PyTorch
+    separately and tell `uv` to ignore any of it's dependencies while installing
+    the `vllm-spyre` plugin.
 
-!!! tip
-    The `dev` group (i.e. `--group dev`) is enabled by default.
+    ```sh
+    echo "torch; sys_platform == 'never'
+    torchaudio; sys_platform == 'never'
+    torchvision; sys_platform == 'never'
+    triton; sys_platform == 'never'" > overrides.txt
+
+    uv pip install vllm-spyre --overrides overrides.txt
+    ```
+
+=== "Source (GitHub)"
+
+    First, clone the `vllm-spyre` repo:
+    
+    ```sh
+    git clone https://github.com/vllm-project/vllm-spyre.git
+    cd vllm-spyre
+    ```
+    
+    To install `vllm-spyre` locally with development dependencies, use the following command:
+    
+    ```sh
+    uv sync --frozen --active --inexact
+    ```
+    
+    To include optional linting dependencies, include `--group lint`:
+    
+    ```sh
+    uv sync --frozen --active --inexact --group lint
+    ```
+    
+    !!! tip
+        The `dev` group (i.e. `--group dev`) is enabled by default.
+
+
+## Install PyTorch
 
 Finally, the `torch` is needed to run examples and tests. If it is not already installed, install it using `pip`:
 
 ```sh
 pip install torch==2.7.0
 ```
+
+## Trouble-Shooting
+
+### Installation using `pip` (instead of `uv`)
+
+If you happen to have followed the pre-`uv` installation instructions, you might
+encounter an error like this:
+
+```
+LookupError: setuptools-scm was unable to detect version for /home/senuser/multi-aiu-dev/_dev/sentient-ci-cd/_dev/sen_latest/vllm-spyre.
+      
+    Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata and will not work.
+      
+    For example, if you're using pip, instead of https://github.com/user/proj/archive/master.zip use git+https://github.com/user/proj.git#egg=proj
+```
+
+Make sure the follow the latest installation steps outlined above.
+
+### Failed to activate the Virtual Environment
+
+If you encounter any of the following errors, it's likely you forgot to activate
+the (correct) Python Virtual Environment:
+
+```
+  File "/home/senuser/.local/lib/python3.12/site-packages/vllm/config.py", line 2260, in __post_init__
+    self.device = torch.device(self.device_type)
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+RuntimeError: Device string must not be empty
+```
+
+```
+  File "/home/senuser/multi-aiu-dev/_dev/sentient-ci-cd/_dev/sen_latest/vllm-spyre/.venv/lib64/python3.12/site-packages/vllm/env_override.py", line 4, in <module>
+    import torch
+ModuleNotFoundError: No module named 'torch'
+```
+
+
+### No module named 'torch'
+
+If you forget to override the torch dependencies when installing from PyPI you
+will likely see a dependency resolution error like this:
+
+```sh
+$ uv pip install vllm-spyre
+
+Using Python 3.12.11 environment at: .venv3
+Resolved 155 packages in 45ms
+  × Failed to build `xformers==0.0.28.post1`
+  ├─▶ The build backend returned an error
+  ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
+
+      [stderr]
+      Traceback (most recent call last):
+        File "<string>", line 14, in <module>
+        File "~.cache/uv/builds-v0/.tmpo0aEXS/lib/python3.12/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
+          return self._get_build_requires(config_settings, requirements=[])
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        File "~.cache/uv/builds-v0/.tmpo0aEXS/lib/python3.12/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
+          self.run_setup()
+        File "~.cache/uv/builds-v0/.tmpo0aEXS/lib/python3.12/site-packages/setuptools/build_meta.py", line 512, in run_setup
+          super().run_setup(setup_script=setup_script)
+        File "~.cache/uv/builds-v0/.tmpo0aEXS/lib/python3.12/site-packages/setuptools/build_meta.py", line 317, in run_setup
+          exec(code, locals())
+        File "<string>", line 24, in <module>
+      ModuleNotFoundError: No module named 'torch'
+
+      hint: This error likely indicates that `xformers@0.0.28.post1` depends on `torch`, but doesn't declare it as a build dependency. If `xformers` is a first-party package, consider adding
+      `torch` to its `build-system.requires`. Otherwise, `uv pip install torch` into the environment and re-run with `--no-build-isolation`.
+  help: `xformers` (v0.0.28.post1) was included because `vllm-spyre` (v0.1.0) depends on `vllm` (v0.2.5) which depends on `xformers`
+```
+
+To avoid this error, make sure to include the dependency overrides as described
+in the installation from source section above.
+
+### No solution found when resolving dependencies
+
+If you forget to override the torch dependencies when installing from PyPI you
+will likely see a dependency resolution error like this:
+
+```sh
+$ uv pip install vllm-spyre==0.4.1
+  ...
+  × No solution found when resolving dependencies:
+  ╰─▶ Because fms-model-optimizer==0.2.0 depends on torch>=2.1,<2.5 and only the following versions of fms-model-optimizer are available:
+          fms-model-optimizer<=0.2.0
+          fms-model-optimizer==0.3.0
+      we can conclude that fms-model-optimizer<0.3.0 depends on torch>=2.1,<2.5.
+      And because fms-model-optimizer==0.3.0 depends on torch>=2.2.0,<2.6 and all of:
+          vllm>=0.9.0,<=0.9.0.1
+          vllm>=0.9.2
+      depend on torch==2.7.0, we can conclude that all versions of fms-model-optimizer and all of:
+          vllm>=0.9.0,<=0.9.0.1
+          vllm>=0.9.2
+       are incompatible.
+      And because only the following versions of vllm are available:
+          vllm<=0.9.0
+          vllm==0.9.0.1
+          vllm==0.9.1
+          vllm==0.9.2
+      and vllm-spyre==0.4.1 depends on fms-model-optimizer, we can conclude that all of:
+          vllm>=0.9.0,<0.9.1
+          vllm>0.9.1
+       and vllm-spyre==0.4.1 are incompatible.
+      And because vllm-spyre==0.4.1 depends on one of:
+          vllm>=0.9.0,<0.9.1
+          vllm>0.9.1
+      and you require vllm-spyre==0.4.1, we can conclude that your requirements are unsatisfiable.
+```
+
+To avoid this error, make sure to include the dependency overrides as described
+in the installation from source section above.

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -77,10 +77,10 @@ cloning the [vllm-Spyre](https://github.com/vllm-project/vllm-spyre) repo from G
 Finally, `torch` is needed to run examples and tests. If it is not already installed,
 install it using `pip`.
 
-Note, on Linux the `+cpu` package should be installed, since we don't need any of
-the `cuda` dependencies that are included by default on linux installs. This requires
-`--index-url https://download.pytorch.org/whl/cpu` on linux. On Windows and macOS
-the cpu package is the default one.
+Note that on Linux the `+cpu` package should be installed, since we don't need any of
+the `cuda` dependencies that are included by default for Linux installs. This requires
+`--index-url https://download.pytorch.org/whl/cpu` on Linux. On Windows and macOS
+the CPU package is the default one.
 
 === "Linux"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,8 +136,8 @@ markers = [
 
 [tool.pymarkdown]
 plugins.md013.enabled = false # line-length
-plugins.md033.enabled = false # inline-html
 plugins.md041.enabled = false # first-line-h1
+plugins.md033.enabled = false # inline-html
 plugins.md024.allow_different_nesting = true # no-duplicate-headers
 plugins.md007.enabled = true
 plugins.md007.indent = 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,6 @@ markers = [
 plugins.md013.enabled = false # line-length
 plugins.md033.enabled = false # inline-html
 plugins.md041.enabled = false # first-line-h1
-plugins.md046.enabled = false # code-block-style
 plugins.md024.allow_different_nesting = true # no-duplicate-headers
 plugins.md007.enabled = true
 plugins.md007.indent = 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,8 +136,9 @@ markers = [
 
 [tool.pymarkdown]
 plugins.md013.enabled = false # line-length
-plugins.md041.enabled = false # first-line-h1
 plugins.md033.enabled = false # inline-html
+plugins.md041.enabled = false # first-line-h1
+plugins.md046.enabled = false # code-block-style
 plugins.md024.allow_different_nesting = true # no-duplicate-headers
 plugins.md007.enabled = true
 plugins.md007.indent = 4


### PR DESCRIPTION
Update the install docs to include install from PyPI

https://vllm-spyre--327.org.readthedocs.build/en/327/getting_started/installation.html#install-vllm-with-the-vllm-spyre-plugin

<img width="718" height="421" alt="image" src="https://github.com/user-attachments/assets/048d220d-c97c-42be-9880-dabeb7108653" />


