### PR TITLE
🎨 make max_num_seqs 4 for online test

### DIFF
--- a/tests/e2e/test_spyre_online.py
+++ b/tests/e2e/test_spyre_online.py
@@ -35,7 +35,7 @@ def _check_result(client, model, max_tokens=8, temperature=0.0, n=1) -> None:
 )
 @pytest.mark.parametrize("cb",
                          [pytest.param(1, marks=pytest.mark.cb, id="cb"), 0])
-@pytest.mark.parametrize("max_num_seqs", [2],
+@pytest.mark.parametrize("max_num_seqs", [4],
                          ids=lambda val: f"max_num_seqs({val})")
 @pytest.mark.parametrize("max_model_len", [256],
                          ids=lambda val: f"max_model_len({val})")


### PR DESCRIPTION
# Description

For model `ibm-ai-platform/micro-g3.3-8b-instruct-1b`:
`max_num_seqs` 2 with TP 4 and CB for `test_openai_serving` seems to be failing:

```
numValidElems: 139984597168000 larger than attn mask vector size: 256dataformat_src_: IEEE_INT64
```

Some notes:

Earlier we had only BS 2 tested with:
1. `test_openai_serving` which tested with `SB` and `TP` 1, 2, 4, and
2. `test_openai_serving_cb` which tested against `CB` but with no `TP`.

Both of them separately passed, but TP (4) with `CB` and BS 2 for `test_spyre_online` is failing (but TP (2) with CB and BS 2 passes)

Also the full model passes:

```tests/e2e/test_spyre_online.py::test_openai_serving[max_model_len(256)-max_num_seqs(2)-cb-sendnn-TP(4)-ibm-granite/granite-3.3-8b-instruct] PASSED```