### PR TITLE
:arrow_up: bump base image

### DIFF
--- a/docker/Dockerfile.amd64
+++ b/docker/Dockerfile.amd64
@@ -1,6 +1,6 @@
 # This is a reference dockerfile for vLLM Spyre support on an x86 host
 ARG BASE_IMAGE_URL="quay.io/ibm-aiu/spyre-base"
-ARG BASE_IMAGE_TAG="2025_07_30-amd64"
+ARG BASE_IMAGE_TAG="2025_08_21-amd64"
 
 ##############################################
 # Base


### PR DESCRIPTION
# Description

Bumps to the latest base image. Note these images have security vulnerabilities that we won't be fixing, we'll be transitioning off of them in the very bear future.