### PR TITLE
[CP] Simplify code

### DIFF
--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -1873,7 +1873,7 @@ class ChunkedPrefillModelRunner(ContinuousBatchingSpyreModelRunner):
                                     device=self.device,
                                     dtype=torch.int64).unsqueeze(0)
 
-        if prompt_len < chunk_size:
+        if prompt_len <= chunk_size:
             # Case I - Prompt fits in a single chunk
             chunk_start = 0
             chunk_end = prompt_len


### PR DESCRIPTION
By substituting a few variables by their definitions, some terms cancel each other out and the code can be simplified
