### PR TITLE
[cb][tests] 🐛 fix bug in test utils, please merge ASAP

### DIFF
--- a/tests/scheduling_utils.py
+++ b/tests/scheduling_utils.py
@@ -60,8 +60,6 @@ def check_scheduler_inference_steps(
     if use_cb:
         monkeypatch.setenv("VLLM_SPYRE_USE_CB", "1")
 
-    max_model_len = 256
-
     # Input parameters sanity check, not actual testing
     # ------
     if not (len(prompts_lengths) == len(seqs_max_tokens)


### PR DESCRIPTION
### [cb][tests] 🐛 fix bug in test utils, please merge ASAP

during some test script refactoring, the parameter `max_model_len` was overridden to always be 256, even if set differently. 