### PR TITLE
🎨 make available_blocks as 18 in scheduler test

### DIFF
--- a/tests/e2e/test_spyre_cb_scheduler_steps.py
+++ b/tests/e2e/test_spyre_cb_scheduler_steps.py
@@ -480,7 +480,7 @@ def test_two_sequences_finish_same_time_as_new_arrive(
 # These values are all parameterized for test sorting
 @pytest.mark.parametrize("max_num_seqs", [3])
 @pytest.mark.parametrize("max_model_len", [192])
-@pytest.mark.parametrize("available_blocks", [16])  # no restriction
+@pytest.mark.parametrize("available_blocks", [18])  # no restriction
 def test_new_sequence_joins_during_decode(model: str, backend: str,
                                           monkeypatch: pytest.MonkeyPatch,
                                           set_random_seed, max_num_seqs: int,


### PR DESCRIPTION
# Description

With `16` as the value the test seemed to fail on Spyre hardware. Maybe `available_blocks` needs to be a multiple of BS?

FYI both `"available_blocks", [15])` and `"available_blocks", [18])` work with BS 3. So the assumption that available_blocks needs to be a multiple of BS seems accurate.

## Related Issues

<!-- Link related issues e.g. `Fixes #<issue>` -->
