### PR TITLE
[CP] fix empty model runner output

### DIFF
--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -2191,7 +2191,7 @@ class ChunkedPrefillModelRunner(ContinuousBatchingSpyreModelRunner):
                                         prompt_logprobs_dict={},
                                         pooler_output=[],
                                         num_nans_in_logits=None,
-                                        tkv=self.tkv,
+                                        tkv=0,
                                         n_free_blocks=self.get_n_free_blocks(),
                                         left_padding={})
 


### PR DESCRIPTION
### bug description
currently, when no sequences are left in the batch, the scheduler sees the old tkv from the sequence that has left the batch last. This creates problems for the scheduler level tests with a cached engine. This issue was not present for continuous batching. 


for **continuous batching** we had: 

```
return CBSpyreModelRunnerOutput(
            **asdict(output),
            tkv=self.tkv
            if scheduler_output.total_num_scheduled_tokens > 0 else 0,
            n_free_blocks=self.get_n_free_blocks(),
        )
```
see lines [here](https://github.com/vllm-project/vllm-spyre/blob/c6cc61f8f26baac93b362debaf3f889f5d238c25/vllm_spyre/v1/worker/spyre_model_runner.py#L1320-L1325)

for chunked prefill we have:

```
def get_empty_output(self):
        return CPSpyreModelRunnerOutput(req_ids=[],
                                        req_id_to_index={},
                                        sampled_token_ids=[],
                                        logprobs=None,
                                        prompt_logprobs_dict={},
                                        pooler_output=[],
                                        num_nans_in_logits=None,
                                        tkv=self.tkv,
                                        n_free_blocks=self.get_n_free_blocks(),
                                        left_padding={})
```
### proposed fix
set `tkv = 0` in empty model runner for **chunked prefill** (`get_empty_output()`).

Note that `get_empty_output()` is called for non-driver workers and when there is no work to do (cleanup). While the output of the former case does not matter, it does matter for the latter. Hence I suggest to simply set `tkv=0` in `get_empty_output()`.  