### PR TITLE
:fire: remove unused test parametrizations

### DIFF
--- a/tests/e2e/test_logits_processors.py
+++ b/tests/e2e/test_logits_processors.py
@@ -54,8 +54,7 @@ def test_custom_logits_processor(model: ModelInfo, backend, monkeypatch,
     assert has_invoked_logits_processor
 
 
-def test_cb_logits_processor(model: ModelInfo, backend, monkeypatch,
-                             warmup_shapes, max_model_len, cb):
+def test_cb_logits_processor(model: ModelInfo, backend, monkeypatch, max_model_len):
     '''
     Test if the state of logits for CB are correct due to the switch of
     prefill/decode in a step engine. The LLM is initialized with bs=2,


### PR DESCRIPTION
I noticed that this test ends up in both the static and continuous batching runs because it's automatically parametrized both ways with the unused `warmup_shapes` and `cb` parameters. This should fix that so it only runs in the continuous batching suite