### PR TITLE
🎨 add info about DT_DEEPRT_VERBOSE

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -130,9 +130,14 @@ Various log levels that can be configured:
 - `DTLOG_LEVEL` - `TRACE, DEBUG, INFO, WARNING, ERROR`
 - `TORCH_SENDNN_LOG` - `WARNING, CRITICAL`
 - `VLLM_LOGGING_LEVEL` - `DEBUG, INFO, WARNING, ERROR`
+- `DT_DEEPRT_VERBOSE` - `0, -1` 
 
 !!! tip
     `DTLOG_LEVEL=INFO` (piped to file) can help you see what device addresses are actually in use. Look for the string `Opened: SEN:VFIO`.
+
+!!! tip
+
+    Set `DT_DEEPRT_VERBOSE` to 0 to enable verbose compiler prints for debugging.
 
 !!! tip
     In order to stop massive log spew, this configuration is ideal:


### PR DESCRIPTION
# Description

Add info about DT_DEEPRT_VERBOSE. Enables verbose compiler prints
