### PR TITLE
♻️ Compatibility with vllm main

### DIFF
--- a/vllm_spyre/core/scheduler.py
+++ b/vllm_spyre/core/scheduler.py
@@ -1267,7 +1267,6 @@ class SpyreScheduler:
                     multi_modal_placeholders=(
                         seq_group.multi_modal_placeholders
                         if scheduler_outputs.num_prefill_groups > 0 else None),
-                    prompt_adapter_request=seq_group.prompt_adapter_request,
                 )
             else:
                 # When SPMD mode is enabled, we only send delta data except for

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -35,6 +35,7 @@ else:
 from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, ModelRunnerOutput
 
 #############################################################
+# from vllm.tasks import GenerationTask, PoolingTask, SupportedTask
 # TODO: remove when we have this in vllm/tasks.py
 #############################################################
 GenerationTask = Literal["generate", "transcription"]

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -76,7 +76,6 @@ class SpyreModelRunner:
         self.scheduler_config = vllm_config.scheduler_config
         self.device_config = vllm_config.device_config
         self.speculative_config = vllm_config.speculative_config
-        self.prompt_adapter_config = vllm_config.prompt_adapter_config
         self.observability_config = vllm_config.observability_config
 
         self.pad_token_id = 0

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -10,7 +10,6 @@ from torch import nn
 from vllm.config import DeviceConfig, VllmConfig
 from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
-from vllm.model_executor.models.interfaces_base import is_text_generation_model
 from vllm.sampling_params import SamplingType
 from vllm.utils import is_pin_memory_available
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec
@@ -387,20 +386,11 @@ class SpyreModelRunner:
         else:
             return self._prepare_decode(scheduler_output.scheduled_cached_reqs)
 
-    def get_supported_generation_tasks(self) -> list[GenerationTask]:
-        model = self.get_model()
-        supported_tasks = list[GenerationTask]()
-
-        if is_text_generation_model(model):
-            supported_tasks.append("generate")
-
-        return supported_tasks
-
     def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
         tasks = list[SupportedTask]()
 
-        if self.model_config.runner_type == "generate":
-            tasks.extend(self.get_supported_generation_tasks())
+        if "generate" in self.model_config.supported_tasks:
+            tasks.extend(["generate"])
 
         return tuple(tasks)
 

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -29,7 +29,8 @@ import vllm_spyre.perf_metrics as perf_metrics
 from vllm_spyre.model_executor.model_loader import spyre_setup
 from vllm_spyre.platform import SpyrePlatform
 from vllm_spyre.v1.worker.spyre_model_runner import (
-    ContinuousBatchingSpyreModelRunner, StaticBatchingSpyreModelRunner)
+    ContinuousBatchingSpyreModelRunner, StaticBatchingSpyreModelRunner,
+    SupportedTask)
 
 logger = init_logger(__name__)
 
@@ -615,6 +616,9 @@ class SpyreWorker(WorkerBaseV1):
     @property
     def kv_cache(self) -> Optional[list[list[torch.Tensor]]]:
         return None
+
+    def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
+        return self.model_runner.get_supported_tasks()
 
     @SpyrePlatform.inference_mode()
     def execute_model(

--- a/vllm_spyre/worker/spyre_embedding_model_runner.py
+++ b/vllm_spyre/worker/spyre_embedding_model_runner.py
@@ -42,11 +42,20 @@ class SpyreEmbeddingModelRunner(SpyreModelRunner):
                          is_driver_worker=is_driver_worker)
 
         pooler_config = model_config.pooler_config
-        self.pooler = Pooler.from_config_with_defaults(
-            pooler_config,
-            pooling_type=PoolingType.CLS,
-            normalize=True,
-            softmax=False)
+        if hasattr(Pooler, "from_config_with_defaults"):
+            # TODO: remove this when we no longer support
+            # vllm version v0.9.2
+            self.pooler = Pooler.from_config_with_defaults(
+                pooler_config,
+                pooling_type=PoolingType.CLS,
+                normalize=True,
+                softmax=False)
+        else:
+            self.pooler = Pooler.for_embed(
+                pooler_config=pooler_config,
+                default_pooling_type=PoolingType.CLS,
+                default_normalize=True,
+                default_softmax=False)
 
     def load_model(self, prompt_lens: Iterable[int],
                    num_decode_tokens: Iterable[int]) -> None:


### PR DESCRIPTION
# Changes

- Remove prompt adapter config
    - Based on upstream vllm changes in https://github.com/vllm-project/vllm/pull/20588
- Implement `get_supported_tasks` in model_runner for online API
    -  only needed for online API, related PR - https://github.com/vllm-project/vllm/pull/21585
    
    Implementation for online API:
    ```
    if envs.VLLM_USE_V1:
        supported_tasks = await engine_client \
            .get_supported_tasks()  # type: ignore
    else:
        supported_tasks = model_config.supported_tasks
    ```

## Related Issues

fix https://github.com/vllm-project/vllm-spyre/issues/336