### PR TITLE
:bug: fixup full_model marker

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,12 +46,8 @@ def pytest_generate_tests(metafunc):
         # When -m full_model is called, all tests tagged with
         # full_model mark will be injected with these custom values
         if metafunc.definition.get_closest_marker("full_model"):
-            _add_param(
-                "model",
-                ["ibm-granite/granite-3.3-8b-instruct"],
-                metafunc,
-                existing_markers,
-            )
+            _add_param("model", get_spyre_model_list(full_size_models=True),
+                       metafunc, existing_markers)
             _add_param(
                 "backend",
                 ["sendnn"],

--- a/tests/llm_cache_util.py
+++ b/tests/llm_cache_util.py
@@ -183,8 +183,12 @@ class SortKey(NamedTuple):
         for key in MODEL_KEYS:
             if key in params:
                 SortKey._assert_param(isinstance(params[key], str | ModelInfo),
-                                      "model must be a string", item)
-                return params[key]
+                                      "model must be a string or ModelInfo",
+                                      item)
+                model_or_info = params[key]
+                if isinstance(model_or_info, ModelInfo):
+                    return model_or_info.name
+                return model_or_info
         # No assumption about default model, we likely don't need an llm if this
         # isn't set
         return ""


### PR DESCRIPTION
# Description

This PR fixes a bug where the test collection failed on the full-sized models because we injected a string instead of a `ModelInfo` for the `model` param. This both:
1. Updates the full-sized model parameterization to use a ModelInfo with a pinned revision
2. Updates the test collection code to not fail if a string is passed anyway

