### PR TITLE
♻️ fix vllm:main

### DIFF
--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -59,7 +59,7 @@ def is_v1_compatible(self) -> bool:
     if any(pat in arch for arch in architectures for pat in patterns):
         return True
     import vllm.model_executor.models as me_models
-    return me_models.ModelRegistry.is_v1_compatible(architectures)
+    return me_models.ModelRegistry.is_v1_compatible(architectures, self)
 
 
 class SpyrePlatform(Platform):

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -106,11 +106,8 @@ class SpyrePlatform(Platform):
         if scheduler_config.is_multi_step:
             raise NotImplementedError
 
-        is_decoder = model_config.task == "generate"
-        is_pooling = model_config.task == "embed"
-        if model_config.task == "auto":
-            is_pooling = "embed" in model_config.supported_tasks
-            is_decoder = "generate" in model_config.supported_tasks
+        is_pooling = "embed" in model_config.supported_tasks
+        is_decoder = "generate" in model_config.supported_tasks
 
         if is_decoder and not envs.VLLM_USE_V1:
             raise ValueError("Decoder models are only supported on v1")

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -1,3 +1,4 @@
+import inspect
 import sys
 
 # When running this plugin on a Mac, we assume it's for local development
@@ -13,7 +14,7 @@ if sys.platform.startswith("darwin"):
 import math
 import operator
 import os
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import torch
 from vllm.inputs import ProcessorInputs, PromptType
@@ -59,7 +60,12 @@ def is_v1_compatible(self) -> bool:
     if any(pat in arch for arch in architectures for pat in patterns):
         return True
     import vllm.model_executor.models as me_models
-    return me_models.ModelRegistry.is_v1_compatible(architectures, self)
+    extra_kwargs: dict[str, Any] = {}
+    extra_kwargs["architectures"] = architectures
+    if "model_config" in inspect.signature(
+            me_models.ModelRegistry.is_v1_compatible).parameters:
+        extra_kwargs["model_config"] = self
+    return me_models.ModelRegistry.is_v1_compatible(**extra_kwargs)
 
 
 class SpyrePlatform(Platform):

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -60,6 +60,8 @@ def is_v1_compatible(self) -> bool:
     if any(pat in arch for arch in architectures for pat in patterns):
         return True
     import vllm.model_executor.models as me_models
+
+    # Can be simplified after the model_config change from vllm:main
     extra_kwargs: dict[str, Any] = {}
     extra_kwargs["architectures"] = architectures
     if "model_config" in inspect.signature(
@@ -112,6 +114,7 @@ class SpyrePlatform(Platform):
         if scheduler_config.is_multi_step:
             raise NotImplementedError
 
+        # Can be simplified after the model_config change from vllm:main
         is_decoder = model_config.task == "generate" \
             if model_config.task \
                 else "generate" in model_config.supported_tasks

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -112,8 +112,13 @@ class SpyrePlatform(Platform):
         if scheduler_config.is_multi_step:
             raise NotImplementedError
 
-        is_pooling = "embed" in model_config.supported_tasks
-        is_decoder = "generate" in model_config.supported_tasks
+        is_decoder = model_config.task == "generate" \
+            if model_config.task \
+                else "generate" in model_config.supported_tasks
+
+        is_pooling = model_config.task == "embed" \
+            if model_config.task \
+        else "embed" in model_config.supported_tasks
 
         if is_decoder and not envs.VLLM_USE_V1:
             raise ValueError("Decoder models are only supported on v1")

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -81,11 +81,12 @@ class SpyrePlatform(Platform):
     def device_type(cls):
         # TODO: temporary hack while BertModels
         # inherit SupportsV0Only in vllm upstream.
+        import vllm.model_executor.models as me_models
         from vllm.config import ModelConfig
 
         # no need to patch after the model_config change
         if 'model_config' not in \
-                inspect.getfullargspec(ModelConfig.is_v1_compatible).args:
+                inspect.getfullargspec(me_models.ModelRegistry.is_v1_compatible).args:
             ModelConfig.is_v1_compatible = is_v1_compatible
         return cls._device_type
 

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -85,7 +85,8 @@ class SpyreWorker(WorkerBaseV1):
             (s["prompt_length"], s["new_tokens"], s["batch_size"])
                 for s in self.spyre_warmup_shapes
         ]):
-            if "embed" not in self.model_config.supported_tasks:
+            if (self.model_config.task and self.model_config.task != "embed"
+                    or "embed" not in self.model_config.supported_tasks):
                 # TODO: remove if spyre supports
                 # lower number of output tokens
                 assert num_decode_tokens >= 2, (
@@ -168,7 +169,8 @@ class SpyreWorker(WorkerBaseV1):
         self.model_runner: \
             Union[StaticBatchingSpyreModelRunner,
                   ContinuousBatchingSpyreModelRunner, SpyrePoolingModelRunner]
-        if "embed" in self.model_config.supported_tasks:
+        if (self.model_config.task and self.model_config.task == "embed"
+                or "embed" in self.model_config.supported_tasks):
             self.model_runner = SpyrePoolingModelRunner(
                 self.vllm_config, self.is_driver_worker)
             self.spyre_warmup_shapes = SpyrePlatform.get_warmup_shapes(

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -86,7 +86,8 @@ class SpyreWorker(WorkerBaseV1):
                 for s in self.spyre_warmup_shapes
         ]):
             if (self.model_config.task and self.model_config.task != "embed"
-                    or "embed" not in self.model_config.supported_tasks):
+                    or not self.model_config.task
+                    and "embed" not in self.model_config.supported_tasks):
                 # TODO: remove if spyre supports
                 # lower number of output tokens
                 assert num_decode_tokens >= 2, (
@@ -169,8 +170,11 @@ class SpyreWorker(WorkerBaseV1):
         self.model_runner: \
             Union[StaticBatchingSpyreModelRunner,
                   ContinuousBatchingSpyreModelRunner, SpyrePoolingModelRunner]
+        # earlier versions had self.model_config.task==embed
+        # but also had embed in self.model_config.supported_tasks
         if (self.model_config.task and self.model_config.task == "embed"
-                or "embed" in self.model_config.supported_tasks):
+                or not self.model_config.task
+                and "embed" in self.model_config.supported_tasks):
             self.model_runner = SpyrePoolingModelRunner(
                 self.vllm_config, self.is_driver_worker)
             self.spyre_warmup_shapes = SpyrePlatform.get_warmup_shapes(

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -463,8 +463,7 @@ class SpyreWorker(WorkerBaseV1):
             0, len(valid_token_ids_tensor), (batch_size, prompt_len))]
 
         sampling_params, pooling_params = None, None
-        if (self.model_config.task != "embed"
-                or not self.model_config.task
+        if (self.model_config.task != "embed" or not self.model_config.task
                 and "embed" not in self.model_config.supported_tasks):
             sampling_params = SamplingParams(max_tokens=num_decode_tokens)
         else:

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -57,6 +57,18 @@ class SpyreWorker(WorkerBaseV1):
     """A worker class that executes the model on a group of Spyre cores.
     """
 
+    @property
+    def is_pooling(self) -> bool:
+        return self.model_config.task == "embed" \
+            if self.model_config.task else \
+                "embed" in self.model_config.supported_tasks
+
+    @property
+    def is_decoder(self) -> bool:
+        return self.model_config.task == "generate" \
+            if self.model_config.task else \
+                "generate" in self.model_config.supported_tasks
+
     def get_kv_cache_spec(self) -> KVCacheSpec:
         """Get specifications for KV cache implementation.
 
@@ -85,10 +97,7 @@ class SpyreWorker(WorkerBaseV1):
             (s["prompt_length"], s["new_tokens"], s["batch_size"])
                 for s in self.spyre_warmup_shapes
         ]):
-            # Can be simplified after the model_config change from vllm:main
-            if (self.model_config.task and self.model_config.task != "embed"
-                    or not self.model_config.task
-                    and "embed" not in self.model_config.supported_tasks):
+            if not self.is_pooling:
                 # TODO: remove if spyre supports
                 # lower number of output tokens
                 assert num_decode_tokens >= 2, (
@@ -171,10 +180,7 @@ class SpyreWorker(WorkerBaseV1):
         self.model_runner: \
             Union[StaticBatchingSpyreModelRunner,
                   ContinuousBatchingSpyreModelRunner, SpyrePoolingModelRunner]
-        # Can be simplified after the model_config change from vllm:main
-        if (self.model_config.task and self.model_config.task == "embed"
-                or not self.model_config.task
-                and "embed" in self.model_config.supported_tasks):
+        if self.is_pooling:
             self.model_runner = SpyrePoolingModelRunner(
                 self.vllm_config, self.is_driver_worker)
             self.spyre_warmup_shapes = SpyrePlatform.get_warmup_shapes(
@@ -463,10 +469,7 @@ class SpyreWorker(WorkerBaseV1):
             0, len(valid_token_ids_tensor), (batch_size, prompt_len))]
 
         sampling_params, pooling_params = None, None
-        # Can be simplified after the model_config change from vllm:main
-        if (self.model_config.task and self.model_config.task != "embed"
-                or not self.model_config.task
-                and "embed" not in self.model_config.supported_tasks):
+        if not self.is_pooling:
             sampling_params = SamplingParams(max_tokens=num_decode_tokens)
         else:
             pooling_params = PoolingParams()

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -85,6 +85,7 @@ class SpyreWorker(WorkerBaseV1):
             (s["prompt_length"], s["new_tokens"], s["batch_size"])
                 for s in self.spyre_warmup_shapes
         ]):
+            # Can be simplified after the model_config change from vllm:main
             if (self.model_config.task and self.model_config.task != "embed"
                     or not self.model_config.task
                     and "embed" not in self.model_config.supported_tasks):
@@ -170,8 +171,7 @@ class SpyreWorker(WorkerBaseV1):
         self.model_runner: \
             Union[StaticBatchingSpyreModelRunner,
                   ContinuousBatchingSpyreModelRunner, SpyrePoolingModelRunner]
-        # earlier versions had self.model_config.task==embed
-        # but also had embed in self.model_config.supported_tasks
+        # Can be simplified after the model_config change from vllm:main
         if (self.model_config.task and self.model_config.task == "embed"
                 or not self.model_config.task
                 and "embed" in self.model_config.supported_tasks):
@@ -463,6 +463,7 @@ class SpyreWorker(WorkerBaseV1):
             0, len(valid_token_ids_tensor), (batch_size, prompt_len))]
 
         sampling_params, pooling_params = None, None
+        # Can be simplified after the model_config change from vllm:main
         if (self.model_config.task and self.model_config.task != "embed"
                 or not self.model_config.task
                 and "embed" not in self.model_config.supported_tasks):

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -85,7 +85,8 @@ class SpyreWorker(WorkerBaseV1):
             (s["prompt_length"], s["new_tokens"], s["batch_size"])
                 for s in self.spyre_warmup_shapes
         ]):
-            if (self.model_config.task != "embed" or not self.model_config.task
+            if (self.model_config.task and self.model_config.task != "embed"
+                    or not self.model_config.task
                     and "embed" not in self.model_config.supported_tasks):
                 # TODO: remove if spyre supports
                 # lower number of output tokens
@@ -171,7 +172,8 @@ class SpyreWorker(WorkerBaseV1):
                   ContinuousBatchingSpyreModelRunner, SpyrePoolingModelRunner]
         # earlier versions had self.model_config.task==embed
         # but also had embed in self.model_config.supported_tasks
-        if (self.model_config.task == "embed" or not self.model_config.task
+        if (self.model_config.task and self.model_config.task == "embed"
+                or not self.model_config.task
                 and "embed" in self.model_config.supported_tasks):
             self.model_runner = SpyrePoolingModelRunner(
                 self.vllm_config, self.is_driver_worker)
@@ -461,7 +463,8 @@ class SpyreWorker(WorkerBaseV1):
             0, len(valid_token_ids_tensor), (batch_size, prompt_len))]
 
         sampling_params, pooling_params = None, None
-        if (self.model_config.task != "embed" or not self.model_config.task
+        if (self.model_config.task != "embed"
+                or not self.model_config.task
                 and "embed" not in self.model_config.supported_tasks):
             sampling_params = SamplingParams(max_tokens=num_decode_tokens)
         else:

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -85,7 +85,7 @@ class SpyreWorker(WorkerBaseV1):
             (s["prompt_length"], s["new_tokens"], s["batch_size"])
                 for s in self.spyre_warmup_shapes
         ]):
-            if self.model_config.task != "embed":
+            if "embed" not in self.model_config.supported_tasks:
                 # TODO: remove if spyre supports
                 # lower number of output tokens
                 assert num_decode_tokens >= 2, (
@@ -168,7 +168,7 @@ class SpyreWorker(WorkerBaseV1):
         self.model_runner: \
             Union[StaticBatchingSpyreModelRunner,
                   ContinuousBatchingSpyreModelRunner, SpyrePoolingModelRunner]
-        if self.model_config.task == "embed":
+        if "embed" in self.model_config.supported_tasks:
             self.model_runner = SpyrePoolingModelRunner(
                 self.vllm_config, self.is_driver_worker)
             self.spyre_warmup_shapes = SpyrePlatform.get_warmup_shapes(

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -85,8 +85,7 @@ class SpyreWorker(WorkerBaseV1):
             (s["prompt_length"], s["new_tokens"], s["batch_size"])
                 for s in self.spyre_warmup_shapes
         ]):
-            if (self.model_config.task and self.model_config.task != "embed"
-                    or not self.model_config.task
+            if (self.model_config.task != "embed" or not self.model_config.task
                     and "embed" not in self.model_config.supported_tasks):
                 # TODO: remove if spyre supports
                 # lower number of output tokens
@@ -172,8 +171,7 @@ class SpyreWorker(WorkerBaseV1):
                   ContinuousBatchingSpyreModelRunner, SpyrePoolingModelRunner]
         # earlier versions had self.model_config.task==embed
         # but also had embed in self.model_config.supported_tasks
-        if (self.model_config.task and self.model_config.task == "embed"
-                or not self.model_config.task
+        if (self.model_config.task == "embed" or not self.model_config.task
                 and "embed" in self.model_config.supported_tasks):
             self.model_runner = SpyrePoolingModelRunner(
                 self.vllm_config, self.is_driver_worker)
@@ -463,8 +461,7 @@ class SpyreWorker(WorkerBaseV1):
             0, len(valid_token_ids_tensor), (batch_size, prompt_len))]
 
         sampling_params, pooling_params = None, None
-        if (self.model_config.task and self.model_config.task != "embed"
-                or not self.model_config.task
+        if (self.model_config.task != "embed" or not self.model_config.task
                 and "embed" not in self.model_config.supported_tasks):
             sampling_params = SamplingParams(max_tokens=num_decode_tokens)
         else:

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -463,7 +463,8 @@ class SpyreWorker(WorkerBaseV1):
             0, len(valid_token_ids_tensor), (batch_size, prompt_len))]
 
         sampling_params, pooling_params = None, None
-        if (self.model_config.task != "embed" or not self.model_config.task
+        if (self.model_config.task and self.model_config.task != "embed"
+                or not self.model_config.task
                 and "embed" not in self.model_config.supported_tasks):
             sampling_params = SamplingParams(max_tokens=num_decode_tokens)
         else:

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -463,7 +463,9 @@ class SpyreWorker(WorkerBaseV1):
             0, len(valid_token_ids_tensor), (batch_size, prompt_len))]
 
         sampling_params, pooling_params = None, None
-        if self.model_config.task != "embed":
+        if (self.model_config.task and self.model_config.task != "embed"
+                or not self.model_config.task
+                and "embed" not in self.model_config.supported_tasks):
             sampling_params = SamplingParams(max_tokens=num_decode_tokens)
         else:
             pooling_params = PoolingParams()

--- a/vllm_spyre/worker/spyre_worker.py
+++ b/vllm_spyre/worker/spyre_worker.py
@@ -64,6 +64,7 @@ class SpyreWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             from vllm.utils import init_cached_hf_modules
             init_cached_hf_modules()
 
+        # Can be simplified after the model_config change from vllm:main
         if (self.model_config.task and self.model_config.task == "embed"
                 or not self.model_config.task
                 and "embed" in self.model_config.supported_tasks):
@@ -207,6 +208,7 @@ class SpyreWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             (s["prompt_length"], s["new_tokens"], s["batch_size"])
                 for s in self.spyre_warmup_shapes
         ]):
+            # Can be simplified after the model_config change from vllm:main
             if (self.model_config.task and self.model_config.task != "embed"
                     or not self.model_config.task
                     and "embed" not in self.model_config.supported_tasks):

--- a/vllm_spyre/worker/spyre_worker.py
+++ b/vllm_spyre/worker/spyre_worker.py
@@ -64,7 +64,7 @@ class SpyreWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             from vllm.utils import init_cached_hf_modules
             init_cached_hf_modules()
 
-        if self.model_config.task == "embed":
+        if "embed" in self.model_config.supported_tasks:
             self.model_runner: SpyreModelRunner = SpyreEmbeddingModelRunner(
                 self.model_config, self.parallel_config, self.scheduler_config,
                 self.device_config, self.is_driver_worker)
@@ -205,7 +205,7 @@ class SpyreWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             (s["prompt_length"], s["new_tokens"], s["batch_size"])
                 for s in self.spyre_warmup_shapes
         ]):
-            if self.model_config.task != "embed":
+            if "embed" not in self.model_config.supported_tasks:
                 # TODO: remove if spyre supports
                 # lower number of output tokens
                 assert num_decode_tokens >= 2, (

--- a/vllm_spyre/worker/spyre_worker.py
+++ b/vllm_spyre/worker/spyre_worker.py
@@ -64,7 +64,8 @@ class SpyreWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             from vllm.utils import init_cached_hf_modules
             init_cached_hf_modules()
 
-        if (self.model_config.task == "embed" or not self.model_config.task
+        if (self.model_config.task and self.model_config.task == "embed"
+                or not self.model_config.task
                 and "embed" in self.model_config.supported_tasks):
             self.model_runner: SpyreModelRunner = SpyreEmbeddingModelRunner(
                 self.model_config, self.parallel_config, self.scheduler_config,
@@ -206,7 +207,8 @@ class SpyreWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             (s["prompt_length"], s["new_tokens"], s["batch_size"])
                 for s in self.spyre_warmup_shapes
         ]):
-            if (self.model_config.task != "embed" or not self.model_config.task
+            if (self.model_config.task and self.model_config.task != "embed"
+                    or not self.model_config.task
                     and "embed" not in self.model_config.supported_tasks):
                 # TODO: remove if spyre supports
                 # lower number of output tokens

--- a/vllm_spyre/worker/spyre_worker.py
+++ b/vllm_spyre/worker/spyre_worker.py
@@ -65,7 +65,8 @@ class SpyreWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             init_cached_hf_modules()
 
         if (self.model_config.task and self.model_config.task == "embed"
-                or "embed" in self.model_config.supported_tasks):
+                or not self.model_config.task
+                and "embed" in self.model_config.supported_tasks):
             self.model_runner: SpyreModelRunner = SpyreEmbeddingModelRunner(
                 self.model_config, self.parallel_config, self.scheduler_config,
                 self.device_config, self.is_driver_worker)
@@ -207,7 +208,8 @@ class SpyreWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
                 for s in self.spyre_warmup_shapes
         ]):
             if (self.model_config.task and self.model_config.task != "embed"
-                    or "embed" not in self.model_config.supported_tasks):
+                    or not self.model_config.task
+                    and "embed" not in self.model_config.supported_tasks):
                 # TODO: remove if spyre supports
                 # lower number of output tokens
                 assert num_decode_tokens >= 2, (

--- a/vllm_spyre/worker/spyre_worker.py
+++ b/vllm_spyre/worker/spyre_worker.py
@@ -64,7 +64,8 @@ class SpyreWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             from vllm.utils import init_cached_hf_modules
             init_cached_hf_modules()
 
-        if "embed" in self.model_config.supported_tasks:
+        if (self.model_config.task and self.model_config.task == "embed"
+                or "embed" in self.model_config.supported_tasks):
             self.model_runner: SpyreModelRunner = SpyreEmbeddingModelRunner(
                 self.model_config, self.parallel_config, self.scheduler_config,
                 self.device_config, self.is_driver_worker)
@@ -205,7 +206,8 @@ class SpyreWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             (s["prompt_length"], s["new_tokens"], s["batch_size"])
                 for s in self.spyre_warmup_shapes
         ]):
-            if "embed" not in self.model_config.supported_tasks:
+            if (self.model_config.task and self.model_config.task != "embed"
+                    or "embed" not in self.model_config.supported_tasks):
                 # TODO: remove if spyre supports
                 # lower number of output tokens
                 assert num_decode_tokens >= 2, (

--- a/vllm_spyre/worker/spyre_worker.py
+++ b/vllm_spyre/worker/spyre_worker.py
@@ -64,8 +64,7 @@ class SpyreWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             from vllm.utils import init_cached_hf_modules
             init_cached_hf_modules()
 
-        if (self.model_config.task and self.model_config.task == "embed"
-                or not self.model_config.task
+        if (self.model_config.task == "embed" or not self.model_config.task
                 and "embed" in self.model_config.supported_tasks):
             self.model_runner: SpyreModelRunner = SpyreEmbeddingModelRunner(
                 self.model_config, self.parallel_config, self.scheduler_config,
@@ -207,8 +206,7 @@ class SpyreWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             (s["prompt_length"], s["new_tokens"], s["batch_size"])
                 for s in self.spyre_warmup_shapes
         ]):
-            if (self.model_config.task and self.model_config.task != "embed"
-                    or not self.model_config.task
+            if (self.model_config.task != "embed" or not self.model_config.task
                     and "embed" not in self.model_config.supported_tasks):
                 # TODO: remove if spyre supports
                 # lower number of output tokens


### PR DESCRIPTION
It seems `model_config.task` is deprecated, instead from what I understand we can use `model_config.supported_tasks`, which is initialized when an llm engine is instantiated:
https://github.com/vllm-project/vllm/pull/21470/files#diff-7eaad0b7dee0626bf29d10081b0f0c5e3ea15a4af97e7b182a4e0d35f8346953R705-R706

To maintain backward compatibility, it's a bit tricky since:
- Earlier version had `model_config.task` pointing to the task and `model_config.supported_tasks` as a list of all tasks which could contain more than 1 task
    ```
    model_config.task :  generate
    model_config.supported_tasks :  {'embed', 'reward', 'generate', 'classify'}
    ``` 
- Latest `main` now populates `model_config.supported_tasks` as the only task the model supports.
    ```
    model_config.task :  None
    model_config.supported_tasks :  ['generate']
    ```