### PR TITLE
Fix compatibility issue when trust_remote_code==True

### DIFF
--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -41,11 +41,12 @@ def test_pin_memory_available():
         try:
             from vllm.utils import is_pin_memory_available  # # noqa
             from vllm.utils import make_tensor_with_pad  # # noqa
+            from vllm.utils import init_cached_hf_modules  # # noqa
         except ImportError as e:
             raise AssertionError(
                 "remove backwards compatibility imports for "
-                "is_pin_memory_available and "
-                "make_tensor_with_pad"
+                "is_pin_memory_available, "
+                "make_tensor_with_pad and init_cached_hf_modules"
             ) from e
 
 

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -271,7 +271,11 @@ class SpyreWorker(WorkerBase):
             )
         if self.model_config.trust_remote_code:
             # note: lazy import to avoid importing torch before initializing
-            from vllm.utils import init_cached_hf_modules
+            try:
+                # pre 0.11.1 compatibility
+                from vllm.utils import init_cached_hf_modules
+            except ImportError:
+                from vllm.utils.import_utils import init_cached_hf_modules
 
             init_cached_hf_modules()
         self.model_runner: Union[


### PR DESCRIPTION
There is an vllm.utils import that only fails when `trust_remote_code=True` is set because the import is inside an `if`. The import still uses the pre utils refactoring path.
