### PR TITLE
[CB] 🐛  fix padding of position ids

### DIFF
--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -182,7 +182,6 @@ class BaseSpyreModelRunner(ABC, Generic[InputBatchT, RequestStateT,
                                   dtype=torch.long,
                                   device=input_ids_i.device)
 
-            pos_ids_pads = pads
             pos_ids_seq = torch.arange(0,
                                        seq_len,
                                        dtype=torch.long,
@@ -193,7 +192,7 @@ class BaseSpyreModelRunner(ABC, Generic[InputBatchT, RequestStateT,
             # workflow works for nested tensor, this can probably be removed
             padded_input_ids_list.append(torch.cat((pads, input_ids_i)))
             mask_list.append(torch.cat((torch.zeros_like(pads), non_pads)))
-            position_ids_list.append(torch.cat((pos_ids_pads, pos_ids_seq)))
+            position_ids_list.append(torch.cat((torch.zeros_like(pads), pos_ids_seq)))
 
         return padded_input_ids_list, mask_list, position_ids_list
 

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -192,7 +192,8 @@ class BaseSpyreModelRunner(ABC, Generic[InputBatchT, RequestStateT,
             # workflow works for nested tensor, this can probably be removed
             padded_input_ids_list.append(torch.cat((pads, input_ids_i)))
             mask_list.append(torch.cat((torch.zeros_like(pads), non_pads)))
-            position_ids_list.append(torch.cat((torch.zeros_like(pads), pos_ids_seq)))
+            position_ids_list.append(
+                torch.cat((torch.zeros_like(pads), pos_ids_seq)))
 
         return padded_input_ids_list, mask_list, position_ids_list
 


### PR DESCRIPTION
When padding the position ids, we should always use 0 (not padding token id !)

As the mask disregards the padded tokens anyway, that does not have an influence on the generation results. It can break the implementation though when the padding token is bigger than the max model length (that is also how I found the bug). 

**_For the models we support so far this was never a problem, but for future ones we should fix it!_**

Note: We did not find that bug earlier as for our models of interest, the padding token id happens to be 0 too, but that does not have to hold true in general.

