### PR TITLE
:goal_net: disallow compilation in certain cases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
           - name: "worker and utils"
             markers: "not e2e"
             flags: "--timeout=300"
+            hf_models: "JackFram/llama-160m"
           - name: "compatibility"
             markers: "compat"
             flags: "--timeout=300"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,6 @@ jobs:
           - name: "worker and utils"
             markers: "not e2e"
             flags: "--timeout=300"
-            hf_models: "JackFram/llama-160m"
           - name: "compatibility"
             markers: "compat"
             flags: "--timeout=300"

--- a/tests/spyre_util.py
+++ b/tests/spyre_util.py
@@ -433,7 +433,7 @@ def get_longer_chicken_soup_prompts(num_prompts: int) -> list[str]:
 
 
 def write_sample_model_config(tmp_path, data):
-    """Helper to write a sample models_config.log.json in tmp_path."""
-    config_path = tmp_path / "models_config.log.json"
+    """Helper to write a sample model_compile.log.json in tmp_path."""
+    config_path = tmp_path / "model_compile.log.json"
     config_path.write_text(json.dumps(data))
     return config_path

--- a/tests/spyre_util.py
+++ b/tests/spyre_util.py
@@ -1,4 +1,5 @@
 import inspect
+import json
 import math
 import os
 import random
@@ -429,3 +430,10 @@ def get_longer_chicken_soup_prompts(num_prompts: int) -> list[str]:
         prompts = prompts * (math.ceil(num_prompts / 4))
 
     return prompts[:num_prompts]
+
+
+def write_sample_model_config(tmp_path, data):
+    """Helper to write a sample models_config.log.json in tmp_path."""
+    config_path = tmp_path / "models_config.log.json"
+    config_path.write_text(json.dumps(data))
+    return config_path

--- a/tests/unit/test_disable_compilation.py
+++ b/tests/unit/test_disable_compilation.py
@@ -50,8 +50,9 @@ def test_handle_disable_compilation(monkeypatch, tmp_path, batch_type):
     monkeypatch.setenv("TORCH_SENDNN_CACHE_ENABLE", "1")
 
     dummy_vllm_config = VllmConfig(
-        model_config=ModelConfig(model="JackFram/llama-160m",
-                                 max_model_len=256),
+        model_config=ModelConfig(
+            model="ibm-ai-platform/micro-g3.3-8b-instruct-1b",
+            max_model_len=256),
         parallel_config=ParallelConfig(tensor_parallel_size=2),
         scheduler_config=SchedulerConfig(max_num_seqs=2))
 

--- a/tests/unit/test_disable_compilation.py
+++ b/tests/unit/test_disable_compilation.py
@@ -50,9 +50,8 @@ def test_handle_disable_compilation(monkeypatch, tmp_path, batch_type):
     monkeypatch.setenv("TORCH_SENDNN_CACHE_ENABLE", "1")
 
     dummy_vllm_config = VllmConfig(
-        model_config=ModelConfig(
-            model="JackFram/llama-160m",
-            max_model_len=256),
+        model_config=ModelConfig(model="JackFram/llama-160m",
+                                 max_model_len=256),
         parallel_config=ParallelConfig(tensor_parallel_size=4),
         scheduler_config=SchedulerConfig(max_num_seqs=2))
 

--- a/tests/unit/test_disable_compilation.py
+++ b/tests/unit/test_disable_compilation.py
@@ -24,7 +24,7 @@ def test_handle_disable_compilation(monkeypatch, tmp_path, batch_type):
             "vllm_spyre_version": "0.8.0",
             "data": {
                 "MODEL_NAME": "/models/granite-3.3-8b-instruct-FP8",
-                "NUM_AIUS": 4,
+                "NUM_AIUS": 2,
                 "VLLM_SPYRE_WARMUP_PROMPT_LENS": "128",
                 "VLLM_SPYRE_WARMUP_NEW_TOKENS": "128",
                 "VLLM_SPYRE_WARMUP_BATCH_SIZES": "1",
@@ -37,7 +37,7 @@ def test_handle_disable_compilation(monkeypatch, tmp_path, batch_type):
             "vllm_spyre_version": "0.8.0",
             "data": {
                 "MODEL_NAME": "/models/granite-3.3-8b-instruct-FP8",
-                "NUM_AIUS": 4,
+                "NUM_AIUS": 2,
                 "VLLM_DT_MAX_CONTEXT_LEN": 256,
                 "VLLM_DT_MAX_BATCH_SIZE": 2
             },
@@ -52,7 +52,7 @@ def test_handle_disable_compilation(monkeypatch, tmp_path, batch_type):
     dummy_vllm_config = VllmConfig(
         model_config=ModelConfig(model="JackFram/llama-160m",
                                  max_model_len=256),
-        parallel_config=ParallelConfig(tensor_parallel_size=4),
+        parallel_config=ParallelConfig(tensor_parallel_size=2),
         scheduler_config=SchedulerConfig(max_num_seqs=2))
 
     SpyrePlatform._handle_disable_compilation(dummy_vllm_config,

--- a/tests/unit/test_disable_compilation.py
+++ b/tests/unit/test_disable_compilation.py
@@ -51,7 +51,7 @@ def test_handle_disable_compilation(monkeypatch, tmp_path, batch_type):
 
     dummy_vllm_config = VllmConfig(
         model_config=ModelConfig(
-            model="ibm-ai-platform/micro-g3.3-8b-instruct-1b",
+            model="JackFram/llama-160m",
             max_model_len=256),
         parallel_config=ParallelConfig(tensor_parallel_size=4),
         scheduler_config=SchedulerConfig(max_num_seqs=2))

--- a/tests/unit/test_disable_compilation.py
+++ b/tests/unit/test_disable_compilation.py
@@ -16,6 +16,9 @@ def test_handle_disable_compilation(monkeypatch, tmp_path, batch_type):
     monkeypatch.setattr("vllm_spyre._version.version", "0.8.0")
 
     if batch_type == "sb":
+        monkeypatch.setenv("VLLM_SPYRE_WARMUP_PROMPT_LENS", "128")
+        monkeypatch.setenv("VLLM_SPYRE_WARMUP_NEW_TOKENS", "128")
+        monkeypatch.setenv("VLLM_SPYRE_WARMUP_BATCH_SIZES", "1")
         monkeypatch.setenv("VLLM_SPYRE_USE_CB", "0")
         sample_model_config = {
             "vllm_spyre_version": "0.8.0",
@@ -27,9 +30,6 @@ def test_handle_disable_compilation(monkeypatch, tmp_path, batch_type):
                 "VLLM_SPYRE_WARMUP_BATCH_SIZES": "1",
             },
         }
-        monkeypatch.setenv("VLLM_SPYRE_WARMUP_PROMPT_LENS", "128")
-        monkeypatch.setenv("VLLM_SPYRE_WARMUP_NEW_TOKENS", "128")
-        monkeypatch.setenv("VLLM_SPYRE_WARMUP_BATCH_SIZES", "1")
 
     else:
         monkeypatch.setenv("VLLM_SPYRE_USE_CB", "1")
@@ -51,7 +51,7 @@ def test_handle_disable_compilation(monkeypatch, tmp_path, batch_type):
 
     dummy_vllm_config = VllmConfig(
         model_config=ModelConfig(
-            model="ibm-ai-platform/micro-g3.3-8b-instruct-1b-FP8",
+            model="ibm-ai-platform/micro-g3.3-8b-instruct-1b",
             max_model_len=256),
         parallel_config=ParallelConfig(tensor_parallel_size=4),
         scheduler_config=SchedulerConfig(max_num_seqs=2))

--- a/tests/unit/test_disable_compilation.py
+++ b/tests/unit/test_disable_compilation.py
@@ -1,0 +1,60 @@
+import pytest
+from spyre_util import write_sample_model_config
+from vllm.config import (ModelConfig, ParallelConfig, SchedulerConfig,
+                         VllmConfig)
+
+from vllm_spyre.platform import SpyrePlatform
+
+
+@pytest.mark.parametrize("batch_type", ["sb", "cb"])
+def test_handle_disable_compilation(monkeypatch, tmp_path, batch_type):
+    """
+    Test _handle_disable_compilation for static and continuous batching.
+    """
+
+    # Patch version to avoid test failures around version mismatch
+    monkeypatch.setattr("vllm_spyre._version.version", "0.8.0")
+
+    if batch_type == "sb":
+        monkeypatch.setenv("VLLM_SPYRE_USE_CB", "0")
+        sample_model_config = {
+            "vllm_spyre_version": "0.8.0",
+            "data": {
+                "MODEL_NAME": "/models/granite-3.3-8b-instruct-FP8",
+                "NUM_AIUS": 4,
+                "VLLM_SPYRE_WARMUP_PROMPT_LENS": "128",
+                "VLLM_SPYRE_WARMUP_NEW_TOKENS": "128",
+                "VLLM_SPYRE_WARMUP_BATCH_SIZES": "1",
+            },
+        }
+        monkeypatch.setenv("VLLM_SPYRE_WARMUP_PROMPT_LENS", "128")
+        monkeypatch.setenv("VLLM_SPYRE_WARMUP_NEW_TOKENS", "128")
+        monkeypatch.setenv("VLLM_SPYRE_WARMUP_BATCH_SIZES", "1")
+
+    else:
+        monkeypatch.setenv("VLLM_SPYRE_USE_CB", "1")
+        sample_model_config = {
+            "vllm_spyre_version": "0.8.0",
+            "data": {
+                "MODEL_NAME": "/models/granite-3.3-8b-instruct-FP8",
+                "NUM_AIUS": 4,
+                "VLLM_DT_MAX_CONTEXT_LEN": 256,
+                "VLLM_DT_MAX_BATCH_SIZE": 2
+            },
+        }
+
+    write_sample_model_config(tmp_path, sample_model_config)
+
+    monkeypatch.setenv("DISABLE_COMPILATION", "true")
+    monkeypatch.setenv("TORCH_SENDNN_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("TORCH_SENDNN_CACHE_ENABLE", "1")
+
+    dummy_vllm_config = VllmConfig(
+        model_config=ModelConfig(
+            model="ibm-ai-platform/micro-g3.3-8b-instruct-1b-FP8",
+            max_model_len=256),
+        parallel_config=ParallelConfig(tensor_parallel_size=4),
+        scheduler_config=SchedulerConfig(max_num_seqs=2))
+
+    SpyrePlatform._handle_disable_compilation(dummy_vllm_config,
+                                              is_decoder=True)

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -540,9 +540,8 @@ class SpyrePlatform(Platform):
         """
         disable_compilation_env_var = "DISABLE_COMPILATION"
 
-        disable_flag = os.getenv(disable_compilation_env_var, None)
-        if disable_flag is None or not bool(int(disable_flag)):
-            # Not set, or set to "0". Nothing to do
+        disable_flag = os.getenv(disable_compilation_env_var, "").lower()
+        if disable_flag not in ("1", "true"):
             return
 
         # If this isn't a decoder model, re-enable compilation

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -564,7 +564,7 @@ class SpyrePlatform(Platform):
                 "to a valid path and setting TORCH_SENDNN_CACHE_ENABLE=1")
 
         compilation_config_path = Path(
-            torch_cache_dir) / "models_config.log.json"
+            torch_cache_dir) / "model_compile.log.json"
         if not compilation_config_path.exists():
             raise ValueError(
                 f"DISABLE_COMPILATION=1 was set, but no pre-compiled model "


### PR DESCRIPTION
# Description

For decoder models if `DISABLE_COMPILATION` is set, then we validate that both:
1. The torch sendnn cache exists
2. There is a valid compilation config in the cache which matches the current vllm runtime config

This _will not_ ensure that the model can actually load from cache, but should catch most simple misconfiguration errors.

