### PR TITLE
[PC] 🐛 fix: only add left padding for first chunk during masking.

### DIFF
--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -1947,7 +1947,7 @@ class ChunkedPrefillModelRunner(ContinuousBatchingSpyreModelRunner):
             # blocks will the the number of blocks to recompute.
             if chunk_i == chunks_from_cache:
                 blocks_to_recompute = request.total_hit_blocks - request.usable_blocks
-                # For the first block we must also account for left-padding blocks: 
+                # For the first block we must also account for left-padding blocks:
                 # blocks_to_recompute = total_hit_blocks - usable_blocks + padding_blocks
                 if chunk_i == 0:
                     blocks_to_recompute += request.padding_blocks


### PR DESCRIPTION
The left padding should only influence the `blocks_to_recompute` if the re-computation happens in the first chunk (where left padding blocks are potentially present). The current implementation seems to add `request.padding_blocks`  to `blocks_to_recompute` also for non-first chunks, which is wrong. 

ToDo:
- [ ] @maxdebayser added a test case covering this in #615 (see diffs [here](https://github.com/vllm-project/vllm-spyre/pull/615/files#diff-07e57724b3132f027d058b51df42b0084859b06be430cef440fe9409148e2fe0R341))
