### PR TITLE
[CB] consistent max context length

### DIFF
--- a/examples/offline_inference/long_context.py
+++ b/examples/offline_inference/long_context.py
@@ -121,7 +121,7 @@ def round_up(t):
 
 
 tokens_to_generate = [
-    args.max_model_len + 1 - round_up(prompt_len) for prompt_len in prompt_lens
+    args.max_model_len - round_up(prompt_len) for prompt_len in prompt_lens
 ]
 
 sampling_params = [

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -340,8 +340,7 @@ class SpyrePlatform(Platform):
             # ceil division to pad to next block boundary
             prompt_padding_len = math.ceil(
                 prompt_len / cls._block_size) * cls._block_size
-            # we have to account for the token generated during prefill (-1)
-            if (prompt_padding_len + max_tokens - 1
+            if (prompt_padding_len + max_tokens
                     > cls._config.scheduler_config.max_model_len):
                 raise ValueError(
                     "Could not add request: prompt length is "


### PR DESCRIPTION

We had a (known) inconsistency: Allowing the additional token in `platform.validate_request`, but not in `scheduler.can_schedule()` (#332 would allow it in the scheduler). However, as the upstream vllm version vllm-spyre is tied to does not currently allow the additional token, this PR removes the inconsistency and establishes same behavior as upstream. 

Note: as soon as the upstream version tied to this repo allows the additional token, we can revert this PR and merge #332 (along with some unit tests).

cc @sducouedic 