### PR TITLE
[CB] hard code number of spyre blocks to 2080

### DIFF
--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -848,6 +848,8 @@ class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):
             # hard coded value for tensor parallel size 4 with the below model
             # https://huggingface.co/ibm-granite/granite-3.3-8b-instruct
             NUM_BLOCKS_SPYRE = 2080
+            logger.info("Model granite-3.3-8b-instruct and tensor parallel " \
+            "size 4 detected. Using NUM_BLOCKS_SPYRE = %d", 2080)
         else:
             # default value for any other model/ tensor parallel size
             NUM_BLOCKS_SPYRE = max_batch_size * min_req_num_blocks

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -843,15 +843,18 @@ class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):
         # TODO: replace the hard coded NUM_BLOCKS_SPYRE by calling a function
         # in torch_sendnn which returns the value set by the Spyre compiler.
 
-        if 'granite-3.3-8b-instruct' in self.model_config.model:
+        if ('granite-3.3-8b-instruct' in self.model_config.model
+                and self.parallel_config.world_size == 4):
+            # hard coded value for tensor parallel size 4 with the below model
             # https://huggingface.co/ibm-granite/granite-3.3-8b-instruct
-            NUM_BLOCKS_SPYRE = 2080  # HARD CODED VALUE
+            NUM_BLOCKS_SPYRE = 2080
         else:
-            # default value for any other model
+            # default value for any other model/ tensor parallel size
             NUM_BLOCKS_SPYRE = max_batch_size * min_req_num_blocks
-            logger.info("No model specific value for the number of KV cache " \
-            "blocks available on Spyre found. Using default value " \
-            "(max_batch_size * min_req_num_blocks): %d", NUM_BLOCKS_SPYRE)
+            logger.info("No model / tensor parallel size specific value for" \
+            "the number of KV cache blocks available on Spyre found. Using " \
+            "default value (max_batch_size * max_model_len / block_size): %d",
+              NUM_BLOCKS_SPYRE)
 
         if envs_spyre.VLLM_SPYRE_DYNAMO_BACKEND == 'sendnn':
             num_blocks_spyre = NUM_BLOCKS_SPYRE


### PR DESCRIPTION
### [CB] hard code number of Spyre blocks to 2080

We have received a number from the compiler team for the [model](https://huggingface.co/ibm-granite/granite-3.3-8b-instruct) of interest with TP 4 and hard code it here. For all other models/ TP sizes the number of blocks defaults to `max_batch_size * max_model_len / block_size`.