### PR TITLE
♻️ [tests] Full model testing

### DIFF
--- a/tests/aftu/test_compare_graphs.py
+++ b/tests/aftu/test_compare_graphs.py
@@ -12,15 +12,11 @@ from graph_compare_utils import (collect_graph_files, compare_graphs,
                                  get_aftu_script_dir, get_model_path,
                                  run_inference_py_and_get_graphs)
 from llm_cache import DecodeWarmupShapes
-from spyre_util import (generate_spyre_vllm_output, get_chicken_soup_prompts,
-                        get_spyre_model_list)
+from spyre_util import generate_spyre_vllm_output, get_chicken_soup_prompts
 from vllm import SamplingParams
 
 
 @pytest.mark.spyre
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize("max_num_seqs", [4],
-                         ids=lambda val: f"max_num_seqs({val})")
 def test_compare_graphs_cb(model: str, max_num_seqs: int,
                            monkeypatch: pytest.MonkeyPatch, use_llm_cache):
     """Test that the spyre worker correctly outputs
@@ -91,7 +87,6 @@ def test_compare_graphs_cb(model: str, max_num_seqs: int,
 
 
 @pytest.mark.spyre
-@pytest.mark.parametrize("model", get_spyre_model_list())
 @pytest.mark.parametrize(
     "warmup_shapes", [[(64, 4, 4)]])  # (prompt_length/new_tokens/batch_size)
 def test_compare_graphs_static_batching(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,7 @@ def pytest_generate_tests(metafunc):
 
 def _add_param(param_name: str, param_value, metafunc,
                existing_markers) -> None:
+    """helper function to parametrize stuff"""
     if (param_name in metafunc.fixturenames
             and param_name not in existing_markers):
         metafunc.parametrize(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,9 @@ def pytest_generate_tests(metafunc):
     ]
 
     marker = metafunc.config.option.markexpr  # From CLI
+    # TODO: make this condition better
+    # it can accidentally be triggered if we say
+    # -m "not full_model"
     if "full_model" in marker:
         # When -m full_model is called, all tests tagged with
         # full_model mark will be injected with these custom values
@@ -52,32 +55,18 @@ def pytest_generate_tests(metafunc):
                 metafunc,
                 existing_markers,
             )
-            if "not cb" in marker:
-                _add_param(
-                    "warmup_shapes",
-                    [[(1024, 20, 4)]],
-                    metafunc,
-                    existing_markers,
-                )
-                _add_param(
-                    "max_model_len",
-                    [2048],
-                    metafunc,
-                    existing_markers,
-                )
-            else:
-                _add_param(
-                    "max_model_len",
-                    default_max_model_len,
-                    metafunc,
-                    existing_markers,
-                )
-                _add_param(
-                    "warmup_shapes",
-                    default_warmup_shape,
-                    metafunc,
-                    existing_markers,
-                )
+            _add_param(
+                "warmup_shapes",
+                [[(1024, 20, 4)]],
+                metafunc,
+                existing_markers,
+            )
+            _add_param(
+                "max_model_len",
+                default_max_model_len,
+                metafunc,
+                existing_markers,
+            )
     else:
         # Default parameters
         _add_param("model", get_spyre_model_list(), metafunc, existing_markers)
@@ -108,6 +97,9 @@ def pytest_generate_tests(metafunc):
         existing_markers,
     )
 
+    # TODO: add both these using _add_param too
+    # Will need to do some fancy stuff to add custom
+    # markers
     if "cb" in metafunc.fixturenames and "cb" not in existing_markers:
         metafunc.parametrize(
             "cb", [pytest.param(1, marks=pytest.mark.cb, id="cb"), 0])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,34 +52,43 @@ def pytest_generate_tests(metafunc):
             for marker in metafunc.definition.own_markers
         ]
         # Default parameters
-        if "model" in metafunc.fixturenames and 'model' not in existing_markers:
+        if "model" in metafunc.fixturenames and "model" not in existing_markers:
             metafunc.parametrize("model", get_spyre_model_list())
 
-        if "backend" in metafunc.fixturenames and "backend" not in existing_markers:
+        if "backend" in metafunc.fixturenames and \
+            "backend" not in existing_markers:
             metafunc.parametrize("backend", get_spyre_backend_list())
 
-        if "warmup_shapes" in metafunc.fixturenames and "warmup_shapes" not in existing_markers:
+        if ("warmup_shapes" in metafunc.fixturenames
+                and "warmup_shapes" not in existing_markers):
             metafunc.parametrize(
                 "warmup_shapes",
                 default_warmup_shape,
                 ids=lambda val: f"warmup_shapes({val})",
             )
-        if "max_num_seqs" in metafunc.fixturenames and "max_num_seqs" not in existing_markers:
+
+        if ("max_num_seqs" in metafunc.fixturenames
+                and "max_num_seqs" not in existing_markers):
             metafunc.parametrize(
                 "max_num_seqs",
                 default_max_num_seqs,
                 ids=lambda val: f"max_num_seqs({val})",
             )
-        if "max_model_len" in metafunc.fixturenames and "max_model_len" not in existing_markers:
+
+        if ("max_model_len" in metafunc.fixturenames
+                and "max_model_len" not in existing_markers):
             metafunc.parametrize(
                 "max_model_len",
                 default_max_model_len,
                 ids=lambda val: f"max_model_len({val})",
             )
+
         if "cb" in metafunc.fixturenames and "cb" not in existing_markers:
             metafunc.parametrize(
                 "cb", [pytest.param(1, marks=pytest.mark.cb, id="cb"), 0])
-        if "tp_size" in metafunc.fixturenames and "tp_size" not in existing_markers:
+
+        if "tp_size" in metafunc.fixturenames and \
+            "tp_size" not in existing_markers:
             metafunc.parametrize(
                 "tp_size",
                 [
@@ -90,117 +99,6 @@ def pytest_generate_tests(metafunc):
                 ],
                 ids=lambda val: f"TP({val})",
             )
-
-        # if {"model", "backend", "warmup_shapes"}.issubset(metafunc.fixturenames):
-        # override full model specs
-        # params = list(itertools.product(get_spyre_model_list(), get_spyre_backend_list()))
-        # Override both x and y with new values
-        # params.append(
-        #     pytest.param(
-        #         "ibm-granite/granite-3.3-8b-instruct",
-        #         "sendnn",
-        #         marks=pytest.mark.full_model,
-        #     ),
-        # )
-        # else:
-        # #     # Default parameters
-        #     params = [get_spyre_model_list(), get_spyre_backend_list()]
-        # params = ["a", "b"]
-
-        # else:
-        #     params = [(get_spyre_model_list(), get_spyre_backend_list())]
-
-        # metafunc.parametrize(("model, backend"), params)
-
-    # existing_markers = [
-    #     marker.name if marker.name != "parametrize" else marker.args[0]
-    #     for marker in metafunc.definition.own_markers
-    # ]
-    # if "model" in metafunc.fixturenames and "model" not in existing_markers:
-    #     if metafunc.definition.get_closest_marker("test_with_full_model"):
-    #         # we append it here dynamically only to tests marked with
-    #         # the custom marker
-    #         model_list = get_spyre_model_list()
-    #         model_list.append(
-    #             pytest.param(
-    #                 "ibm-granite/granite-3.3-8b-instruct",
-    #                 marks=[pytest.mark.full_model],
-    #             ),
-    #         )
-    #         metafunc.parametrize("model", model_list)
-    #     else:
-    #         metafunc.parametrize("model", get_spyre_model_list())
-    # if (
-    #     "backend" in metafunc.fixturenames
-    #     and "backend" not in existing_markers
-    # ):
-    #     if metafunc.definition.get_closest_marker("test_with_full_model"):
-    #         # we append it here dynamically only to tests marked with
-    #         # the custom marker
-    #         backend_list = get_spyre_backend_list()
-    #         backend_list.append(
-    #             pytest.param("sendnn", marks=[pytest.mark.full_model]),
-    #         )
-    #         metafunc.parametrize("backend", backend_list)
-    #     else:
-    #         metafunc.parametrize("backend", get_spyre_backend_list())
-
-
-# models = ["model_a", "model_b"]
-# backends = ["backend_a", "backend_b"]
-
-# # Generate all combinations
-# combinations = zip(models, backends)
-
-# # For each combination, add a custom marker name
-# params = []
-# ids = []
-# for model, backend in combinations:
-#     marker = f"{model}_{backend}"
-#     param = pytest.param(
-#         model, backend, marks=pytest.mark.__getattr__(marker)
-#     )
-#     params.append(param)
-#     ids.append(marker)
-
-# metafunc.parametrize(("model", "backend"), params, ids=ids)
-
-# def pytest_generate_tests(metafunc):
-#     param_names = ("model", "backend")
-#     if metafunc.definition.get_closest_marker("full_model"):
-#         # Override parameters
-#         print("metafunc.fixturenames : ", metafunc.fixturenames)
-#         metafunc.parametrize("model", ["ibm-granite/granite-3.3-8b-instruct"])
-#         metafunc.parametrize("backend", ["sendnn"])
-#     else:
-#         # Check if any of the parameter names are already explicitly parametrized
-#         already_parametrized = set(metafunc.fixturenames) & set(param_names)
-#         print("already_parametrized :", already_parametrized)
-#         # assert 0
-#         if len(already_parametrized) == len(param_names):
-#             # parameters already exist on the test, return
-#             return
-#         # Default parameters
-#         if "model" in metafunc.fixturenames:
-#             metafunc.parametrize("model", get_spyre_model_list())
-#         if "backend" in metafunc.fixturenames:
-#             metafunc.parametrize("backend", get_spyre_backend_list())
-
-#     if metafunc.definition.get_closest_marker("full_model"):
-#         # Check if the test is marked with @pytest.mark.full_model
-#         # Override parameters
-#         metafunc.parametrize("model", ["ibm-granite/granite-3.3-8b-instruct"])
-#     else:
-#         # Default parameters
-#         metafunc.parametrize("model", get_spyre_model_list())
-# if "backend" in metafunc.fixturenames:
-#     # Check if the test is marked with @pytest.mark.full_model
-#     if metafunc.definition.get_closest_marker("full_model"):
-#         # Override parameters
-#         metafunc.parametrize("backend", ["sendnn"])
-#     else:
-#         # Default parameters
-#         metafunc.parametrize("backend", get_spyre_backend_list())
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,7 @@ def pytest_generate_tests(metafunc):
             )
     else:
         # Default parameters
-        _add_param("model", get_spyre_model_list, metafunc, existing_markers)
+        _add_param("model", get_spyre_model_list(), metafunc, existing_markers)
         _add_param(
             "backend",
             get_spyre_backend_list(),
@@ -136,7 +136,7 @@ def _add_param(param_name: str, param_value, metafunc,
         metafunc.parametrize(
             param_name,
             param_value,
-            ids=lambda val: f"{param_name}({val}))",
+            ids=lambda val: f"{param_name}({val})",
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,11 @@ os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 
 def pytest_generate_tests(metafunc):
+    """This hook is called during the collection phase, 
+    specifically when Pytest encounters a test function that 
+    needs parametrization. It receives a metafunc object, 
+    which provides information about the test function and 
+    allows for dynamic parametrization."""
 
     # default parameterizations
     default_warmup_shape = [[(64, 20, 4)]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,12 +61,6 @@ def pytest_generate_tests(metafunc):
                 metafunc,
                 existing_markers,
             )
-            _add_param(
-                "max_model_len",
-                default_max_model_len,
-                metafunc,
-                existing_markers,
-            )
     else:
         # Default parameters
         _add_param("model", get_spyre_model_list(), metafunc, existing_markers)
@@ -82,14 +76,15 @@ def pytest_generate_tests(metafunc):
             metafunc,
             existing_markers,
         )
-        _add_param(
-            "max_model_len",
-            default_max_model_len,
-            metafunc,
-            existing_markers,
-        )
 
     # apply to all
+    _add_param(
+        "max_model_len",
+        default_max_model_len,
+        metafunc,
+        existing_markers,
+    )
+
     _add_param(
         "max_num_seqs",
         default_max_num_seqs,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def pytest_addoption(parser):
         "--test-mode",
         action="store",
         default="micro",
-        choices=["micro", "full"],
+        choices=["micro", "full_sb", "full_cb"],
         help="Choose test mode",
     )
 
@@ -41,7 +41,7 @@ def pytest_generate_tests(metafunc):
     ]
 
     mode = metafunc.config.getoption("test_mode")  # from CLI
-    if mode == "full":
+    if "full" in mode:
         if metafunc.definition.get_closest_marker("full_model"):
             _add_param(
                 "model",
@@ -55,6 +55,7 @@ def pytest_generate_tests(metafunc):
                 metafunc,
                 existing_markers,
             )
+        if mode == "full_sb":
             _add_param(
                 "warmup_shapes",
                 [[(1024, 20, 4)]],
@@ -64,6 +65,19 @@ def pytest_generate_tests(metafunc):
             _add_param(
                 "max_model_len",
                 [2048],
+                metafunc,
+                existing_markers,
+            )
+        if mode == "full_cb":
+            _add_param(
+                "max_model_len",
+                default_max_model_len,
+                metafunc,
+                existing_markers,
+            )
+            _add_param(
+                "warmup_shapes",
+                default_warmup_shape,
                 metafunc,
                 existing_markers,
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,7 +128,9 @@ def pytest_generate_tests(metafunc):
 
 def _add_param(param_name: str, param_value, metafunc,
                existing_markers) -> None:
-    """helper function to parametrize stuff"""
+    """helper function to parametrize stuff.
+    We make sure to not parametrize something 
+    if it exists explicitly on the test"""
     if (param_name in metafunc.fixturenames
             and param_name not in existing_markers):
         metafunc.parametrize(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,7 +100,7 @@ def pytest_generate_tests(metafunc):
             existing_markers,
         )
 
-    # apply to both
+    # apply to all
     _add_param(
         "max_num_seqs",
         default_max_num_seqs,

--- a/tests/e2e/test_spyre_async_llm.py
+++ b/tests/e2e/test_spyre_async_llm.py
@@ -3,8 +3,7 @@ from contextlib import ExitStack
 
 import pytest
 from llm_cache import DecodeWarmupShapes
-from spyre_util import (get_chicken_soup_prompts, get_spyre_backend_list,
-                        get_spyre_model_list)
+from spyre_util import (get_chicken_soup_prompts)
 from vllm import PromptType, SamplingParams
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine
@@ -46,13 +45,6 @@ async def generate(
     return count, request_id
 
 
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
-@pytest.mark.parametrize("cb",
-                         [pytest.param(1, marks=pytest.mark.cb, id="cb"), 0])
-@pytest.mark.parametrize("warmup_shapes", [[
-    (64, 20, 4),
-]])
 @pytest.mark.parametrize(
     "output_kind", [RequestOutputKind.DELTA, RequestOutputKind.FINAL_ONLY])
 @pytest.mark.asyncio

--- a/tests/e2e/test_spyre_async_llm.py
+++ b/tests/e2e/test_spyre_async_llm.py
@@ -3,7 +3,7 @@ from contextlib import ExitStack
 
 import pytest
 from llm_cache import DecodeWarmupShapes
-from spyre_util import (get_chicken_soup_prompts)
+from spyre_util import get_chicken_soup_prompts
 from vllm import PromptType, SamplingParams
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine

--- a/tests/e2e/test_spyre_basic.py
+++ b/tests/e2e/test_spyre_basic.py
@@ -6,9 +6,8 @@ Run `python -m pytest tests/e2e/test_spyre_basic.py`.
 import pytest
 from llm_cache import DecodeWarmupShapes
 from spyre_util import (check_output_against_hf, create_random_request,
-                        default_sb_cb_params, generate_spyre_vllm_output,
-                        get_chicken_soup_prompts, get_spyre_backend_list,
-                        get_spyre_model_list, skip_unsupported_tp_size)
+                        generate_spyre_vllm_output, get_chicken_soup_prompts,
+                        skip_unsupported_tp_size)
 from vllm import EngineArgs, SamplingParams
 from vllm.v1.engine.core import EngineCore
 from vllm.v1.executor.abstract import Executor
@@ -16,19 +15,7 @@ from vllm.v1.executor.abstract import Executor
 from vllm_spyre.v1.core.scheduler import StaticBatchingSpyreScheduler
 
 
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize(
-    "tp_size",
-    [
-        pytest.param(1),
-        pytest.param(2, marks=pytest.mark.multi),
-        pytest.param(4, marks=pytest.mark.multi),
-        pytest.param(8, marks=pytest.mark.multi),
-    ],
-    ids=lambda val: f"TP({val})",
-)
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
-@default_sb_cb_params
+@pytest.mark.full_model
 def test_output(model: str, tp_size: int, backend: str, cb: int,
                 max_num_seqs: int, max_model_len: int,
                 warmup_shapes: DecodeWarmupShapes,
@@ -79,9 +66,6 @@ def test_output(model: str, tp_size: int, backend: str, cb: int,
                             prompts)
 
 
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize(
-    "warmup_shapes", [[(64, 20, 4)]])  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend", [
     pytest.param(
         "sendnn_decoder", marks=pytest.mark.spyre, id="sendnn_decoder")
@@ -117,9 +101,6 @@ def test_output_sendnn_decoder(model: str, warmup_shapes: DecodeWarmupShapes,
                             prompts)
 
 
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
-@default_sb_cb_params
 def test_batch_handling(model: str, backend: str, cb: int, warmup_shapes,
                         max_num_seqs: int, max_model_len: int,
                         monkeypatch: pytest.MonkeyPatch, use_llm_cache):
@@ -166,8 +147,6 @@ def test_batch_handling(model: str, backend: str, cb: int, warmup_shapes,
                             prompts)
 
 
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
 def test_full_batch_scheduling(model: str, backend: str, monkeypatch):
     """Test that we can schedule a full batch of prompts."""
 

--- a/tests/e2e/test_spyre_cb.py
+++ b/tests/e2e/test_spyre_cb.py
@@ -13,16 +13,13 @@ from openai import BadRequestError
 from spyre_util import (RemoteOpenAIServer, check_output_against_hf,
                         compare_results, create_seq_prompt, extract_output,
                         generate_spyre_vllm_output, get_chicken_soup_prompts,
-                        get_spyre_model_list, skip_unsupported_tp_size)
+                        skip_unsupported_tp_size)
 from vllm import LLM, SamplingParams
 
 
-@pytest.mark.parametrize("model", get_spyre_model_list())
 @pytest.mark.cb
 @pytest.mark.parametrize(
     "backend", [pytest.param("eager", marks=pytest.mark.cpu, id="eager")])
-@pytest.mark.parametrize("max_num_seqs", [4])
-@pytest.mark.parametrize("max_model_len", [256])
 def test_cb_max_tokens(model: str, backend: str, max_model_len: int,
                        max_num_seqs: int, monkeypatch: pytest.MonkeyPatch,
                        use_llm_cache):
@@ -51,9 +48,6 @@ def test_cb_max_tokens(model: str, backend: str, max_model_len: int,
 
 @pytest.mark.cb
 @pytest.mark.parametrize("cb", [True])
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize("max_model_len", [256])
-@pytest.mark.parametrize("max_num_seqs", [4])
 @pytest.mark.parametrize(
     "backend", [pytest.param("eager", marks=pytest.mark.cpu, id="eager")])
 def test_api_cb_rejects_oversized_request(
@@ -81,9 +75,6 @@ def test_api_cb_rejects_oversized_request(
 
 @pytest.mark.cb
 @pytest.mark.parametrize("cb", [True])
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize("max_model_len", [256])
-@pytest.mark.parametrize("max_num_seqs", [4])
 @pytest.mark.parametrize(
     "backend", [pytest.param("eager", marks=pytest.mark.cpu, id="eager")])
 def test_api_cb_generates_correct_max_tokens(
@@ -109,7 +100,6 @@ def test_api_cb_generates_correct_max_tokens(
 
 @pytest.mark.compiler_support_16k
 @pytest.mark.cb
-@pytest.mark.parametrize("model", get_spyre_model_list())
 @pytest.mark.parametrize(
     "backend", [pytest.param("sendnn", marks=pytest.mark.spyre, id="sendnn")])
 @pytest.mark.parametrize(

--- a/tests/e2e/test_spyre_cb_scheduler_steps.py
+++ b/tests/e2e/test_spyre_cb_scheduler_steps.py
@@ -8,13 +8,10 @@ Run `python -m pytest tests/e2e/test_spyre_cb_inference_steps.py`.
 
 import pytest
 from scheduling_utils import check_scheduler_inference_steps
-from spyre_util import (check_output_against_hf, get_spyre_backend_list,
-                        get_spyre_model_list)
+from spyre_util import (check_output_against_hf)
 
 
 @pytest.mark.cb
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
 # These values are all parameterized for test sorting
 @pytest.mark.parametrize("max_num_seqs", [2])
 @pytest.mark.parametrize("max_model_len", [192])
@@ -175,8 +172,6 @@ def test_prompts_aligned_with_tkv_boundaries(model: str, backend: str,
 
 
 @pytest.mark.cb
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
 # These values are all parameterized for test sorting
 @pytest.mark.parametrize("max_num_seqs", [2])
 @pytest.mark.parametrize("max_model_len", [128])
@@ -333,8 +328,6 @@ def test_prompts_misaligned_with_tkv_boundaries(
 
 
 @pytest.mark.cb
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
 # These values are all parameterized for test sorting
 @pytest.mark.parametrize("max_num_seqs", [2])
 @pytest.mark.parametrize("max_model_len", [128])
@@ -480,8 +473,6 @@ def test_two_sequences_finish_same_time_as_new_arrive(
 
 
 @pytest.mark.cb
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
 # These values are all parameterized for test sorting
 @pytest.mark.parametrize("max_num_seqs", [3])
 @pytest.mark.parametrize("max_model_len", [192])
@@ -664,8 +655,6 @@ def test_new_sequence_joins_during_decode(model: str, backend: str,
 
 
 @pytest.mark.cb
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
 @pytest.mark.parametrize("prefill_optimization", [True, False])
 # These values are all parameterized for test sorting
 @pytest.mark.parametrize("max_num_seqs", [2])
@@ -888,8 +877,6 @@ def test_prompt_too_long_for_current_tkv(model: str, backend: str,
 
 
 @pytest.mark.cb
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
 # These values are all parameterized for test sorting
 @pytest.mark.parametrize("max_num_seqs", [2])
 @pytest.mark.parametrize("max_model_len",
@@ -1058,8 +1045,6 @@ def test_prefill_optimization_tkv_too_big(model: str, backend: str,
 
 
 @pytest.mark.cb
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
 # These values are all parameterized for test sorting
 @pytest.mark.parametrize("max_num_seqs", [2])
 @pytest.mark.parametrize("max_model_len", [128])
@@ -1197,8 +1182,6 @@ def test_prefill_optimization_use_more_than_available_blocks(
 
 
 @pytest.mark.cb
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
 # These values are all parameterized for test sorting
 @pytest.mark.parametrize("max_num_seqs", [2])
 @pytest.mark.parametrize("max_model_len", [128])
@@ -1368,8 +1351,6 @@ def test_requested_tokens_not_fitting_remaining_space(
 
 
 @pytest.mark.cb
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
 # These values are all parameterized for test sorting
 @pytest.mark.parametrize("max_num_seqs", [4])
 @pytest.mark.parametrize("max_model_len", [128])
@@ -1508,8 +1489,6 @@ def test_requests_use_all_available_blocks(model: str, backend: str,
 
 
 @pytest.mark.cb
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
 # These values are all parameterized for test sorting
 @pytest.mark.parametrize("max_num_seqs", [4])
 @pytest.mark.parametrize("max_model_len", [128])
@@ -1674,8 +1653,6 @@ def test_requests_use_more_than_available_blocks(
 
 
 @pytest.mark.cb
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
 @pytest.mark.parametrize("max_num_seqs", [2])
 @pytest.mark.parametrize("max_model_len", [192])
 @pytest.mark.parametrize("available_blocks", [16])  # no restriction
@@ -1805,8 +1782,6 @@ def test_requests_use_full_batch_tkv_limit(model: str, backend: str,
 
 
 @pytest.mark.cb
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
 @pytest.mark.parametrize("max_num_seqs", [2])
 @pytest.mark.parametrize("max_model_len", [192])
 @pytest.mark.parametrize("available_blocks", [16])  # no restriction

--- a/tests/e2e/test_spyre_cb_scheduler_steps.py
+++ b/tests/e2e/test_spyre_cb_scheduler_steps.py
@@ -8,7 +8,7 @@ Run `python -m pytest tests/e2e/test_spyre_cb_inference_steps.py`.
 
 import pytest
 from scheduling_utils import check_scheduler_inference_steps
-from spyre_util import (check_output_against_hf)
+from spyre_util import check_output_against_hf
 
 
 @pytest.mark.cb

--- a/tests/e2e/test_spyre_embeddings.py
+++ b/tests/e2e/test_spyre_embeddings.py
@@ -8,9 +8,8 @@ from functools import partial
 import pytest
 from llm_cache import EmbeddingWarmupShapes
 from spyre_util import (compare_embedding_results, get_chicken_soup_prompts,
-                        get_spyre_backend_list, get_spyre_model_list,
-                        patch_warmup_shapes, spyre_vllm_embeddings,
-                        st_embeddings)
+                        get_spyre_model_list, patch_warmup_shapes,
+                        spyre_vllm_embeddings, st_embeddings)
 from vllm import LLM
 
 
@@ -23,7 +22,6 @@ from vllm import LLM
         pytest.param([(128, 4)]),
         pytest.param([(128, 8)])
     ])
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
 def test_output(
     model: str,
     warmup_shapes: EmbeddingWarmupShapes,
@@ -64,7 +62,6 @@ def test_output(
     [(128, 2)],
     [(128, 4)],
 ])  # (prompt_length/batch_size)
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
 @pytest.mark.parametrize("model", get_spyre_model_list(isEmbeddings=True))
 def test_scheduling_invariance(
     model,

--- a/tests/e2e/test_spyre_max_new_tokens.py
+++ b/tests/e2e/test_spyre_max_new_tokens.py
@@ -5,16 +5,12 @@ Run `python -m pytest tests/e2e/test_spyre_max_new_tokens.py`.
 
 import pytest
 from llm_cache import DecodeWarmupShapes
-from spyre_util import (check_output_against_hf, default_sb_cb_params,
-                        generate_spyre_vllm_output, get_chicken_soup_prompts,
-                        get_spyre_backend_list, get_spyre_model_list)
+from spyre_util import (check_output_against_hf, generate_spyre_vllm_output,
+                        get_chicken_soup_prompts)
 from vllm import SamplingParams
 
 
-@pytest.mark.parametrize("model", get_spyre_model_list())
 @pytest.mark.parametrize("stop_last", [True, False])
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
-@default_sb_cb_params
 def test_output(model: str, stop_last: bool, max_model_len: int,
                 max_num_seqs: int, warmup_shapes: DecodeWarmupShapes,
                 backend: str, cb: int, monkeypatch: pytest.MonkeyPatch,

--- a/tests/e2e/test_spyre_online.py
+++ b/tests/e2e/test_spyre_online.py
@@ -1,7 +1,5 @@
 import openai
 import pytest
-from spyre_util import (default_sb_cb_params, get_spyre_backend_list,
-                        get_spyre_model_list)
 
 
 def _check_result(client, model, max_tokens=8, temperature=0.0, n=1) -> None:
@@ -16,19 +14,6 @@ def _check_result(client, model, max_tokens=8, temperature=0.0, n=1) -> None:
     assert len(completion.choices[0].text) > 0
 
 
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize(
-    "tp_size",
-    [
-        pytest.param(1, marks=pytest.mark.basic),
-        pytest.param(2, marks=pytest.mark.multi),
-        pytest.param(4, marks=pytest.mark.multi),
-        pytest.param(8, marks=pytest.mark.multi),
-    ],
-    ids=lambda val: f"TP({val})",
-)
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
-@default_sb_cb_params
 def test_openai_serving(
     remote_openai_server,
     model,

--- a/tests/e2e/test_spyre_prompt_logprobs.py
+++ b/tests/e2e/test_spyre_prompt_logprobs.py
@@ -8,8 +8,7 @@ import pytest
 import torch
 import torch.nn.functional
 from llm_cache import force_engine_shutdown
-from spyre_util import (get_chicken_soup_prompts, get_spyre_backend_list,
-                        get_spyre_model_list, skip_unsupported_tp_size)
+from spyre_util import (get_chicken_soup_prompts, skip_unsupported_tp_size)
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from vllm import LLM, RequestOutput, SamplingParams
 from vllm.config import ModelConfig, VllmConfig
@@ -17,14 +16,6 @@ from vllm.config import ModelConfig, VllmConfig
 from vllm_spyre.platform import SpyrePlatform
 
 
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize("tp_size", [
-    pytest.param(1),
-    pytest.param(2, marks=pytest.mark.multi),
-    pytest.param(4, marks=pytest.mark.multi)
-],
-                         ids=lambda val: f"TP({val})")
 # Skip for now until prompt logprobs are fixed
 @pytest.mark.skip
 def test_prompt_logprobs(backend: str, model: str, tp_size: int,
@@ -74,7 +65,6 @@ def test_prompt_logprobs_must_be_enabled(monkeypatch: pytest.MonkeyPatch):
 
 @pytest.mark.cpu
 @pytest.mark.decoder
-@pytest.mark.parametrize("model", get_spyre_model_list())
 def test_prompt_logprobs_not_supported_with_cb(
         model: str, monkeypatch: pytest.MonkeyPatch):
     # Server shouldn't boot with both prompt logprobs and continuous batching
@@ -88,7 +78,6 @@ def test_prompt_logprobs_not_supported_with_cb(
 
 @pytest.mark.cpu
 @pytest.mark.decoder
-@pytest.mark.parametrize("model", get_spyre_model_list())
 def test_prompt_logprobs_on_single_requests_only(
         model: str, monkeypatch: pytest.MonkeyPatch):
     # Only bs=1 is supported for prompt logprobs

--- a/tests/e2e/test_spyre_prompt_logprobs.py
+++ b/tests/e2e/test_spyre_prompt_logprobs.py
@@ -8,7 +8,7 @@ import pytest
 import torch
 import torch.nn.functional
 from llm_cache import force_engine_shutdown
-from spyre_util import (get_chicken_soup_prompts, skip_unsupported_tp_size)
+from spyre_util import get_chicken_soup_prompts, skip_unsupported_tp_size
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from vllm import LLM, RequestOutput, SamplingParams
 from vllm.config import ModelConfig, VllmConfig

--- a/tests/e2e/test_spyre_seed.py
+++ b/tests/e2e/test_spyre_seed.py
@@ -7,17 +7,12 @@ import math
 
 import pytest
 from llm_cache import DecodeWarmupShapes
-from spyre_util import (default_sb_cb_params, generate_spyre_vllm_output,
-                        get_chicken_soup_prompts, get_spyre_backend_list,
-                        get_spyre_model_list)
+from spyre_util import (generate_spyre_vllm_output, get_chicken_soup_prompts)
 from vllm import SamplingParams
 
 
-@pytest.mark.parametrize("model", get_spyre_model_list())
 @pytest.mark.parametrize("temperature", [0.1, 1.0])
 @pytest.mark.parametrize("seed", [42])
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
-@default_sb_cb_params
 def test_seed(model: str, temperature: float, seed: int, max_model_len: int,
               max_num_seqs: int, warmup_shapes: DecodeWarmupShapes,
               backend: str, cb: int, monkeypatch: pytest.MonkeyPatch,

--- a/tests/e2e/test_spyre_seed.py
+++ b/tests/e2e/test_spyre_seed.py
@@ -7,7 +7,7 @@ import math
 
 import pytest
 from llm_cache import DecodeWarmupShapes
-from spyre_util import (generate_spyre_vllm_output, get_chicken_soup_prompts)
+from spyre_util import generate_spyre_vllm_output, get_chicken_soup_prompts
 from vllm import SamplingParams
 
 

--- a/tests/e2e/test_spyre_stagger_basic.py
+++ b/tests/e2e/test_spyre_stagger_basic.py
@@ -5,26 +5,11 @@ Run `python -m pytest tests/e2e/test_stagger_spyre_basic.py`.
 """
 
 import pytest
-from spyre_util import (check_output_against_hf, default_sb_cb_params,
-                        generate_spyre_vllm_output, get_chicken_soup_prompts,
-                        get_spyre_backend_list, get_spyre_model_list,
-                        skip_unsupported_tp_size)
+from spyre_util import (check_output_against_hf, generate_spyre_vllm_output,
+                        get_chicken_soup_prompts, skip_unsupported_tp_size)
 from vllm import SamplingParams
 
 
-@pytest.mark.parametrize("model", get_spyre_model_list())
-@pytest.mark.parametrize(
-    "tp_size",
-    [
-        pytest.param(1),
-        pytest.param(2, marks=pytest.mark.multi),
-        pytest.param(4, marks=pytest.mark.multi),
-        pytest.param(8, marks=pytest.mark.multi),
-    ],
-    ids=lambda val: f"TP({val})",
-)
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
-@default_sb_cb_params
 def test_stagger_output(model: str, tp_size: int, backend: str, cb: int,
                         max_num_seqs: int, max_model_len: int, warmup_shapes,
                         monkeypatch: pytest.MonkeyPatch,

--- a/tests/e2e/test_spyre_static_batching_limits.py
+++ b/tests/e2e/test_spyre_static_batching_limits.py
@@ -5,17 +5,14 @@ Run `python -m pytest tests/e2e/test_spyre_max_prompt_length.py`.
 
 import pytest
 from llm_cache import DecodeWarmupShapes
-from spyre_util import (create_text_prompt, get_cached_llm,
-                        get_spyre_backend_list, get_spyre_model_list)
+from spyre_util import (create_text_prompt, get_cached_llm)
 from vllm import SamplingParams
 
 
-@pytest.mark.parametrize("model", get_spyre_model_list())
 @pytest.mark.parametrize(
     "warmup_shapes",
     [[(64, 20, 4)], [(64, 20, 4),
                      (128, 20, 2)]])  # (prompt_length/new_tokens/batch_size)
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
 def test_max_prompt_len_and_new_tokens(model: str,
                                        warmup_shapes: DecodeWarmupShapes,
                                        backend: str, use_llm_cache,

--- a/tests/e2e/test_spyre_static_batching_limits.py
+++ b/tests/e2e/test_spyre_static_batching_limits.py
@@ -5,7 +5,7 @@ Run `python -m pytest tests/e2e/test_spyre_max_prompt_length.py`.
 
 import pytest
 from llm_cache import DecodeWarmupShapes
-from spyre_util import (create_text_prompt, get_cached_llm)
+from spyre_util import create_text_prompt, get_cached_llm
 from vllm import SamplingParams
 
 

--- a/tests/e2e/test_spyre_warmup_shapes.py
+++ b/tests/e2e/test_spyre_warmup_shapes.py
@@ -6,16 +6,13 @@ Run `python -m pytest tests/e2e/test_spyre_warmup_shapes.py`.
 import pytest
 from llm_cache import DecodeWarmupShapes
 from spyre_util import (check_output_against_hf, generate_spyre_vllm_output,
-                        get_chicken_soup_prompts, get_spyre_backend_list,
-                        get_spyre_model_list)
+                        get_chicken_soup_prompts)
 from vllm import SamplingParams
 
 
-@pytest.mark.parametrize("model", get_spyre_model_list())
 @pytest.mark.parametrize(
     "warmup_shapes", [[(64, 20, 4),
                        (128, 20, 2)]])  # (prompt_length/new_tokens/batch_size)
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
 def test_multiple_warmup_shapes(model: str, warmup_shapes: DecodeWarmupShapes,
                                 backend: str, monkeypatch: pytest.MonkeyPatch,
                                 use_llm_cache) -> None:
@@ -58,10 +55,8 @@ def test_multiple_warmup_shapes(model: str, warmup_shapes: DecodeWarmupShapes,
                             prompts)
 
 
-@pytest.mark.parametrize("model", get_spyre_model_list())
 @pytest.mark.parametrize("prompts", [["Hello"]])
 @pytest.mark.parametrize("warmup_shapes", [[(65, 1, 1)]])
-@pytest.mark.parametrize("backend", get_spyre_backend_list())
 def test_invalid_prompt_len(model: str, prompts: list[str],
                             warmup_shapes: DecodeWarmupShapes, backend: str,
                             monkeypatch: pytest.MonkeyPatch,

--- a/tests/spyre_util.py
+++ b/tests/spyre_util.py
@@ -64,28 +64,6 @@ def extract_output(req_output):
     return result
 
 
-def default_sb_cb_params(test_func):
-    """Decorate a test function with the default parameterizations for:
-    - warmup shapes for static batching
-    - max model length and max batch size for continuous batching
-    
-    Setting these defaults in one place helps ensure that most test reuse the
-    same config, allowing us to cache more loaded models.
-    """
-    test_func = pytest.mark.parametrize(
-        "cb", [pytest.param(1, marks=pytest.mark.cb, id="cb"), 0])(test_func)
-    test_func = pytest.mark.parametrize(
-        "max_model_len", [256],
-        ids=lambda val: f"max_model_len({val})")(test_func)
-    test_func = pytest.mark.parametrize(
-        "max_num_seqs", [4], ids=lambda val: f"max_num_seqs({val})")(test_func)
-    test_func = pytest.mark.parametrize(
-        "warmup_shapes", [[(64, 20, 4)]],
-        ids=lambda val: f"warmup_shapes({val})")(test_func)
-
-    return test_func
-
-
 # vLLM / Spyre
 def generate_spyre_vllm_output(
     model: str,

--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -2,7 +2,6 @@ import inspect
 import os
 
 import pytest
-from spyre_util import get_spyre_model_list
 
 from vllm_spyre.compat_utils import dataclass_fields
 
@@ -33,7 +32,6 @@ def test_vllm_bert_support():
 
 
 @pytest.mark.cpu
-@pytest.mark.parametrize("model", get_spyre_model_list())
 def test_model_config_task(model: str):
 
     from vllm.engine.arg_utils import EngineArgs


### PR DESCRIPTION
# Description

Introduces `pytest_generate_tests` - [pytest_generate_tests](https://docs.pytest.org/en/latest/how-to/parametrize.html#pytest-generate-tests) allows one to define custom parametrization schemes or extensions.

`pytest_generate_tests` is called when collecting a test function. Through the passed in `metafunc` object you can inspect the requesting test context and, most importantly, you can call `metafunc.parametrize()` to cause parametrization.

This was required for full model testing, in which case we want some of the parameters to change based on certain runtime configurations.


Running `pytest -m "full_model and cb"` will inject `full_model` CB arguments into the test marked with `full_model` .

_Note: We make sure to not parametrize something if it exists explicitly on the test._

⚠️ ⚠️ ⚠️ 

> SB with full model testing is broken since SB is picking up `--max-model-len` parameter instead of overriding it based on the warmup shapes. I have opened an issue on our internal board for this.