### PR TITLE
chore: Use Python 3.11 by default for type-check

### DIFF
--- a/tools/type_check.sh
+++ b/tools/type_check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CI=${1:-0}
-PYTHON_VERSION=${2:-3.9}
+PYTHON_VERSION=${2:-3.11}
 
 if [ "$CI" -eq 1 ]; then
     set -e


### PR DESCRIPTION
# Description

Currently, type-check with `mypy` defaults to Python 3.9 which generates incorrect type hint errors and we longer support Python 3.9 (or 3.10)

## Related Issues

N/A
