### PR TITLE
[GHA] skip tests against vLLM:main if ready label not assigned yet

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
             os: "ubuntu-latest"
             python_version: "3.12"
         # Exclude vLLM:main if PR does NOT have the ready label
-        exclude: ${{ github.event_name == 'pull_request' && !contains(toJson(github.event.pull_request.labels), '"ready"') && fromJSON('[{"vllm_version":{"name":"vLLM:main"}}]') || '[]' }}
+        exclude: ${{ github.event_name == 'pull_request' && !contains(toJson(github.event.pull_request.labels), '"ready"') && fromJSON('[{"vllm_version":{"name":"vLLM:main"}}]') || fromJSON('[]') }}
 
 
     name: "${{ matrix.test_suite.name }} (${{ matrix.vllm_version.name }})"


### PR DESCRIPTION
### [GHA] skip tests against vLLM:main if ready label not assigned yet

Effort to reduce the github actions for each commit. 
Only run against vLLM:main if the PR is labelled ready. 