### PR TITLE
:arrow_up: bump base image

### DIFF
--- a/docker/Dockerfile.amd64
+++ b/docker/Dockerfile.amd64
@@ -1,6 +1,6 @@
 # This is a reference dockerfile for vLLM Spyre support on an x86 host
 ARG BASE_IMAGE_URL="quay.io/ibm-aiu/spyre-base"
-ARG BASE_IMAGE_TAG="2025_06_23-amd64"
+ARG BASE_IMAGE_TAG="2025_07_18-amd64"
 
 ##############################################
 # Base


### PR DESCRIPTION
# Description

This PR sets the base image to the latest spyre-base drop that now supports compiling models for continuous batching at batch sizes other than 2
