### PR TITLE
[profiler] fix multi-aiu profiling and add setable options

### DIFF
--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -259,25 +259,43 @@ class SpyreWorker(WorkerBaseV1):
         # VLLM_TORCH_PROFILER_DIR=/path/to/save/trace
         if envs.VLLM_TORCH_PROFILER_DIR:
             torch_profiler_trace_dir = envs.VLLM_TORCH_PROFILER_DIR
-            activities = [torch.profiler.ProfilerActivity.CPU]
+            logger.info("Profiling enabled. Traces will be saved to: %s",
+                        torch_profiler_trace_dir)
 
             if envs_spyre.VLLM_SPYRE_DYNAMO_BACKEND == "sendnn":
-                from torch_sendnn import torch_sendnn
-                torch.utils.rename_privateuse1_backend("aiu")
-                torch._register_device_module("aiu",
-                                              torch_sendnn.sendnn_backend)
-                torch.utils.generate_methods_for_privateuse1_backend()
-                activities.append(torch.profiler.ProfilerActivity.PrivateUse1)
+                logger.info("Traces will contain AIU events if PyTorch with"
+                            " AIU profiling support is installed.")
+                os.environ["ProfilerActivity"] = "PrivateUse1"  # noqa: SIM112
+
+                # Get the current value of DT_OPT and autopilot
+                dt_opt = os.environ.get("DT_OPT", "")
+                options = dict(
+                    opt.split('=') for opt in dt_opt.split(',') if '=' in opt)
+                autopilot_opt = options.get(
+                    "autopilot", "1")  # autopilot defaults to 1 if not set
+                if autopilot_opt == "1":
+                    logger.warning(
+                        "autopilot on detected with profiling enabled. Add "
+                        "autpilot=0 to DT_OPT to see individual AIU-kernel "
+                        "execution in the trace.")
+
+            logger.debug(
+                "Profiler config: record_shapes=%s,"
+                "profile_memory=%s,with_stack=%s,with_flops=%s",
+                envs.VLLM_TORCH_PROFILER_RECORD_SHAPES,
+                envs.VLLM_TORCH_PROFILER_WITH_PROFILE_MEMORY,
+                envs.VLLM_TORCH_PROFILER_WITH_STACK,
+                envs.VLLM_TORCH_PROFILER_WITH_FLOPS,
+            )
 
             self.profiler = torch.profiler.profile(
-                activities=activities,
-                record_shapes=True,
-                with_stack=True,
+                activities=[torch.profiler.ProfilerActivity.CPU],
+                record_shapes=envs.VLLM_TORCH_PROFILER_RECORD_SHAPES,
+                profile_memory=envs.VLLM_TORCH_PROFILER_WITH_PROFILE_MEMORY,
+                with_stack=envs.VLLM_TORCH_PROFILER_WITH_STACK,
+                with_flops=envs.VLLM_TORCH_PROFILER_WITH_FLOPS,
                 on_trace_ready=torch.profiler.tensorboard_trace_handler(
                     torch_profiler_trace_dir, use_gzip=True))
-            print(
-                "[SpyreWorker] Profiling enabled. Traces will be saved to: %s",
-                torch_profiler_trace_dir)
         else:
             self.profiler = None
 


### PR DESCRIPTION
# Description

1. Switches to an alternative method for enabling AIU event profiling when profiling is enabled with `VLLM_TORCH_PROFILER_DIR`. This resolves the following error that occurs when trying to profile a multi-AIU workload: `RuntimeError: Please register PrivateUse1HooksInterface by 'RegisterPrivateUse1HooksInterface' first. `
2. Adds support for the following profiling options that were added to vLLM: https://github.com/vllm-project/vllm/blob/30f78af147cb9eac0a5c643a69882a3b0e45f986/docs/contributing/profiling.md?plain=1#L10-L13

## Related Issues

n/a
