### PR TITLE
:bug: correct fms lower bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 license = {text = "Apache 2"}
 dependencies = [
     "fms-model-optimizer[fp8]>=0.6.0",
-    "ibm-fms>=1.4.0",
+    "ibm-fms>=1.4.0,<2.0",
     "vllm>=0.10.1.1,<=0.10.2",
     "pytest-mock>=3.15.0",
 ]


### PR DESCRIPTION
# Description

I forgot the change in https://github.com/vllm-project/llm-spyre/pull/464  to bump the lower bound of fms, because nothing good happens while making changes to deploy late on fridays :(

The changes from `uv sync --upgrade` were added but I probably should have run `uv add ibm-fms~=1.4.0`.
