### PR TITLE
[CP] rewrite scheduler constraints for chunked prefill (🐛 fix)

### DIFF
--- a/vllm_spyre/v1/core/scheduler.py
+++ b/vllm_spyre/v1/core/scheduler.py
@@ -561,9 +561,9 @@ class ChunkedPrefillSpyreScheduler(ContinuousBatchingSpyreScheduler):
 
         # calculate new max tkv of the batch given the new sequence joins
         # considers all possible cases:
-        # - prompt_len > self.tkv by more than self.block_size
+        # - prompt_len > self.tkv and fall into different blocks
         # - prompt_len and self.tkv fall within the same block
-        # - prompt_len < self.tkv by more than self.block_size
+        # - prompt_len < self.tkv and fall into different blocks
         prompt_len = request.num_prompt_tokens
         n_blocks = math.floor(max(self.tkv, prompt_len) / self.block_size)
         max_tkv = n_blocks * self.block_size + max(


### PR DESCRIPTION
rewriting the `can_schedule()` constraints for chunked prefill (reusing `can_schedule()` of the continuous batching scheduler as currently on main does not check all conditions correctly). 

-> this is a conservative formulation, some conditions (cond3 and cond5) will be written more optimal soon...

notes:
- for chunked prefill `VLLM_SPYRE_ENABLE_PREFILL_OPTIMIZATION` will always be **_ON_**. 
- getting rid of `VLLM_SPYRE_N_TOKENS_PREFILL_PRIO` for chunked prefill: does not make sense as we choose the chunk size to be as small as not to peak ITL too much. 