### PR TITLE
Update pyproject vllm max version to 0.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = {text = "Apache 2"}
 dependencies = [
     "fms-model-optimizer[fp8]>=0.8.0",
     "ibm-fms>=1.6.0,<2.0",
-    "vllm>=0.10.2,<=0.12.0",
+    "vllm>=0.10.2,<=0.13.0",
     "pytest-mock>=3.15.0",
 ]
 requires-python = ">=3.11"


### PR DESCRIPTION
Looks like this was missed in https://github.com/vllm-project/vllm-spyre/pull/623/changes