### PR TITLE
CI: Show isort diff

### DIFF
--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -34,10 +34,9 @@ jobs:
           echo "::add-matcher::.github/workflows/matchers/ruff.json"
           ruff check --output-format github .
       - name: Run isort
-        # using `always()` here ensures all the checks run even if previous
-        # checks fail
+        # `if: always()` ensures all checks run even if previous checks fail
         if: always()
-        run: isort . --check-only
+        run: isort . --check --diff
       - name: run yapf
         if: always()
         run: yapf --diff --recursive .


### PR DESCRIPTION
# Description

As part of the `lint-code` CI check, `isort` will raise errors if import statements are not well organized.

However it does not reveal how to fix them. This change will ensure the corrected imports are visible in the CI logs.

## Related Issues

N/A
