### PR TITLE
[Docs] Avoid multiple artifacts

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -35,5 +35,5 @@ jobs:
       - name: Upload built site artifact
         uses: actions/upload-artifact@v4
         with:
-          name: built-site
+          name: github-pages
           path: site

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -23,15 +23,5 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Download built site
-        uses: actions/download-artifact@v5
-        with:
-          name: built-site
-          path: site
-      - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: site
-
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
`actions/deploy-pages@v4` looks for an artifact named `github-pages`. Between these two workflows, we were creating two artifacts. 