### PR TITLE
[doc] 👨‍🎨 Adding drawings explaining optimizations 

### DIFF
--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -1109,6 +1109,12 @@ class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):
         return model_inputs
 
     def reduce_left_padding(self) -> None:
+        """ Optimizes the decode batch by removing entire columns that consist 
+        solely of left pads. This reduces unnecessary decode computation. 
+
+        Note: drawing explaining the optimization in more detail uploaded here:
+        https://github.com/vllm-project/vllm-spyre/pull/131#issuecomment-3233440852 
+        """
 
         requests = self.requests.values()
         if len(self.requests) == 0:

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -884,6 +884,9 @@ class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):
             tkv_offset = math.ceil(
                 (prompt_len - self.tkv) / self.block_size) * self.block_size
             if tkv_offset > 0:
+                # Note: drawing explaining this optimization in more detail
+                # can be found here (see page 3 in particular):
+                # https://github.com/vllm-project/vllm-spyre/pull/340#issuecomment-3179337304
                 logger.debug("Prefill optimization: Adding %d blocks per " \
                 "sequence in the decode batch to prefill the current " \
                 "sequence.", tkv_offset // self.block_size)

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -917,6 +917,9 @@ class ContinuousBatchingSpyreModelRunner(SpyreModelRunner):
         right_padding_tkv -= n_pad_blocks * self.block_size
         left_padding_tkv = self.tkv - n_pad_blocks * self.block_size
         if n_pad_blocks > 0:
+            # Note: drawing explaining this optimization in more detail can
+            # be found here (see page 2 in particular):
+            # https://github.com/vllm-project/vllm-spyre/pull/340#issuecomment-3179337304
             logger.debug("Prefill reduced by %d blocks due to optimization.",
                          n_pad_blocks)
 


### PR DESCRIPTION
### [doc] 👨‍🎨 Adding drawings explaining optimizations 

@joerunde's request to link my iPad [drawing](https://github.com/vllm-project/vllm-spyre/pull/363#issuecomment-3173605517) explaining the function in #363 in the code, made me think it might be useful to also link the drawings about the other optimizations I made. 

changes: 
- uploaded and linked [this](https://github.com/vllm-project/vllm-spyre/pull/131#issuecomment-3233440852) drawing explaining #131
- linked [this](https://github.com/vllm-project/vllm-spyre/pull/340#issuecomment-3179337304) drawing (page 3) explaining  #340 
- linked the [same](https://github.com/vllm-project/vllm-spyre/pull/340#issuecomment-3179337304) drawing (page 2) explaining #262
