### PR TITLE
Only set threading env vars if not already defined

### DIFF
--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -456,7 +456,8 @@ class SpyrePlatform(Platform):
                 )
 
             for env in THREADING_ENVS:
-                os.environ[env] = str(cpus_per_worker)
+                if not os.environ.get(env):
+                    os.environ[env] = str(cpus_per_worker)
 
             logger.info(
                 "%s for %d workers. Since VLLM_SPYRE_UPDATE_THREAD_CONFIG is "


### PR DESCRIPTION
# Description

This PR ensures that threading-related environment variables (e.g. OPENBLAS_NUM_THREADS, MKL_NUM_THREADS, etc.) are only set if they are not already defined by the user.

