### PR TITLE
:zap: Reduce idle prefills for better throughput

### DIFF
--- a/tests/e2e/test_spyre_pc_scheduler_steps.py
+++ b/tests/e2e/test_spyre_pc_scheduler_steps.py
@@ -1376,7 +1376,7 @@ def test_multi_chunk_full_match(
             "block_tables": {"0": [1, 2, 3, 4, 5, 6]},
             "block_ref_count": {1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1},
         },
-        {   # prefill chunks 1+2 seq 1
+        {  # prefill chunks 1+2 seq 1
             # prefix hit!
             "step": 4,
             "tkv": 384,
@@ -1393,7 +1393,7 @@ def test_multi_chunk_full_match(
             "block_tables": {"0": [1, 2, 3, 4, 5, 6], "1": [1, 2, 3, 4, 5, 6]},
             "block_ref_count": {1: 2, 2: 2, 3: 2, 4: 2, 5: 2, 6: 2},
         },
-        {   # prefill chunk 3 seq 1
+        {  # prefill chunk 3 seq 1
             # cannot use prefix, as the last chunk has to always be recomputed
             "step": 5,
             "tkv": 384,
@@ -1723,7 +1723,7 @@ def test_multi_chunk_partial_match_aligned(
             "n_used_blocks": 6,
             "n_prefix_hits": 0,
         },
-        {   # prefill chunk 1 and 2 seq 1
+        {  # prefill chunk 1 and 2 seq 1
             # prefix hit!
             "step": 4,
             "tkv": 384,
@@ -1734,9 +1734,9 @@ def test_multi_chunk_partial_match_aligned(
             "n_used_blocks": 8,
             "n_prefix_hits": 1,
             # The number of cached blocks is determined up front
-            "n_cached_blocks": 4 # Reusing two chunks (4 blocks)
+            "n_cached_blocks": 4,  # Reusing two chunks (4 blocks)
         },
-        {   # prefill chunk 3 seq 1
+        {  # prefill chunk 3 seq 1
             "step": 5,
             "tkv": 384,
             "waiting": [],

--- a/vllm_spyre/v1/core/scheduler.py
+++ b/vllm_spyre/v1/core/scheduler.py
@@ -455,16 +455,14 @@ class ChunkedPrefillSpyreScheduler(ContinuousBatchingSpyreScheduler):
             is_first_chunk = req.num_computed_tokens <= self.chunk_size
             is_last_chunk = req.num_computed_tokens == req.num_prompt_tokens
             if is_first_chunk and not is_last_chunk:
-
-                left_padding = model_runner_output.left_padding.get(
-                    req.request_id, 0)
-                prefix_cache_len = model_runner_output.prefix_cache_hit_len.get(
-                    req.request_id, 0)
+                left_padding = model_runner_output.left_padding.get(req.request_id, 0)
+                prefix_cache_len = model_runner_output.prefix_cache_hit_len.get(req.request_id, 0)
 
                 req.num_computed_tokens = self.adjust_computed_tokens(
                     computed_tokens=req.num_computed_tokens,
                     left_padding=left_padding,
-                    prefix_cache_len=prefix_cache_len)
+                    prefix_cache_len=prefix_cache_len,
+                )
 
         # Remove completed prefills
         self.ongoing_prefills = [
@@ -484,8 +482,9 @@ class ChunkedPrefillSpyreScheduler(ContinuousBatchingSpyreScheduler):
 
         return super().update_from_output(scheduler_output, model_runner_output)
 
-    def adjust_computed_tokens(self, computed_tokens: int, left_padding: int,
-                               prefix_cache_len: int) -> int:
+    def adjust_computed_tokens(
+        self, computed_tokens: int, left_padding: int, prefix_cache_len: int
+    ) -> int:
         """
         Returns an adjusted `num_computed_tokens` given left padding and prefix
         cache hit info.

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -2476,7 +2476,7 @@ class ChunkedPrefillModelRunner(ContinuousBatchingSpyreModelRunner):
                 left_padding=left_padding,
                 kv_cache_usage=self.get_kv_cache_usage(),
                 prefix_cache_stats=self.prefix_cache_stats,
-                prefix_cache_hit_len=self.get_prefix_cache_len()
+                prefix_cache_hit_len=self.get_prefix_cache_len(),
             )
 
         # Sample the next token.


### PR DESCRIPTION
# Description

Currently prefix caching is implemented entirely in the model runner with no changes in the scheduler. This means that when we hit large prefixes in cache, the scheduler still thinks it has to schedule many prefill chunks that have already been loaded into cache, resulting in extra idle prefill iterations. This causes slow performance as those idle prefill iterations are interleaved with decode iterations, resulting in multiple seconds of extra queuing for requests in some cases.

This PR simply passes back the prefix cache hit length to the scheduler on the first chunk of a prefill so that the scheduler can account for the cache hit and advance the request to the next chunk that requires prefilling. This change is reflected in the existing multi-chunk prefix match test case.

Benchmarks show an appreciable speedup. Using:
```
vllm bench serve --dataset-name prefix_repetition --model ibm-granite/granite-3.3-8b-instruct --num-prompts 64 --max-concurrency 32 --prefix-repetition-prefix-len 8192 --percentile-metrics="ttft,tpot,itl,e2el" --metric-percentiles="95,99" 
```

We can see multi-second speedups in TTFT and end-to-end latency ⚡⚡⚡