### PR TITLE
[CB] tighten constraint max model length decode sequences

### DIFF
--- a/vllm_spyre/v1/core/scheduler.py
+++ b/vllm_spyre/v1/core/scheduler.py
@@ -248,9 +248,11 @@ class ContinuousBatchingSpyreScheduler(SpyreScheduler):
         # if the tkv has been shifted
         if tkv > self.tkv:
             for req in self.running:
-                # note that this a conservative upper bound not including
-                # the already generated tokens
-                cond3_current = req.max_tokens <= (max_context_len - tkv)
+                n_generated_output_tokens = (req.num_computed_tokens -
+                                             req.num_prompt_tokens)
+                max_tokens_remaining = (req.max_tokens -
+                                        n_generated_output_tokens)
+                cond3_current = max_tokens_remaining <= (max_context_len - tkv)
                 cond3 = cond3 and cond3_current
                 # early exiting loop if condition is violated
                 if not cond3:


### PR DESCRIPTION
applying the tighter constraint for the max model length to the continuous batching scheduler too. 
this establishes parity between the chunked prefill and continuous batching constraints. 

see discussion [here](https://github.com/vllm-project/vllm-spyre/pull/562#discussion_r2543133714)