### PR TITLE
[Docs] Add arch doc to dev guide view

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -39,6 +39,7 @@ nav:
     - Supported Models: user_guide/supported_models.md
   - Developer Guide:
     - Contributing: contributing/README.md
+    - Architecture: contributing/architecture.md
     - Continuous Batching:
       - Overview: contributing/continuous_batching/overview.md
       - Tests:


### PR DESCRIPTION
# Description

Adds new architecture doc to the "Developer Guide" view. 