### PR TITLE
update and expand online example to continious batching

### DIFF
--- a/examples/online_inference/openai_spyre_inference.py
+++ b/examples/online_inference/openai_spyre_inference.py
@@ -4,8 +4,7 @@ This example shows how to use Spyre with vLLM for running online inference.
 Static Batching:
 
 First, start the server with the following command:
-    python3 -m vllm.entrypoints.openai.api_server \
-        --model 'ibm-granite/granite-3.3-8b-instruct' \
+    vllm serve 'ibm-granite/granite-3.3-8b-instruct' \
         --max-model-len=2048 \
         --tensor-parallel-size=4
 
@@ -18,8 +17,7 @@ You can change these with the env variables `VLLM_SPYRE_WARMUP_BATCH_SIZES`,
 Continuous Batching:
 
 First, start the server with the following command:
-    VLLM_SPYRE_USE_CB=1 python3 -m vllm.entrypoints.openai.api_server \
-        --model 'ibm-granite/granite-3.3-8b-instruct' \
+    VLLM_SPYRE_USE_CB=1 vllm serve 'ibm-granite/granite-3.3-8b-instruct' \
         --max-model-len=2048 \
         --tensor-parallel-size=4 \
         --max-num-seqs=4


### PR DESCRIPTION
### update openai_spyre_inference.py

changes:
- use model 'ibm-granite/granite-3.3-8b-instruct'
- use tp 4
- remove `block-size` argument as this gets overridden anyway (actually 2048 throws an error as not supported upstream)
- expand (and explain) server startup instructions for continuous batching