### PR TITLE
:bug: fixup more tests to use the default max model length

### DIFF
--- a/docs/contributing/continuous_batching/tests/other_tests.md
+++ b/docs/contributing/continuous_batching/tests/other_tests.md
@@ -1,7 +1,7 @@
 # Other Tests
 
 !!! note
-    Unless otherwise specified, all the continuous batching tests are running with `max_model_len=256`
+    Unless otherwise specified, all the continuous batching tests are running with `max_model_len=512`
 
 ::: tests.e2e.test_spyre_cb
     options:

--- a/docs/contributing/continuous_batching/tests/output_tests.md
+++ b/docs/contributing/continuous_batching/tests/output_tests.md
@@ -1,7 +1,7 @@
 # Output Tests
 
 !!! note
-    Unless otherwise specified, all the continuous batching tests are running with `max_model_len=256`
+    Unless otherwise specified, all the continuous batching tests are running with `max_model_len=512`
 
 ::: tests.e2e.test_spyre_basic
     options:

--- a/docs/contributing/continuous_batching/tests/scheduler_steps_tests.md
+++ b/docs/contributing/continuous_batching/tests/scheduler_steps_tests.md
@@ -1,6 +1,6 @@
 # Scheduler Steps Tests
 
 !!! note
-    Unless otherwise specified, all the continuous batching tests are running with `max_model_len=256`
+    Unless otherwise specified, all the continuous batching tests are running with `max_model_len=512`
 
 ::: tests.e2e.test_spyre_cb_scheduler_steps

--- a/tests/aftu/test_compare_graphs.py
+++ b/tests/aftu/test_compare_graphs.py
@@ -35,7 +35,7 @@ def mock_get_mask_dtype(mocker: MockerFixture):
 @pytest.mark.spyre
 @pytest.mark.cb
 def test_compare_graphs_cb(model: ModelInfo, max_num_seqs: int,
-                           monkeypatch: pytest.MonkeyPatch,
+                           max_model_len: int, monkeypatch: pytest.MonkeyPatch,
                            mocker: MockerFixture):
     """Test that the spyre worker correctly outputs
     continuous batches of requests by comparing to HF"""
@@ -45,7 +45,6 @@ def test_compare_graphs_cb(model: ModelInfo, max_num_seqs: int,
     if script_dir is None:
         pytest.skip("aiu-fms-testing-utils is required "
                     "and is not installed to run this test")
-    max_model_len = 256
 
     model_path = get_model_path(model)
 

--- a/tests/e2e/test_spyre_async_llm.py
+++ b/tests/e2e/test_spyre_async_llm.py
@@ -48,6 +48,7 @@ async def generate(
     "output_kind", [RequestOutputKind.DELTA, RequestOutputKind.FINAL_ONLY])
 @pytest.mark.asyncio
 async def test_abort(model: ModelInfo, backend: str, cb: int,
+                     max_model_len: int, max_num_seqs: int,
                      warmup_shapes: DecodeWarmupShapes,
                      output_kind: RequestOutputKind,
                      monkeypatch: pytest.MonkeyPatch):
@@ -72,8 +73,8 @@ async def test_abort(model: ModelInfo, backend: str, cb: int,
         engine = AsyncLLM.from_engine_args(
             AsyncEngineArgs(model=model.name,
                             tokenizer=model.name,
-                            max_model_len=256,
-                            max_num_seqs=4,
+                            max_model_len=max_model_len,
+                            max_num_seqs=max_num_seqs,
                             revision=model.revision))
         has_unfinished_requests = \
             engine.output_processor.has_unfinished_requests

--- a/tests/e2e/test_spyre_static_batching_limits.py
+++ b/tests/e2e/test_spyre_static_batching_limits.py
@@ -34,7 +34,7 @@ def test_max_prompt_len_and_new_tokens(model: ModelInfo,
 
     llm = get_cached_llm(
         model=model,
-        max_model_len=256,
+        max_model_len=256,  # unused
         tensor_parallel_size=1,
         backend=backend,
         monkeypatch=monkeypatch,


### PR DESCRIPTION
# Description

Following up on #509, this fixes up a few remaining tests that were setting their own max model lengths instead of using the default. Using the default makes it much easier to respond to changes in hardware support