### PR TITLE
♻️ enable offline mode in GHA tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,7 @@ jobs:
           # be removed by an admin or can be left to expire after 7 days.
           
           download_tinygranite() {
-            python -c "from transformers import pipeline, AutoTokenizer; pipeline('text-generation', model='ibm-ai-platform/micro-g3.3-8b-instruct-1b'; tokenizer=AutoTokenizer.from_pretrained('ibm-ai-platform/micro-g3.3-8b-instruct-1b')"
+            python -c "from transformers import pipeline, AutoTokenizer; pipeline('text-generation', model='ibm-ai-platform/micro-g3.3-8b-instruct-1b'); tokenizer=AutoTokenizer.from_pretrained('ibm-ai-platform/micro-g3.3-8b-instruct-1b')"
           }
           download_roberta_large() {
             python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-roberta-large-v1')"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,6 +151,7 @@ jobs:
           MASTER_ADDR: localhost
           DISTRIBUTED_STRATEGY_IGNORE_MODULES: WordEmbedding
           VLLM_SPYRE_TEST_MODEL_LIST: "${{ matrix.test_suite.name == 'static batching' && 'JackFram/llama-160m' || '' }}"
+          HF_HUB_OFFLINE: 1
         run: |
           # Delete the source code so we can ensure we're testing the installed
           # wheel
@@ -160,5 +161,5 @@ jobs:
           # re-install the vllm_sypre package from source
           source .venv/bin/activate
 
-          export HF_HUB_OFFLINE=1 python3 -m pytest ${{ matrix.test_suite.flags }} \
+          python3 -m pytest ${{ matrix.test_suite.flags }} \
             tests -v -m "${{ matrix.test_suite.markers }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,5 +160,5 @@ jobs:
           # re-install the vllm_sypre package from source
           source .venv/bin/activate
 
-          python3 -m pytest ${{ matrix.test_suite.flags }} \
+          export HF_HUB_OFFLINE=1 python3 -m pytest ${{ matrix.test_suite.flags }} \
             tests -v -m "${{ matrix.test_suite.markers }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,7 @@ jobs:
           # be removed by an admin or can be left to expire after 7 days.
           
           download_tinygranite() {
-            python -c "from transformers import pipeline; pipeline('text-generation', model='ibm-ai-platform/micro-g3.3-8b-instruct-1b')"
+            python -c "from transformers import pipeline, AutoTokenizer; pipeline('text-generation', model='ibm-ai-platform/micro-g3.3-8b-instruct-1b'; tokenizer=AutoTokenizer.from_pretrained('ibm-ai-platform/micro-g3.3-8b-instruct-1b')"
           }
           download_roberta_large() {
             python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-roberta-large-v1')"

--- a/tests/e2e/test_spyre_prompt_logprobs.py
+++ b/tests/e2e/test_spyre_prompt_logprobs.py
@@ -75,27 +75,29 @@ def test_prompt_logprobs_must_be_enabled(monkeypatch: pytest.MonkeyPatch):
 
 @pytest.mark.cpu
 @pytest.mark.decoder
+@pytest.mark.parametrize("model", get_spyre_model_list())
 def test_prompt_logprobs_not_supported_with_cb(
-        monkeypatch: pytest.MonkeyPatch):
+        model: str, monkeypatch: pytest.MonkeyPatch):
     # Server shouldn't boot with both prompt logprobs and continuous batching
     # enabled
     monkeypatch.setenv("VLLM_SPYRE_ENABLE_PROMPT_LOGPROBS", "1")
     monkeypatch.setenv("VLLM_SPYRE_USE_CB", "1")
 
     with pytest.raises(ValueError, match="continuous batching"):
-        VllmConfig(model_config=ModelConfig(task="generate"))
+        VllmConfig(model_config=ModelConfig(model=model, task="generate"))
 
 
 @pytest.mark.cpu
 @pytest.mark.decoder
+@pytest.mark.parametrize("model", get_spyre_model_list())
 def test_prompt_logprobs_on_single_requests_only(
-        monkeypatch: pytest.MonkeyPatch):
+        model: str, monkeypatch: pytest.MonkeyPatch):
     # Only bs=1 is supported for prompt logprobs
     monkeypatch.setenv("VLLM_SPYRE_ENABLE_PROMPT_LOGPROBS", "1")
     monkeypatch.setenv("VLLM_SPYRE_WARMUP_BATCH_SIZES", "2")
 
     with pytest.raises(ValueError, match="batch size 1"):
-        VllmConfig(model_config=ModelConfig(task="generate"))
+        VllmConfig(model_config=ModelConfig(model=model, task="generate"))
 
 
 def _compare_prompt_logprobs(expected: list, actual: list,


### PR DESCRIPTION
# Description

We should be able to run the tests in offline mode to avoid multiple calls to HF unnecessarily.

This also caught a bug (I think?) in one of the tests where we were unnecessarily trying to download the `facebook/opt-125m` model.