### PR TITLE
:fire: Limit CI usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,13 +101,12 @@ jobs:
             os: "ubuntu-latest"
             python_version: "3.12"
 
-        # Exclude vLLM:main if PR does NOT have "ready" label AND auto-merge is not enabled
+        # Only run vllm:main jobs on PRs with `vllm:main` label
         exclude: >-
           ${{
-            github.event_name == 'pull_request' &&
+            github.event_name != 'pull_request' ||
             !(
-              contains(toJson(github.event.pull_request.labels), '"ready"') ||
-              github.event.action == 'auto_merge_enabled'
+              contains(toJson(github.event.pull_request.labels), '"vllm:main"')
             )
               && fromJSON('[{"vllm_version":{"name":"vLLM:main"}}]')
               || fromJSON('[]')


### PR DESCRIPTION
# Description

This PR:
- Removes a duplicated set of precompilation tests
- Removes the vllm:main tests from the main branch
- Uses a new `vllm:main` label to enable the main tests (in preparation for re-using the `ready` label to gate all the test jobs)