### PR TITLE
:bug: try again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,11 +104,10 @@ jobs:
         # Only run vllm:main jobs on PRs with `vllm:main` label
         exclude: >-
           ${{
-            github.event_name != 'pull_request' ||
-            !(
-              contains(toJson(github.event.pull_request.labels), '"vllm:main"')
-            )
-              && fromJSON('[{"vllm_version":{"name":"vLLM:main"}}]')
+            (
+              github.event_name != 'pull_request' ||
+              !(contains(toJson(github.event.pull_request.labels), '"vllm:main"'))
+            ) && fromJSON('[{"vllm_version":{"name":"vLLM:main"}}]')
               || fromJSON('[]')
           }}
 


### PR DESCRIPTION
# Description

Instead of https://github.com/vllm-project/vllm-spyre/pull/597, this might fix the failure on main. This wraps an `||` so that we don't short-circuit to `true` and instead print some json