### PR TITLE
[GHA] 🐛 fix: Save HF models cache for all jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,7 +164,7 @@ jobs:
           key: ${{ runner.os }}-hf-model-${{ env.model_key }}
 
       - name: "Download HF models"
-        if: steps.changed-src-files.outputs.any_changed == 'true'
+        if: steps.changed-src-files.outputs.any_changed == 'true' && steps.cache_restore.outputs.cache-hit != 'true'
         run: |
           # We are caching HF models (HF_HUB_CACHE) for reliability rather than speed, since HF downloads are flaky for concurrent jobs.
           # Be careful when adding models to the cache here, as the GHA cache is limited to 10 GB.
@@ -209,7 +209,7 @@ jobs:
           esac
 
       - name: "Save HF models cache"
-        if: ( steps.changed-src-files.outputs.any_changed == 'true' && github.event_name != 'pull_request' )
+        if: ( steps.changed-src-files.outputs.any_changed == 'true' && github.event_name != 'pull_request' && steps.cache_restore.outputs.cache-hit != 'true' )
         uses: actions/cache/save@v4
         with:
           path: ${{ env.model_path }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,7 +164,7 @@ jobs:
           key: ${{ runner.os }}-hf-model-${{ env.model_key }}
 
       - name: "Download HF models"
-        if: steps.changed-src-files.outputs.any_changed == 'true' && steps.cache_restore.outputs.cache-hit != 'true'
+        if: steps.changed-src-files.outputs.any_changed == 'true'
         run: |
           # We are caching HF models (HF_HUB_CACHE) for reliability rather than speed, since HF downloads are flaky for concurrent jobs.
           # Be careful when adding models to the cache here, as the GHA cache is limited to 10 GB.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
             vllm_spyre/**/*.py
 
       - name: "Install PyTorch 2.7.1"
-        if: (steps.changed-src-files.outputs.any_changed == 'true')
+        if: steps.changed-src-files.outputs.any_changed == 'true'
         run: |
           pip install torch=="2.7.1+cpu" --index-url https://download.pytorch.org/whl/cpu
 
@@ -122,7 +122,7 @@ jobs:
             pyproject.toml
 
       - name: "Set vLLM version"
-        if: (steps.changed-src-files.outputs.any_changed == 'true' && matrix.vllm_version.repo)
+        if: ( steps.changed-src-files.outputs.any_changed == 'true' && matrix.vllm_version.repo )
         run: |
           uv add ${{ matrix.vllm_version.repo }}
           echo "TEST_VLLM_VERSION=${{ matrix.vllm_version.name }}" >> "$GITHUB_ENV"
@@ -164,7 +164,7 @@ jobs:
           key: ${{ runner.os }}-hf-model-${{ env.model_key }}
 
       - name: "Download HF models"
-        if: steps.changed-src-files.outputs.any_changed == 'true' && steps.cache_restore.outputs.cache-hit != 'true'
+        if: ( steps.changed-src-files.outputs.any_changed == 'true' && steps.cache_restore.outputs.cache-hit != 'true' )
         run: |
           # We are caching HF models (HF_HUB_CACHE) for reliability rather than speed, since HF downloads are flaky for concurrent jobs.
           # Be careful when adding models to the cache here, as the GHA cache is limited to 10 GB.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,7 +209,7 @@ jobs:
           esac
 
       - name: "Save HF models cache"
-        if: ( steps.changed-src-files.outputs.any_changed == 'true' && github.event_name != 'pull_request' && strategy.job-index == 0 )
+        if: ( steps.changed-src-files.outputs.any_changed == 'true' && github.event_name != 'pull_request' )
         uses: actions/cache/save@v4
         with:
           path: ${{ env.model_path }}


### PR DESCRIPTION
### [GHA] 🐛 fix: Save HF models cache for all jobs

Since #393 , we only load a subset of the cached models instead of all. However, the condition in "Save HF models cache" assumed that all caches across the matrix are the same (as previously the case) and only saved the one for the first job. I removed that condition to save in all cases. 