### PR TITLE
:arrow_up: bump base image with more CB fixes

### DIFF
--- a/docker/Dockerfile.amd64
+++ b/docker/Dockerfile.amd64
@@ -1,6 +1,6 @@
 # This is a reference dockerfile for vLLM Spyre support on an x86 host
 ARG BASE_IMAGE_URL="quay.io/ibm-aiu/spyre-base"
-ARG BASE_IMAGE_TAG="2025_07_18-amd64"
+ARG BASE_IMAGE_TAG="2025_07_30-amd64"
 
 ##############################################
 # Base


### PR DESCRIPTION
# Description

This bumps to the newly released base image with compiler updates to support continuous batching with 8k context and TP=4
