### PR TITLE
[CB] set and respect compiler constraint VLLM_DT_MAX_BATCH_TKV_LIMIT 

### DIFF
--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -210,6 +210,8 @@ class SpyrePlatform(Platform):
             # hard coded value for tensor parallel size 4 with the below model
             # https://huggingface.co/ibm-granite/granite-3.3-8b-instruct
             os.environ["VLLM_DT_MAX_BATCH_TKV_LIMIT"] = str(131072)
+            logger.info("Model granite-3.3-8b-instruct and tensor parallel " \
+            "size 4 detected. Using VLLM_DT_MAX_BATCH_TKV_LIMIT = %d", 131072)
         else:
             # default value for any other model/ tensor parallel size
             default_max_batch_tkv_limit = \

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -209,9 +209,10 @@ class SpyrePlatform(Platform):
                 and parallel_config.world_size == 4):
             # hard coded value for tensor parallel size 4 with the below model
             # https://huggingface.co/ibm-granite/granite-3.3-8b-instruct
-            os.environ["VLLM_DT_MAX_BATCH_TKV_LIMIT"] = str(131072)
+            os.environ["VLLM_DT_MAX_BATCH_TKV_LIMIT"] = str(128 * 1024)
             logger.info("Model granite-3.3-8b-instruct and tensor parallel " \
-            "size 4 detected. Using VLLM_DT_MAX_BATCH_TKV_LIMIT = %d", 131072)
+            "size 4 detected. Using VLLM_DT_MAX_BATCH_TKV_LIMIT = %d",
+            128 * 1024)
         else:
             # default value for any other model/ tensor parallel size
             default_max_batch_tkv_limit = \

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -203,6 +203,8 @@ class SpyrePlatform(Platform):
         # min decode batch size is 2 due to symbolic shape constraint in torch
         os.environ["VLLM_DT_MAX_BATCH_SIZE"] = str(
             max(vllm_config.scheduler_config.max_num_seqs, 2))
+        # max product of batch size x tkv supported by the Spyre compiler
+        os.environ["VLLM_DT_MAX_BATCH_TKV_LIMIT"] = str(131072)
 
     @classmethod
     def use_all_gather(cls) -> bool:

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -203,8 +203,23 @@ class SpyrePlatform(Platform):
         # min decode batch size is 2 due to symbolic shape constraint in torch
         os.environ["VLLM_DT_MAX_BATCH_SIZE"] = str(
             max(vllm_config.scheduler_config.max_num_seqs, 2))
+
         # max product of batch size x tkv supported by the Spyre compiler
-        os.environ["VLLM_DT_MAX_BATCH_TKV_LIMIT"] = str(131072)
+        if ('granite-3.3-8b-instruct' in model_config.model
+                and parallel_config.world_size == 4):
+            # hard coded value for tensor parallel size 4 with the below model
+            # https://huggingface.co/ibm-granite/granite-3.3-8b-instruct
+            os.environ["VLLM_DT_MAX_BATCH_TKV_LIMIT"] = str(131072)
+        else:
+            # default value for any other model/ tensor parallel size
+            default_max_batch_tkv_limit = \
+                vllm_config.model_config.max_model_len * \
+                vllm_config.scheduler_config.max_num_seqs
+            os.environ["VLLM_DT_MAX_BATCH_TKV_LIMIT"] = str(
+                default_max_batch_tkv_limit)
+            logger.info("No model / tensor parallel size specific value for " \
+            "VLLM_DT_MAX_BATCH_TKV_LIMIT found. Using the default value " \
+            "(max_model_len * max_batch_size): %d", default_max_batch_tkv_limit)
 
     @classmethod
     def use_all_gather(cls) -> bool:

--- a/vllm_spyre/v1/core/scheduler.py
+++ b/vllm_spyre/v1/core/scheduler.py
@@ -268,6 +268,9 @@ class ContinuousBatchingSpyreScheduler(SpyreScheduler):
         is reached. Remaining sequences do not need to be checked explicitly, 
         since they were validated when they were added (by inductive reasoning).
 
+        Note: drawing explaining the algorithm in more detail uploaded here: 
+        https://github.com/vllm-project/vllm-spyre/pull/363#issuecomment-3173605517
+        
         WIP: The result of this check could be cached and reused if both the 
         decode batch and the new input request are unchanged between calls.
         """

--- a/vllm_spyre/v1/core/scheduler.py
+++ b/vllm_spyre/v1/core/scheduler.py
@@ -239,12 +239,12 @@ class ContinuousBatchingSpyreScheduler(SpyreScheduler):
         num_blocks_required -= num_fully_padded_blocks
         cond5 = num_blocks_required <= self.n_free_blocks
         # check that batch size x tkv is smaller than the max supported number
-        max_batch_tkv_limit = int(
-            os.getenv("VLLM_DT_MAX_BATCH_TKV_LIMIT", default=str(131072)))
+        max_batch_tkv_limit = os.getenv("VLLM_DT_MAX_BATCH_TKV_LIMIT")
+        assert max_batch_tkv_limit is not None
         max_batch_size = len(self.running) + 1
         # max_tkv is chosen conservatively, a lower number could be found by
         # considering max_tokens and start tkv of all requests in self.running
         max_tkv = self.tkv + request.max_tokens - 1
-        cond6 = max_batch_size * max_tkv <= max_batch_tkv_limit
+        cond6 = max_batch_size * max_tkv <= int(max_batch_tkv_limit)
         return start_new_batch or (cond1 and cond2 and cond3 and cond4
                                    and cond5 and cond6)

--- a/vllm_spyre/v1/core/scheduler.py
+++ b/vllm_spyre/v1/core/scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
+import os
 from collections import deque
 from typing import TYPE_CHECKING
 
@@ -237,5 +238,13 @@ class ContinuousBatchingSpyreScheduler(SpyreScheduler):
             (self.tkv - request.num_prompt_tokens) / self.block_size)
         num_blocks_required -= num_fully_padded_blocks
         cond5 = num_blocks_required <= self.n_free_blocks
+        # check that batch size x tkv is smaller than the max supported number
+        max_batch_tkv_limit = int(
+            os.getenv("VLLM_DT_MAX_BATCH_TKV_LIMIT", default=str(131072)))
+        max_batch_size = len(self.running) + 1
+        # max_tkv is chosen conservatively, a lower number could be found by
+        # considering max_tokens and start tkv of all requests in self.running
+        max_tkv = self.tkv + request.max_tokens - 1
+        cond6 = max_batch_size * max_tkv <= max_batch_tkv_limit
         return start_new_batch or (cond1 and cond2 and cond3 and cond4
-                                   and cond5)
+                                   and cond5 and cond6)


### PR DESCRIPTION
[CB] set and respect compiler constraint VLLM_DT_MAX_BATCH_TKV_LIMIT

The Spyre compiler has a constraint on the product of the batch size and tkv. For our [reference model](https://huggingface.co/ibm-granite/granite-3.3-8b-instruct) and TP=4 it cannot exceed `VLLM_DT_MAX_BATCH_TKV_LIMIT=131072`. The default value for all other models/ TP sizes is `VLLM_DT_MAX_BATCH_TKV_LIMIT=max_model_len * max_batch_size
`

changes:
- set `VLLM_DT_MAX_BATCH_TKV_LIMIT` depending on model and TP size
- introduce additional scheduler condition respecting this new constraint
- add drawing explaining the new scheduler check [here](https://github.com/vllm-project/vllm-spyre/pull/363#issuecomment-3173605517)