### PR TITLE
[docs][CB] remove warning that no output correctness is asserted for scheduler step tests

### DIFF
--- a/docs/contributing/continuous_batching/tests/scheduler_steps_tests.md
+++ b/docs/contributing/continuous_batching/tests/scheduler_steps_tests.md
@@ -3,7 +3,4 @@
 !!! note
     Unless otherwise specified, all the continuous batching tests are running with `max_model_len=256`
 
-!!! warning
-    End output correctness is not verified in those tests (TODO should we? maybe for some of them?)
-
 ::: tests.e2e.test_spyre_cb_scheduler_steps


### PR DESCRIPTION
### [docs][CB] remove warning that no output correctness is asserted for scheduler step tests


we now do assert output correctness for the scheduling test since #337 , hence this warning should be removed. 