### PR TITLE
Granite4 2b & 3b support

### DIFF
--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -341,11 +341,9 @@ class ContinuousBatchingFmsModel(FmsModelBase):
 
         if self.config.model_type in {'llama', 'granite', 'granitemoehybrid'}:
             self.kv_cache_specs['num_layers'] = self.config.num_hidden_layers
-            if 'granite' in self.config.model_type:
-                self.kv_cache_specs['head_dim'] = self.model.config.head_dim
-            else:
-                self.kv_cache_specs['head_dim'] = self.config.hidden_size // \
-                    self.config.num_attention_heads
+            self.kv_cache_specs['head_dim'] = getattr(
+                self.model.config, "head_dim",
+                self.config.hidden_size // self.config.num_attention_heads)
         elif self.config.model_type == 'gpt_bigcode':
             self.kv_cache_specs['num_layers'] = self.config.n_layer
             self.kv_cache_specs[


### PR DESCRIPTION
Supporting granite4 2b & 3b (attention only). 

fms support has been merged into main here: https://github.com/foundation-model-stack/foundation-model-stack/pull/472 

implemented it in a backward compatible way, such that we can get it into vllm-spyre main without relying on a fms version post above PR.  