### PR TITLE
feat: removed 32k from test_swap_decode_programs_for_cb

### DIFF
--- a/tests/e2e/test_spyre_cb.py
+++ b/tests/e2e/test_spyre_cb.py
@@ -272,7 +272,7 @@ def test_swap_decode_programs_for_cb(
 
     model = 'ibm-granite/granite-3.3-8b-instruct'
     backend = 'sendnn'
-    max_num_seqs = 32
+    max_num_seqs = 4
 
     # TODO: change to 32K later
     max_model_len = 16 * 1024  # 16K


### PR DESCRIPTION
# Description

Removed 32K context length for test decode programs.
