### PR TITLE
⬆️ bump vllm lower bound to 0.10.1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
         include:
           - vllm_version:
               name: "vLLM:lowest"
-              repo: "git+https://github.com/vllm-project/vllm --tag v0.10.0"
+              repo: "git+https://github.com/vllm-project/vllm --tag v0.10.1.1"
             test_suite:
               name: "backward compat"
               markers: "compat or (cpu and basic)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = {text = "Apache 2"}
 dependencies = [
     "fms-model-optimizer[fp8]>=0.6.0",
     "ibm-fms>=1.2.1",
-    "vllm>=0.10.0,<=0.10.1.1",
+    "vllm==0.10.1.1",
 ]
 requires-python = ">=3.11"
 dynamic = ["version"]

--- a/tests/spyre_util.py
+++ b/tests/spyre_util.py
@@ -267,7 +267,7 @@ def _default_test_models(isEmbeddings=False, isScoring=False):
         revision="2714578f54cfb744ece40df9326ee0b47e879e03")
     tinygranite_fp8 = ModelInfo(
         name="ibm-ai-platform/micro-g3.3-8b-instruct-1b-FP8",
-        revision="0dff8bacb968836dbbc7c2895c6d9ead0a05dc9e")
+        revision="6e9c6465a9d7e5e9fa35004a29f0c90befa7d23f")
     params = [
         pytest.param(tinygranite,
                      marks=[pytest.mark.decoder],

--- a/tests/spyre_util.py
+++ b/tests/spyre_util.py
@@ -1,4 +1,3 @@
-import inspect
 import math
 import os
 import random
@@ -15,8 +14,6 @@ from transformers import AutoTokenizer
 from vllm import SamplingParams
 from vllm.entrypoints.openai.cli_args import make_arg_parser
 from vllm.utils import FlexibleArgumentParser, get_open_port
-from vllm.v1.engine import EngineCoreRequest
-from vllm.v1.engine.core import EngineCore
 from vllm.v1.request import Request
 
 EmbeddingWarmupShapes = list[tuple[int, int]]
@@ -267,7 +264,7 @@ def _default_test_models(isEmbeddings=False, isScoring=False):
     # the test command includes `-m quantized`.
     tinygranite = ModelInfo(
         name="ibm-ai-platform/micro-g3.3-8b-instruct-1b",
-        revision="6e9c6465a9d7e5e9fa35004a29f0c90befa7d23f")
+        revision="2714578f54cfb744ece40df9326ee0b47e879e03")
     tinygranite_fp8 = ModelInfo(
         name="ibm-ai-platform/micro-g3.3-8b-instruct-1b-FP8",
         revision="0dff8bacb968836dbbc7c2895c6d9ead0a05dc9e")
@@ -332,7 +329,7 @@ def create_random_request(
     sampling_params: SamplingParams,
     from_model_vocab: bool = False,
     model: Optional[str] = None,
-) -> Request | EngineCoreRequest:
+) -> Request:
 
     tokenizer = AutoTokenizer.from_pretrained(model)
     if from_model_vocab:
@@ -354,27 +351,6 @@ def create_random_request(
         assert (len(prompt_token_ids) == num_tokens
                 ), f"need {num_tokens} but got {len(prompt_token_ids)}"
 
-    sig = inspect.signature(EngineCore.add_request)
-    inputs_renamed = hasattr(EngineCoreRequest, 'mm_kwargs')
-    if sig.parameters["request"].annotation == EngineCoreRequest:
-        kwargs = {"mm_kwargs" if inputs_renamed else "mm_inputs": None}
-        return EngineCoreRequest(
-            request_id=str(request_id),
-            prompt_token_ids=prompt_token_ids,
-            mm_hashes=None,
-            mm_placeholders=None,
-            sampling_params=sampling_params,
-            eos_token_id=None,
-            arrival_time=0,
-            lora_request=None,
-            data_parallel_rank=None,
-            pooling_params=None,
-            cache_salt=None,
-            **kwargs,
-        )
-    kwargs = {
-        "multi_modal_kwargs" if inputs_renamed else "multi_modal_inputs": None
-    }
     return Request(
         request_id=str(request_id),
         prompt_token_ids=prompt_token_ids,
@@ -386,7 +362,7 @@ def create_random_request(
         lora_request=None,
         pooling_params=None,
         cache_salt=None,
-        **kwargs,
+        multi_modal_kwargs=None,
     )
 
 

--- a/tests/spyre_util.py
+++ b/tests/spyre_util.py
@@ -264,10 +264,10 @@ def _default_test_models(isEmbeddings=False, isScoring=False):
     # the test command includes `-m quantized`.
     tinygranite = ModelInfo(
         name="ibm-ai-platform/micro-g3.3-8b-instruct-1b",
-        revision="2714578f54cfb744ece40df9326ee0b47e879e03")
+        revision="6e9c6465a9d7e5e9fa35004a29f0c90befa7d23f")
     tinygranite_fp8 = ModelInfo(
         name="ibm-ai-platform/micro-g3.3-8b-instruct-1b-FP8",
-        revision="6e9c6465a9d7e5e9fa35004a29f0c90befa7d23f")
+        revision="0dff8bacb968836dbbc7c2895c6d9ead0a05dc9e")
     params = [
         pytest.param(tinygranite,
                      marks=[pytest.mark.decoder],

--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -12,27 +12,6 @@ VLLM_VERSION = os.getenv("TEST_VLLM_VERSION", "default")
 
 
 @pytest.mark.cpu
-def test_vllm_bert_support():
-    '''
-    Test if the vllm version under test already has Bert support for V1
-    '''
-
-    from vllm.model_executor.models.bert import BertEmbeddingModel
-
-    bert_supports_v0_only = getattr(BertEmbeddingModel, "supports_v0_only",
-                                    False)
-
-    if VLLM_VERSION == "vLLM:main":
-        assert not bert_supports_v0_only
-    elif VLLM_VERSION == "vLLM:lowest":
-        assert bert_supports_v0_only, (
-            "The lowest supported vLLM version already"
-            "supports Bert in V1. Remove the compatibility workarounds.")
-        # The compat code introduced in the PR below can now be removed:
-        # https://github.com/vllm-project/vllm-spyre/pull/277
-
-
-@pytest.mark.cpu
 def test_model_config_task(model: ModelInfo):
 
     from vllm.engine.arg_utils import EngineArgs

--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -3,45 +3,9 @@ import os
 
 import pytest
 
-from vllm_spyre.compat_utils import dataclass_fields
-
 pytestmark = pytest.mark.compat
 
 VLLM_VERSION = os.getenv("TEST_VLLM_VERSION", "default")
-
-
-@pytest.mark.cpu
-def test_engine_core_add_request():
-
-    from vllm.v1.engine import EngineCoreRequest
-    from vllm.v1.engine.core import EngineCore
-    from vllm.v1.request import Request
-
-    sig = inspect.signature(EngineCore.add_request)
-
-    if VLLM_VERSION == "vLLM:main":
-        assert sig.parameters["request"].annotation == Request
-    elif VLLM_VERSION == "vLLM:lowest":
-        assert sig.parameters["request"].annotation == EngineCoreRequest, (
-            "The lowest supported vLLM version already"
-            "switched to the new definition of EngineCore.add_request()")
-        # The compat code introduced in the PR below can now be removed:
-        # https://github.com/vllm-project/vllm-spyre/pull/354
-
-
-@pytest.mark.cpu
-def test_mm_inputs():
-
-    from vllm.v1.core.sched.output import NewRequestData
-    has_mm_inputs = 'mm_inputs' in dataclass_fields(NewRequestData)
-
-    if VLLM_VERSION == "vLLM:main":
-        assert not has_mm_inputs
-    elif VLLM_VERSION == "vLLM:lowest":
-        assert has_mm_inputs, ("The lowest supported vLLM version already"
-                               "renamed mm_inputs to mm_kwargs.")
-        # The compat code introduced in the PR below can now be removed:
-        # https://github.com/vllm-project/vllm-spyre/pull/380
 
 
 @pytest.mark.cpu

--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -2,35 +2,12 @@ import inspect
 import os
 
 import pytest
-from spyre_util import ModelInfo
 
 from vllm_spyre.compat_utils import dataclass_fields
 
 pytestmark = pytest.mark.compat
 
 VLLM_VERSION = os.getenv("TEST_VLLM_VERSION", "default")
-
-
-@pytest.mark.cpu
-def test_model_config_task(model: ModelInfo):
-
-    from vllm.engine.arg_utils import EngineArgs
-
-    vllm_config = EngineArgs(model=model.name,
-                             revision=model.revision).create_engine_config()
-    model_config = vllm_config.model_config
-
-    task = getattr(model_config, "task", None)
-
-    if VLLM_VERSION == "vLLM:main":
-        assert task is None
-    elif VLLM_VERSION == "vLLM:lowest":
-        assert task is not None, (
-            "The lowest supported vLLM version already"
-            "switched to the new definition of runners and task.")
-        # The compat code introduced in the PRs below can now be removed:
-        # https://github.com/vllm-project/vllm-spyre/pull/341
-        # https://github.com/vllm-project/vllm-spyre/pull/352
 
 
 @pytest.mark.cpu

--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -11,21 +11,6 @@ VLLM_VERSION = os.getenv("TEST_VLLM_VERSION", "default")
 
 
 @pytest.mark.cpu
-def test_multi_step_scheduling():
-
-    from vllm.config import SchedulerConfig
-    has_multi_step = hasattr(SchedulerConfig, "is_multi_step")
-
-    if VLLM_VERSION == "vLLM:main":
-        assert not has_multi_step
-    elif VLLM_VERSION == "vLLM:lowest":
-        assert has_multi_step, ("The lowest supported vLLM version already"
-                                "removed multi-step scheduling.")
-        # The compat code introduced in the PR below can now be removed:
-        # https://github.com/vllm-project/vllm-spyre/pull/374
-
-
-@pytest.mark.cpu
 def test_engine_core_add_request():
 
     from vllm.v1.engine import EngineCoreRequest

--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -11,25 +11,6 @@ VLLM_VERSION = os.getenv("TEST_VLLM_VERSION", "default")
 
 
 @pytest.mark.cpu
-def test_has_tasks():
-
-    try:
-        from vllm import tasks  # noqa
-        has_tasks = True
-    except Exception:
-        has_tasks = False
-
-    if VLLM_VERSION == "vLLM:main":
-        assert has_tasks
-    elif VLLM_VERSION == "vLLM:lowest":
-        assert not has_tasks, (
-            "The lowest supported vLLM version already"
-            "switched to the new definition of runners and task.")
-        # The compat code introduced in the PR below can now be removed:
-        # https://github.com/vllm-project/vllm-spyre/pull/338
-
-
-@pytest.mark.cpu
 def test_pooler_default_args():
 
     from vllm.model_executor.layers.pooler import Pooler

--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -9,23 +9,6 @@ VLLM_VERSION = os.getenv("TEST_VLLM_VERSION", "default")
 
 
 @pytest.mark.cpu
-def test_init_builtin_logitsprocs():
-
-    import vllm.v1.sample.logits_processor
-    has_init_builtin_logitsprocs = hasattr(vllm.v1.sample.logits_processor,
-                                           "init_builtin_logitsprocs")
-
-    if VLLM_VERSION == "vLLM:main":
-        assert not has_init_builtin_logitsprocs
-    elif VLLM_VERSION == "vLLM:lowest":
-        assert has_init_builtin_logitsprocs, (
-            "The lowest supported vLLM version already"
-            "refactored init_builtin_logitsprocs.")
-        # The compat code introduced in the PR below can now be removed:
-        # https://github.com/vllm-project/vllm-spyre/pull/443
-
-
-@pytest.mark.cpu
 def test_init_distributed_environment():
     """Tests whether vllm's init_distributed_environment
     has the custom timeout argument"""

--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -11,40 +11,6 @@ VLLM_VERSION = os.getenv("TEST_VLLM_VERSION", "default")
 
 
 @pytest.mark.cpu
-def test_pooler_default_args():
-
-    from vllm.model_executor.layers.pooler import Pooler
-    has_from_config = hasattr(Pooler, "from_config_with_defaults")
-
-    if not has_from_config:
-        annotations = inspect.getfullargspec(Pooler.for_embed).annotations
-        if VLLM_VERSION == "vLLM:main":
-            assert 'default_normalize' not in annotations
-            assert 'default_softmax' not in annotations
-        elif VLLM_VERSION == "vLLM:lowest":
-            assert 'default_normalize' in annotations
-            assert 'default_softmax' in annotations
-            # The compat code introduced in the PR below can now be removed:
-            # https://github.com/vllm-project/vllm-spyre/pull/361
-
-
-@pytest.mark.cpu
-def test_pooler_default_pooling_type():
-
-    from vllm.model_executor.layers.pooler import Pooler
-    has_from_config = hasattr(Pooler, "from_config_with_defaults")
-
-    if not has_from_config:
-        annotations = inspect.getfullargspec(Pooler.for_embed).annotations
-        if VLLM_VERSION == "vLLM:main":
-            assert 'default_pooling_type' not in annotations
-        elif VLLM_VERSION == "vLLM:lowest":
-            assert 'default_pooling_type' in annotations
-            # The compat code introduced in the PR below can now be removed:
-            # https://github.com/vllm-project/vllm-spyre/pull/374
-
-
-@pytest.mark.cpu
 def test_multi_step_scheduling():
 
     from vllm.config import SchedulerConfig

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -79,9 +79,6 @@ class SpyrePlatform(Platform):
         model_config = vllm_config.model_config
         cache_config = vllm_config.cache_config
 
-        if getattr(scheduler_config, "is_multi_step", False):
-            raise NotImplementedError
-
         is_decoder = model_config.runner_type == "generate"
 
         is_pooling = model_config.runner_type == "pooling"

--- a/vllm_spyre/v1/worker/spyre_input_batch.py
+++ b/vllm_spyre/v1/worker/spyre_input_batch.py
@@ -201,27 +201,14 @@ class SamplingRequestState(BaseRequestState):
         return len(self.prompt_token_ids) + len(self.output_token_ids)
 
 
-# Compatibility code, remove when no supported version
-# has init_builtin_logitsprocs any more
 def get_builtin_logits_processors(
         vllm_config: Optional[VllmConfig] = None) -> Any:
-    if hasattr(vllm.v1.sample.logits_processor, "LogitsProcessors"):
-        if vllm_config is None:
-            return vllm.v1.sample.logits_processor.LogitsProcessors()
-        return vllm.v1.sample.logits_processor.LogitsProcessors(
-            ctor(vllm_config, "cpu", False)
-            for ctor in vllm.v1.sample.logits_processor.\
-                BUILTIN_LOGITS_PROCESSORS)
-    else:
-        if vllm_config is None:
-            return vllm.v1.sample.logits_processor.LogitsProcessorManager(
-                non_argmax_invariant=[],
-                argmax_invariant=[],
-            )
-        return vllm.v1.sample.logits_processor.init_builtin_logitsprocs(
-            pin_memory_available=False,
-            max_num_reqs=vllm_config.scheduler_config.max_num_seqs + 1,
-            device="cpu")
+    if vllm_config is None:
+        return vllm.v1.sample.logits_processor.LogitsProcessors()
+    return vllm.v1.sample.logits_processor.LogitsProcessors(
+        ctor(vllm_config, "cpu", False)
+        for ctor in vllm.v1.sample.logits_processor.\
+            BUILTIN_LOGITS_PROCESSORS)
 
 
 class SamplingInputBatch(BaseInputBatch[SamplingRequestState]):

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -1,4 +1,3 @@
-import inspect
 import math
 import time
 from abc import ABC, abstractmethod
@@ -14,8 +13,7 @@ from transformers import (AutoModel, AutoModelForSequenceClassification,
 from vllm.config import DeviceConfig, VllmConfig
 from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
-from vllm.model_executor.layers.pooler import (ClassifierPooler, Pooler,
-                                               PoolingType)
+from vllm.model_executor.layers.pooler import ClassifierPooler, Pooler
 from vllm.sampling_params import SamplingType
 from vllm.utils import is_pin_memory_available
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec
@@ -1421,22 +1419,8 @@ class SpyrePoolingModelRunner(WarmupShapesMixin,
 
         pooler_config = self.model_config.pooler_config
 
-        # TODO: remove this when we no longer support vllm version pre this
-        # PR https://github.com/vllm-project/vllm/pull/20538 (post v0.10.0)
-        annotations = inspect.getfullargspec(Pooler.for_embed).annotations
-        extra_args = {}
-        if ('default_normalize' in annotations
-                and 'default_softmax' in annotations):
-            extra_args.update({
-                'default_normalize': True,
-                'default_softmax': False
-            })
-        if 'default_pooling_type' in annotations:
-            extra_args['default_pooling_type'] = PoolingType.CLS
-
         if task == "embed":
-            self.pooler = Pooler.for_embed(pooler_config=pooler_config,
-                                           **extra_args)
+            self.pooler = Pooler.for_embed(pooler_config=pooler_config)
         elif task == "classify":
             self.pooler = ClassifierPooler(
                 pooling=self._pooler,

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -5,8 +5,7 @@ from abc import ABC, abstractmethod
 from collections import deque
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
-from typing import (TYPE_CHECKING, Generic, Literal, Optional, TypeVar, Union,
-                    cast, get_args)
+from typing import TYPE_CHECKING, Generic, Optional, TypeVar, Union, cast
 
 import torch
 from torch import nn
@@ -44,20 +43,8 @@ else:
     NewRequestData = None
     SamplingMetadata = None
 
+from vllm.tasks import SupportedTask
 from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, ModelRunnerOutput
-
-#############################################################
-# from vllm.tasks import GenerationTask, PoolingTask, SupportedTask
-# TODO: remove when we drop support for 0.10.0
-#############################################################
-GenerationTask = Literal["generate", "transcription"]
-GENERATION_TASKS = get_args(GenerationTask)
-
-PoolingTask = Literal["encode", "embed", "classify", "score"]
-POOLING_TASKS = get_args(PoolingTask)
-
-SupportedTask = Literal[GenerationTask]
-#############################################################
 
 logger = init_logger(__name__)
 

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -100,13 +100,6 @@ class SpyreWorker(WorkerBaseV1):
     """A worker class that executes the model on a group of Spyre cores.
     """
 
-    def get_supported_pooling_tasks(self):
-        # Compatibility code required for vllm == 0.10.0
-        # Can be removed for vllm > 0.10.0
-        if self.is_pooling:
-            return ["embed", "score"]
-        return []
-
     @property
     def is_pooling(self) -> bool:
         return self.model_config.runner_type == "pooling"


### PR DESCRIPTION
# Description

⬆️ bump vllm lower bound to 0.10.1.1 and remove a bunch of backward compatibility code.


Note: This is an intermediate PR for supporting the 0.10.2 since it makes it easy to remove backward compatibility code first before introducing breaking changes for the next release.

## Related Issues

<!-- Link related issues e.g. `Fixes #<issue>` -->
