### PR TITLE
[Docs] Update GH artifact versions

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -22,7 +22,7 @@ jobs:
     needs: build
     steps:
       - name: Download built site
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: built-site
           path: site


### PR DESCRIPTION
Build failed due to deprecated version. 

https://github.com/vllm-project/vllm-spyre/actions/runs/19741570413/job/56566518136#step:1:32