### PR TITLE
[Tests] Add long context batch tests

### DIFF
--- a/tests/e2e/test_spyre_cb.py
+++ b/tests/e2e/test_spyre_cb.py
@@ -189,7 +189,7 @@ def test_long_context_batches(
     prompt_len: int,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Test continuous batching with various batch sizes and prompt lengths."""
+    """Tests continuous batching with various batch sizes and prompt lengths."""
 
     max_model_len = 32768
     max_num_seqs = 32


### PR DESCRIPTION
# Description

Adds six cases:

- 32 prompts with 512 tokens each
- 16 prompts with 1.5k tokens each
- 8 prompts with 3k tokens each
- 4 prompts with 5k tokens each
- 2 prompts with 9k tokens each
- 1 prompt with 17k tokens
