### PR TITLE
Add support for mistral3 (no vision encoding)

### DIFF
--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -350,6 +350,9 @@ class ContinuousBatchingFmsModel(FmsModelBase):
         elif self.config.model_type == "gpt_bigcode":
             self.kv_cache_specs["num_layers"] = self.config.n_layer
             self.kv_cache_specs["head_dim"] = self.config.n_embd // self.config.n_head
+        elif self.config.model_type == "pixtral":
+            self.kv_cache_specs["num_layers"] = self.config.text_config.num_hidden_layers
+            self.kv_cache_specs["head_dim"] = self.config.text_config.head_dim
         else:
             raise NotImplementedError(
                 f"[SpyreCausalLM] model type {self.config.model_type} "

--- a/vllm_spyre/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre/v1/worker/spyre_model_runner.py
@@ -354,6 +354,12 @@ class SpyreModelRunner(
 
     @property
     def vocab_size(self) -> int:
+        cfg = self.model.model.model.config
+        # Mistral3 MM models, which currently only run text;
+        # TODO (Alex) move this to utils after granite vision
+        # is merged.
+        if hasattr(cfg, "text_config"):
+            return cfg.text_config.src_vocab_size
         return self.model.model.model.config.src_vocab_size
 
     def pad_input_ids(


### PR DESCRIPTION
# Description
Supports running only the text part of multimodal mistral3 models through vLLM Spyre; I haven't been able to validate on AIU quite yet, but have at least ensured I can run it with the eager backend.

This PR is dependent on the following PR in FMS: https://github.com/foundation-model-stack/foundation-model-stack/pull/501

I will follow up in both FMS and here (after the granite vision PR is merged) to add support for pixtral in separate PRs & implement the multimodal utils.
