### PR TITLE
[DON'T MERGE] GHA don't use cache for 4-layer granite model (PR #497)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,14 +167,14 @@ jobs:
 
       - name: "Restore HF models cache"
         id: cache_restore
-        if: steps.changed-src-files.outputs.any_changed == 'true'
+        if: ! contains(env.model_key, 'micro')
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.model_path }}
           key: ${{ runner.os }}-hf-model-${{ env.model_key }}
 
       - name: "Download HF models"
-        if: ( steps.changed-src-files.outputs.any_changed == 'true' && steps.cache_restore.outputs.cache-hit == 'true' )
+        if: ( steps.changed-src-files.outputs.any_changed == 'true' && steps.cache_restore.outputs.cache-hit != 'true' )
         run: |
           # We are caching HF models (HF_HUB_CACHE) for reliability rather than speed, since HF downloads are flaky for concurrent jobs.
           # Be careful when adding models to the cache here, as the GHA cache is limited to 10 GB.


### PR DESCRIPTION
# Description

Draft PR #497 has all tests pass because it uses both tiny granite models

- the 4-layer model from the cache
- the 3-layer model downloaded with revision

This PR checks the test results for bypassing the cache (not using 4-layer model)

## Related Issues

#497 
