### PR TITLE
[GHA] Triggering test agains vLLM:main for ready labels added by bot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
         if: matrix.vllm_version.name == 'vLLM:main' && github.event_name == 'pull_request'
         run: |
           PR_NUMBER=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
-          LABELS=$(gh pr view $PR_NUMBER --json labels --jq '.labels[].name')
+          LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
           if echo "$LABELS" | grep -qi '^ready$'; then
             echo "ready label present — continuing"
           else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,12 @@ on:
   # for all pull requests on main irrespective of file type or location
   # Use `changed-src-files` step to determine if source code was changed
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main]
 
   pull_request_target:
-    # Label changes (including bot-applied) need pull_request_target
-    types: [labeled, unlabeled, auto_merge_enabled]
+    # bot-applied label changes need to be triggered with pull_request_target.auto_merge_enabled
+    types: [auto_merge_enabled]
     branches: [main]
 
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
             echo "ready label present — continuing"
           else
             echo "ready label missing — skipping vLLM:main"
-            exit 0
+            exit 1
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   # for all pull requests on main irrespective of file type or location
   # Use `changed-src-files` step to determine if source code was changed
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main]
 
   pull_request_target:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,13 +5,13 @@ on:
   # for all pull requests on main irrespective of file type or location
   # Use `changed-src-files` step to determine if source code was changed
   pull_request:
+    # add labeled and unlabeled to the default types (runs when label is added)
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main]
 
   pull_request_target:
     # bot-applied label changes need to be triggered with pull_request_target.auto_merge_enabled
     types: [auto_merge_enabled]
-    branches: [main]
 
   push:
     branches: [main]
@@ -74,6 +74,7 @@ jobs:
             python_version: "3.12"
         # Exclude vLLM:main if PR does NOT have the ready label
         exclude: ${{ github.event_name == 'pull_request' && !contains(toJson(github.event.pull_request.labels), '"ready"') && fromJSON('[{"vllm_version":{"name":"vLLM:main"}}]') || fromJSON('[]') }}
+
 
     name: "${{ matrix.test_suite.name }} (${{ matrix.vllm_version.name }})"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,13 +68,13 @@ jobs:
               flags: "--timeout=300"
             os: "ubuntu-latest"
             python_version: "3.12"
-        # Exclude vLLM:main if PR is not ready or if auto-merge was enabled
+        # Exclude vLLM:main if PR does NOT have "ready" label AND auto-merge is not enabled
         exclude: >-
-          ${{ 
+          ${{
             github.event_name == 'pull_request' &&
-            (
-              github.event.action == 'auto_merge_enabled' ||
-              !contains(toJson(github.event.pull_request.labels), '"ready"')
+            !(
+              contains(toJson(github.event.pull_request.labels), '"ready"') ||
+              github.event.action == 'auto_merge_enabled'
             )
               && fromJSON('[{"vllm_version":{"name":"vLLM:main"}}]')
               || fromJSON('[]')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,13 +72,24 @@ jobs:
               flags: "--timeout=300"
             os: "ubuntu-latest"
             python_version: "3.12"
-        # Exclude vLLM:main if PR does NOT have the ready label
-        exclude: ${{ github.event_name == 'pull_request' && !contains(toJson(github.event.pull_request.labels), '"ready"') && fromJSON('[{"vllm_version":{"name":"vLLM:main"}}]') || fromJSON('[]') }}
-
 
     name: "${{ matrix.test_suite.name }} (${{ matrix.vllm_version.name }})"
 
     steps:
+      - name: "Skip vLLM:main if PR not ready"
+        if: matrix.vllm_version.name == 'vLLM:main' && github.event_name == 'pull_request'
+        run: |
+          PR_NUMBER=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
+          LABELS=$(gh pr view $PR_NUMBER --json labels --jq '.labels[].name')
+          if echo "$LABELS" | grep -qi '^ready$'; then
+            echo "ready label present — continuing"
+          else
+            echo "ready label missing — skipping vLLM:main"
+            exit 0
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: "Checkout"
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,13 +5,17 @@ on:
   # for all pull requests on main irrespective of file type or location
   # Use `changed-src-files` step to determine if source code was changed
   pull_request:
-    # add labeled and unlabeled to the default types (runs when label is added)
-    types: [opened, synchronize, reopened, labeled, unlabeled]
-    branches:
-      - main
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+  pull_request_target:
+    # Label changes (including bot-applied) need pull_request_target
+    types: [labeled, unlabeled]
+    branches: [main]
+
   push:
-    branches:
-      - main
+    branches: [main]
+
   workflow_dispatch:
 
 env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,12 @@ on:
   # for all pull requests on main irrespective of file type or location
   # Use `changed-src-files` step to determine if source code was changed
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
     branches: [main]
 
   pull_request_target:
     # Label changes (including bot-applied) need pull_request_target
-    types: [labeled, unlabeled]
+    types: [labeled, unlabeled, auto_merge_enabled]
     branches: [main]
 
   push:
@@ -72,6 +72,8 @@ jobs:
               flags: "--timeout=300"
             os: "ubuntu-latest"
             python_version: "3.12"
+        # Exclude vLLM:main if PR does NOT have the ready label
+        exclude: ${{ github.event_name == 'pull_request' && !contains(toJson(github.event.pull_request.labels), '"ready"') && fromJSON('[{"vllm_version":{"name":"vLLM:main"}}]') || fromJSON('[]') }}
 
     name: "${{ matrix.test_suite.name }} (${{ matrix.vllm_version.name }})"
 
@@ -80,20 +82,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-
-      - name: "Skip vLLM:main if PR not ready"
-        if: matrix.vllm_version.name == 'vLLM:main' && github.event_name == 'pull_request'
-        run: |
-          PR_NUMBER=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
-          LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
-          if echo "$LABELS" | grep -qi '^ready$'; then
-            echo "ready label present — continuing"
-          else
-            echo "ready label missing — skipping vLLM:main"
-            exit 1
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Get changed source files"
         id: changed-src-files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,8 @@ on:
   # Use `changed-src-files` step to determine if source code was changed
   pull_request:
     # add labeled and unlabeled to the default types (runs when label is added)
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled, auto_merge_enabled]
     branches: [main]
-
-  pull_request_target:
-    # bot-applied label changes need to be triggered with pull_request_target.auto_merge_enabled
-    types: [auto_merge_enabled]
 
   push:
     branches: [main]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,11 @@ jobs:
     name: "${{ matrix.test_suite.name }} (${{ matrix.vllm_version.name }})"
 
     steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: "Skip vLLM:main if PR not ready"
         if: matrix.vllm_version.name == 'vLLM:main' && github.event_name == 'pull_request'
         run: |
@@ -89,11 +94,6 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: "Checkout"
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
 
       - name: "Get changed source files"
         id: changed-src-files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,8 +68,17 @@ jobs:
               flags: "--timeout=300"
             os: "ubuntu-latest"
             python_version: "3.12"
-        # Exclude vLLM:main if PR does NOT have the ready label
-        exclude: ${{ github.event_name == 'pull_request' && !contains(toJson(github.event.pull_request.labels), '"ready"') && fromJSON('[{"vllm_version":{"name":"vLLM:main"}}]') || fromJSON('[]') }}
+        # Exclude vLLM:main if PR is not ready or if auto-merge was enabled
+        exclude: >-
+          ${{ 
+            github.event_name == 'pull_request' &&
+            (
+              github.event.action == 'auto_merge_enabled' ||
+              !contains(toJson(github.event.pull_request.labels), '"ready"')
+            )
+              && fromJSON('[{"vllm_version":{"name":"vLLM:main"}}]')
+              || fromJSON('[]')
+          }}
 
 
     name: "${{ matrix.test_suite.name }} (${{ matrix.vllm_version.name }})"


### PR DESCRIPTION
### [tests] Triggering test agains vLLM:main for ready labels added by bot

previously PR #388 did only respect manually added `ready` labels. This PR extends the triggering the test against vLLM:main for `ready` labels added by the bot (by enabling auto-merge). 