### PR TITLE
get the token_type_ids from pooling params

### DIFF
--- a/tests/e2e/test_spyre_scoring.py
+++ b/tests/e2e/test_spyre_scoring.py
@@ -18,19 +18,35 @@ def test_serving(remote_openai_server, model, warmup_shapes, backend):
     score_url = remote_openai_server.url_for("/score")
 
     query = "What is the capital of France?"
+    # Number of inputs larger than the warmup batch size of 4
+    # and with a non-uniform token length
     docs = [
-        "The capital of France is Paris.", "The capital of Germany is Berlin."
+        "The capital of France is Paris.", "The capital of Germany is Berlin.",
+        "The capital of Brazil is Brasilia.",
+        "The capital of the country with the best beer is Berlin.",
+        "The capital of the USA is Washington.",
+        "The capital city of Spain is Madrid."
     ]
     vllm_outputs = requests.post(url=score_url,
                                  json={
                                      "text_1": query,
-                                     "text_2": [docs[0], docs[1]]
+                                     "text_2": docs,
                                  }).json()
+    vllm_scores = [o["score"] for o in vllm_outputs["data"]]
 
     ce_model = CrossEncoder(model.name, revision=model.revision)
-    ce_scores = ce_model.predict([(query, docs[0]), (query, docs[1])])
-
-    vllm_scores = [o["score"] for o in vllm_outputs["data"]]
+    ce_scores = ce_model.predict([
+        (query, docs[0]),
+        (query, docs[1]),
+        (query, docs[2]),
+        (query, docs[3]),
+        (query, docs[4]),
+        (query, docs[5]),
+    ])
 
     assert ce_scores[0] == pytest.approx(vllm_scores[0], rel=0.02)
     assert ce_scores[1] == pytest.approx(vllm_scores[1], rel=0.02)
+    assert ce_scores[2] == pytest.approx(vllm_scores[2], rel=0.02)
+    assert ce_scores[3] == pytest.approx(vllm_scores[3], rel=0.02)
+    assert ce_scores[4] == pytest.approx(vllm_scores[4], rel=0.02)
+    assert ce_scores[5] == pytest.approx(vllm_scores[5], rel=0.02)


### PR DESCRIPTION
# Description

The token type ids in upstream vllm are passed to the model runner in the pooling params. This PR fixes the preparation of token type inputs and also fixes the tensor sizes and dimensions to work both with the transformer modeling code and the vllm pooler code.