### PR TITLE
refact: removed unnecessary logits processor

### DIFF
--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -12,7 +12,6 @@ from transformers import PretrainedConfig
 from vllm.config import ModelConfig, VllmConfig
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
-from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.model_loader.weight_utils import (
     download_weights_from_hf)
 from vllm.v1.outputs import SamplerOutput
@@ -58,9 +57,6 @@ class SpyreCausalLM(nn.Module):
         rank: int,
     ) -> None:
         super().__init__()
-        self.logits_processor = LogitsProcessor(
-            vllm_config.model_config.hf_config.vocab_size,
-            logits_as_input=True)
 
         try:
             ## Temporary backwards compatibility for 0.10.2
@@ -130,14 +126,6 @@ class SpyreCausalLM(nn.Module):
             # removing finished or padded sequences
             logits = logits[self.indices]
 
-        return logits
-
-    def compute_logits(
-        self,
-        hidden_states: torch.Tensor,
-        sampling_metadata: SamplingMetadata,
-    ) -> torch.Tensor:
-        logits = self.logits_processor(None, hidden_states, sampling_metadata)
         return logits
 
     def sample(

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -525,13 +525,10 @@ class SpyreModelRunner(BaseSpyreModelRunner[SamplingInputBatch,
         # Execute the model
         attn_metadata = self.build_attn_metadata(model_input)
         with set_forward_context(attn_metadata, self.vllm_config):
-            hidden_states = self.model(input_ids=model_input.input_tokens,
-                                       positions=model_input.input_positions,
-                                       masks=model_input.input_masks,
-                                       is_prompt=model_input.is_prompt)
-
-        # Compute the logits.
-        logits = self.model.compute_logits(hidden_states, None)
+            logits = self.model(input_ids=model_input.input_tokens,
+                                positions=model_input.input_positions,
+                                masks=model_input.input_masks,
+                                is_prompt=model_input.is_prompt)
 
         is_prefill = cast(bool, model_input.is_prompt)
 


### PR DESCRIPTION
# Description

This PR removes a logits processor that does nothing. Probably something legacy from V0. The logits processor currently is called in this snippet from spyre_model_runner:

```
# Sample the next token.
        output: SamplerOutput = self.model.sample(
            logits=logits,
            sampling_metadata=self.get_sampling_metadata(is_prefill),
        )
```
