### PR TITLE
[embedding] support newest vllm main branch 

### DIFF
--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -88,6 +88,24 @@ def test_pooler_from_config():
 
 
 @pytest.mark.cpu
+def test_pooler_default_args():
+
+    from vllm.model_executor.layers.pooler import Pooler
+    has_from_config = hasattr(Pooler, "from_config_with_defaults")
+
+    if not has_from_config:
+        annotations = inspect.getfullargspec(Pooler.for_embed).annotations
+        if VLLM_VERSION == "vLLM:main":
+            assert 'default_normalize' not in annotations
+            assert 'default_softmax' not in annotations
+        elif VLLM_VERSION == "vLLM:lowest":
+            assert 'default_normalize' in annotations
+            assert 'default_softmax' in annotations
+            # The compat code introduced in the PR below can now be removed:
+            # https://github.com/vllm-project/vllm-spyre/pull/361
+
+
+@pytest.mark.cpu
 def test_engine_core_add_request():
 
     from vllm.v1.engine import EngineCoreRequest

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -1,3 +1,4 @@
+import inspect
 import math
 import time
 from abc import ABC, abstractmethod
@@ -1333,11 +1334,21 @@ class SpyrePoolingModelRunner(WarmupShapesMixin,
                 normalize=True,
                 softmax=False)
         else:
+            # TODO: remove this when we no longer support vllm version pre this
+            # PR https://github.com/vllm-project/vllm/pull/20538 (post v0.10.0)
+            annotations = inspect.getfullargspec(Pooler.for_embed).annotations
+            if ('default_normalize' in annotations
+                    and 'default_softmax' in annotations):
+                extra_args = {
+                    'default_normalize': True,
+                    'default_softmax': False
+                }
+            else:
+                extra_args = {}
             self.pooler = Pooler.for_embed(
                 pooler_config=pooler_config,
                 default_pooling_type=PoolingType.CLS,
-                default_normalize=True,
-                default_softmax=False)
+                **extra_args)
 
     def build_input_batch(self) -> PoolingInputBatch:
         return PoolingInputBatch(


### PR DESCRIPTION
### [embedding] support newest vllm main branch 

parameters `default_normalize` and `default_softmax` are deprecated