### PR TITLE
:bug: fixup compilation wrapper

### DIFF
--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -85,7 +85,7 @@ def _maybe_warmup_context(limit: int, world_size: int, rank: int):
     # method on warmup_context
     functools.update_wrapper(__stagger_exit__, sendnn_exit)
     # Replace `warmup_context.__exit__` with our new wrapper
-    warmup_context.__exit__ = __stagger_exit__
+    warmup_context.__exit__ = __stagger_exit__  # type: ignore[method-assign]
 
     with warmup_context():
         _inside_warmup_mode = True

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -81,7 +81,12 @@ def _maybe_warmup_context(limit: int, world_size: int, rank: int):
         with utils_spyre.stagger_region(limit, world_size, rank):
             sendnn_exit(*args, **kwargs)
 
+    # Use update_wrapper to make __stagger_exit__ look like a proper instance
+    # method on warmup_context
     functools.update_wrapper(__stagger_exit__, sendnn_exit)
+    # Replace `warmup_context.__exit__` with our new wrapper
+    warmup_context.__exit__ = __stagger_exit__
+
     with warmup_context():
         _inside_warmup_mode = True
         yield


### PR DESCRIPTION
# Description

After properly updating the stagger wrapper we forgot to actually assign it back to the warmup mode's exit method. This passes manually on my dev pod and looks like it does stagger the exit of warmup_mode

cc @jberkhahn 