### PR TITLE
Add compat code for changing Pooler function signature

### DIFF
--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -94,15 +94,31 @@ def test_pooler_default_args():
     has_from_config = hasattr(Pooler, "from_config_with_defaults")
 
     if not has_from_config:
-        annotations = inspect.getfullargspec(Pooler.for_embed).annotations
+        args = inspect.getfullargspec(Pooler.for_embed).args
         if VLLM_VERSION == "vLLM:main":
-            assert 'default_normalize' not in annotations
-            assert 'default_softmax' not in annotations
+            assert 'default_normalize' not in args
+            assert 'default_softmax' not in args
         elif VLLM_VERSION == "vLLM:lowest":
-            assert 'default_normalize' in annotations
-            assert 'default_softmax' in annotations
+            assert 'default_normalize' in args
+            assert 'default_softmax' in args
             # The compat code introduced in the PR below can now be removed:
             # https://github.com/vllm-project/vllm-spyre/pull/361
+
+
+@pytest.mark.cpu
+def test_pooler_default_pooling_type():
+
+    from vllm.model_executor.layers.pooler import Pooler
+    has_from_config = hasattr(Pooler, "from_config_with_defaults")
+
+    if not has_from_config:
+        args = inspect.getfullargspec(Pooler.for_embed).args
+        if VLLM_VERSION == "vLLM:main":
+            assert 'default_pooling_type' not in args
+        elif VLLM_VERSION == "vLLM:lowest":
+            assert 'default_pooling_type' in args
+            # The compat code introduced in the PR below can now be removed:
+            # TBD
 
 
 @pytest.mark.cpu

--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -118,7 +118,7 @@ def test_pooler_default_pooling_type():
         elif VLLM_VERSION == "vLLM:lowest":
             assert 'default_pooling_type' in args
             # The compat code introduced in the PR below can now be removed:
-            # TBD
+            # https://github.com/vllm-project/vllm-spyre/pull/374
 
 
 @pytest.mark.cpu

--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -122,6 +122,21 @@ def test_pooler_default_pooling_type():
 
 
 @pytest.mark.cpu
+def test_multi_step_scheduling():
+
+    from vllm.config import SchedulerConfig
+    has_multi_step = hasattr(SchedulerConfig, "is_multi_step")
+
+    if VLLM_VERSION == "vLLM:main":
+        assert not has_multi_step
+    elif VLLM_VERSION == "vLLM:lowest":
+        assert has_multi_step, ("The lowest supported vLLM version already"
+                                "removed multi-step scheduling.")
+        # The compat code introduced in the PR below can now be removed:
+        # https://github.com/vllm-project/vllm-spyre/pull/374
+
+
+@pytest.mark.cpu
 def test_engine_core_add_request():
 
     from vllm.v1.engine import EngineCoreRequest

--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -94,13 +94,13 @@ def test_pooler_default_args():
     has_from_config = hasattr(Pooler, "from_config_with_defaults")
 
     if not has_from_config:
-        args = inspect.getfullargspec(Pooler.for_embed).args
+        annotations = inspect.getfullargspec(Pooler.for_embed).annotations
         if VLLM_VERSION == "vLLM:main":
-            assert 'default_normalize' not in args
-            assert 'default_softmax' not in args
+            assert 'default_normalize' not in annotations
+            assert 'default_softmax' not in annotations
         elif VLLM_VERSION == "vLLM:lowest":
-            assert 'default_normalize' in args
-            assert 'default_softmax' in args
+            assert 'default_normalize' in annotations
+            assert 'default_softmax' in annotations
             # The compat code introduced in the PR below can now be removed:
             # https://github.com/vllm-project/vllm-spyre/pull/361
 
@@ -112,11 +112,11 @@ def test_pooler_default_pooling_type():
     has_from_config = hasattr(Pooler, "from_config_with_defaults")
 
     if not has_from_config:
-        args = inspect.getfullargspec(Pooler.for_embed).args
+        annotations = inspect.getfullargspec(Pooler.for_embed).annotations
         if VLLM_VERSION == "vLLM:main":
-            assert 'default_pooling_type' not in args
+            assert 'default_pooling_type' not in annotations
         elif VLLM_VERSION == "vLLM:lowest":
-            assert 'default_pooling_type' in args
+            assert 'default_pooling_type' in annotations
             # The compat code introduced in the PR below can now be removed:
             # https://github.com/vllm-project/vllm-spyre/pull/374
 

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -108,7 +108,7 @@ class SpyrePlatform(Platform):
         model_config = vllm_config.model_config
         cache_config = vllm_config.cache_config
 
-        if scheduler_config.is_multi_step:
+        if getattr(scheduler_config, "is_multi_step", False):
             raise NotImplementedError
 
         # Can be simplified after the deprecation of `model_config.task` in

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -1349,14 +1349,15 @@ class SpyrePoolingModelRunner(WarmupShapesMixin,
         else:
             # TODO: remove this when we no longer support vllm version pre this
             # PR https://github.com/vllm-project/vllm/pull/20538 (post v0.10.0)
-            args = inspect.getfullargspec(Pooler.for_embed).args
+            annotations = inspect.getfullargspec(Pooler.for_embed).annotations
             extra_args = {}
-            if ('default_normalize' in args and 'default_softmax' in args):
+            if ('default_normalize' in annotations
+                    and 'default_softmax' in annotations):
                 extra_args.update({
                     'default_normalize': True,
                     'default_softmax': False
                 })
-            if 'default_pooling_type' in args:
+            if 'default_pooling_type' in annotations:
                 extra_args['default_pooling_type'] = PoolingType.CLS
             self.pooler = Pooler.for_embed(pooler_config=pooler_config,
                                            **extra_args)

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -1349,19 +1349,17 @@ class SpyrePoolingModelRunner(WarmupShapesMixin,
         else:
             # TODO: remove this when we no longer support vllm version pre this
             # PR https://github.com/vllm-project/vllm/pull/20538 (post v0.10.0)
-            annotations = inspect.getfullargspec(Pooler.for_embed).annotations
-            if ('default_normalize' in annotations
-                    and 'default_softmax' in annotations):
-                extra_args = {
+            args = inspect.getfullargspec(Pooler.for_embed).args
+            extra_args = {}
+            if ('default_normalize' in args and 'default_softmax' in args):
+                extra_args.update({
                     'default_normalize': True,
                     'default_softmax': False
-                }
-            else:
-                extra_args = {}
-            self.pooler = Pooler.for_embed(
-                pooler_config=pooler_config,
-                default_pooling_type=PoolingType.CLS,
-                **extra_args)
+                })
+            if 'default_pooling_type' in args:
+                extra_args['default_pooling_type'] = PoolingType.CLS
+            self.pooler = Pooler.for_embed(pooler_config=pooler_config,
+                                           **extra_args)
 
     def build_input_batch(self) -> PoolingInputBatch:
         return PoolingInputBatch(


### PR DESCRIPTION
# Description

Adds compatibility code for the `default_pooling_type` argument that was removed

## Related Issues

https://github.com/vllm-project/vllm-spyre/issues/371