### PR TITLE
🎨 fix warning logs for _cast_bf16_to_f16

### DIFF
--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -259,9 +259,9 @@ class FmsModelBase(nn.Module):
         for name, param in self.model.named_parameters():
             if param.dtype == torch.bfloat16:
                 logger.debug(
-                    "You are casting param %s to fp16, which \
-                        will cause loss of accuracy. You can ignore \
-                            this warning if this is intended.", name)
+                    "You are casting param %s to fp16, which"
+                    " will cause loss of accuracy. You can ignore"
+                    " this warning if this is intended.", name)
                 param.data = param.data.to(dtype=torch.float16)
 
     def _cast_to_f32(self):


### PR DESCRIPTION
# Description

Otherwise the lines are spaced out weird

```DEBUG 08-12 20:14:35 [spyre.py:261] You are casting param base_model.layers.14.attn.in_proj.key.weight to fp16, which                         will cause loss of accuracy. You can ignore                             this warning if this is intended.```
