### PR TITLE
[fp8] fix cb scheduler step tests

### DIFF
--- a/tests/llm_cache.py
+++ b/tests/llm_cache.py
@@ -187,8 +187,9 @@ class EngineCache:
         # then adjust these limits in the engine's scheduler for tests.
 
         # Setup the engine
-        # round max_num_seqs (batch size) to the next power of two for
-        # Spyre compilation
+        # Round max_num_seqs (batch size) to the next power of two for
+        # Spyre compilation. This seems more robust and helps that all tests in
+        # tests/e2e/test_spyre_cb_inference_steps.py pass on Spyre.
         max_num_seqs_compiled = 1 << (max_num_seqs - 1).bit_length()
         engine_args = EngineArgs(
             model=model_name,
@@ -205,6 +206,8 @@ class EngineCache:
                                  executor_class=executor_class,
                                  log_stats=False)
 
+        # Set scheduler configs for max_model_len and max_num_seqs to the
+        # original values. They were changed for more robust compilation only.
         engine_core.scheduler.scheduler_config.max_model_len = max_model_len
         engine_core.scheduler.scheduler_config.max_num_seqs = max_num_seqs
 

--- a/tests/llm_cache.py
+++ b/tests/llm_cache.py
@@ -189,7 +189,7 @@ class EngineCache:
         # Setup the engine
         # round max_num_seqs (batch size) to the next power of two for 
         # Spyre compilation
-        max_num_seqs_compiled =  1 << (max_num_seqs - 1).bit_length()
+        max_num_seqs_compiled = 1 << (max_num_seqs - 1).bit_length()
         engine_args = EngineArgs(
             model=model_name,
             tokenizer=model_name,

--- a/tests/llm_cache.py
+++ b/tests/llm_cache.py
@@ -187,11 +187,14 @@ class EngineCache:
         # then adjust these limits in the engine's scheduler for tests.
 
         # Setup the engine
+        # round max_num_seqs (batch size) to the next power of two for 
+        # Spyre compilation
+        max_num_seqs_compiled =  1 << (max_num_seqs - 1).bit_length()
         engine_args = EngineArgs(
             model=model_name,
             tokenizer=model_name,
             max_model_len=max(max_model_len, 256),
-            max_num_seqs=max(max_num_seqs, 4),
+            max_num_seqs=max_num_seqs_compiled,
             num_gpu_blocks_override=None,
             revision=revision,
         )

--- a/tests/llm_cache.py
+++ b/tests/llm_cache.py
@@ -187,7 +187,7 @@ class EngineCache:
         # then adjust these limits in the engine's scheduler for tests.
 
         # Setup the engine
-        # round max_num_seqs (batch size) to the next power of two for 
+        # round max_num_seqs (batch size) to the next power of two for
         # Spyre compilation
         max_num_seqs_compiled = 1 << (max_num_seqs - 1).bit_length()
         engine_args = EngineArgs(

--- a/tests/llm_cache.py
+++ b/tests/llm_cache.py
@@ -191,7 +191,7 @@ class EngineCache:
             model=model_name,
             tokenizer=model_name,
             max_model_len=max(max_model_len, 256),
-            max_num_seqs=max_num_seqs,
+            max_num_seqs=max(max_num_seqs, 4),
             num_gpu_blocks_override=None,
             revision=revision,
         )
@@ -203,6 +203,7 @@ class EngineCache:
                                  log_stats=False)
 
         engine_core.scheduler.scheduler_config.max_model_len = max_model_len
+        engine_core.scheduler.scheduler_config.max_num_seqs = max_num_seqs
 
         if available_blocks is not None:
             worker = engine_core.model_executor.driver_worker.worker


### PR DESCRIPTION
this change does always compile for the next power of 2 for the batch size. 
