### PR TITLE
test: fix test_spyre_seed to account for batch variance

### DIFF
--- a/tests/e2e/test_spyre_seed.py
+++ b/tests/e2e/test_spyre_seed.py
@@ -1,6 +1,9 @@
-"""Verification of seeded random sampling to be deterministic
+"""Verification of seeded random sampling behavior.
 
-Run `python -m pytest tests/e2e/test_spyre_seed.py`.
+Tests for both single requests and in batched requests. Due to numerical
+differences when batching, we cannot compare responses within a batch from a
+single request. However, multiple batched requests should exhibit the desired
+behavior where the seed induces deterministic sampling.
 """
 
 import math
@@ -10,16 +13,51 @@ from output_util import generate_spyre_vllm_output, kwargs_for_mode
 from spyre_util import DecodeWarmupShapes, ModelInfo, get_chicken_soup_prompts
 from vllm import SamplingParams
 
-sb_mark = pytest.param("sb", marks=pytest.mark.sb, id="sb")
-cb_mark = pytest.param("cb", marks=pytest.mark.cb, id="cb")
+
+def _generate_two_outputs(
+    seed: int | None = None,
+    **kwargs,
+):
+    """Helper to generate multiple separate requests with the same configuration."""
+    max_new_tokens = kwargs["warmup_shapes"][0][1]
+    prompts = get_chicken_soup_prompts(1) * kwargs["batch_size"]
+
+    sampling_params = SamplingParams(
+        min_tokens=max_new_tokens,
+        max_tokens=max_new_tokens,
+        temperature=kwargs["temperature"],
+        logprobs=0,
+        ignore_eos=True,
+        seed=seed,
+    )
+
+    mode_kwargs = kwargs_for_mode(kwargs["mode"], kwargs["max_num_seqs"], kwargs["warmup_shapes"])
+
+    results = []
+    for _ in range(2):
+        outputs = generate_spyre_vllm_output(
+            model=kwargs["model"],
+            prompts=prompts,
+            max_model_len=kwargs["max_model_len"],
+            sampling_params=sampling_params,
+            tensor_parallel_size=1,
+            backend=kwargs["backend"],
+            monkeypatch=kwargs["monkeypatch"],
+            **mode_kwargs,
+        )
+        results.append(outputs)
+
+    return results
 
 
-@pytest.mark.parametrize("temperature", [0.1, 1.0])
+@pytest.mark.parametrize("temperature", [1.5])
 @pytest.mark.parametrize("seed", [42])
-def test_seed(
+@pytest.mark.parametrize("batch_size", [1, 3])
+def test_seed_deterministic(
     model: ModelInfo,
     temperature: float,
     seed: int,
+    batch_size: int,
     max_model_len: int,
     max_num_seqs: int,
     warmup_shapes: DecodeWarmupShapes,
@@ -27,54 +65,83 @@ def test_seed(
     mode: str,
     monkeypatch: pytest.MonkeyPatch,
     use_llm_cache,
-    runtime_xfail,
 ) -> None:
+    """Test that seeded sampling produces identical results across requests.
+
+    Tests both single requests (batch_size=1) and batched requests (batch_size>1).
+    With seeding, the entire batch should be reproducible across multiple requests,
+    even though individual items within a batch may differ from each other due
+    to numerical variance when batching.
     """
-    The warmup is based on a single shape. After the warmup,
-    output is generated for one request with 5 identical prompts
-    using random sampling (non-zero temperature) in combination
-    with a seed. The generated output, including text, token ids,
-    logprobs is verified to be identical for all 5 sequences.
-    """
+    results = _generate_two_outputs(**locals())
 
-    if mode in ["cp", "pc"]:
-        runtime_xfail(reason="Seed is broken in chunked prefill, please fix me!")
+    results_1, results_2 = results[0], results[1]
 
-    max_new_tokens = warmup_shapes[0][1]
+    # Verify batch results are identical across requests
+    assert len(results_1) == len(results_2) == batch_size
 
-    prompts = get_chicken_soup_prompts(1) * 5
+    for i in range(batch_size):
+        result_1 = results_1[i]
+        result_2 = results_2[i]
 
-    vllm_sampling_params = SamplingParams(
-        max_tokens=max_new_tokens,
-        temperature=temperature,
-        logprobs=0,  # return logprobs of generated tokens only
-        ignore_eos=True,
-        seed=seed,
-    )
+        assert result_1["text"] == result_2["text"]
+        assert len(result_1["logprobs"]) == len(result_2["logprobs"])
 
-    vllm_results = generate_spyre_vllm_output(
-        model=model,
-        prompts=prompts,
-        max_model_len=max_model_len,
-        sampling_params=vllm_sampling_params,
-        tensor_parallel_size=1,
-        backend=backend,
-        monkeypatch=monkeypatch,
-        **kwargs_for_mode(mode, max_num_seqs, warmup_shapes),
-    )
-
-    # compare all generated outputs against the first generated output
-    for vllm_result in vllm_results:
-        assert vllm_result["text"] == vllm_results[0]["text"]
-
-        # compare logprobs for all tokens between
-        # the current and the first sequence
-        assert len(vllm_result["logprobs"]) == len(vllm_results[0]["logprobs"])
-        for token_id, logprob, token_id_0, logprob_0 in zip(
-            vllm_result["token_ids"],
-            vllm_result["logprobs"],
-            vllm_results[0]["token_ids"],
-            vllm_results[0]["logprobs"],
+        for token_id_1, logprob_1, token_id_2, logprob_2 in zip(
+            result_1["token_ids"],
+            result_1["logprobs"],
+            result_2["token_ids"],
+            result_2["logprobs"],
         ):
-            assert token_id == token_id_0
-            assert math.isclose(logprob, logprob_0, rel_tol=0.1)
+            assert token_id_1 == token_id_2
+            assert math.isclose(logprob_1, logprob_2, rel_tol=0.1)
+
+
+@pytest.mark.parametrize("temperature", [1.5])
+@pytest.mark.parametrize("batch_size", [1, 3])
+def test_seed_variability(
+    model: ModelInfo,
+    temperature: float,
+    batch_size: int,
+    max_model_len: int,
+    max_num_seqs: int,
+    warmup_shapes: DecodeWarmupShapes,
+    backend: str,
+    mode: str,
+    monkeypatch: pytest.MonkeyPatch,
+    use_llm_cache,
+) -> None:
+    """Test that unseeded sampling produces different results across requests.
+
+    Tests both single requests (batch_size=1) and batched requests (batch_size>1).
+    Without seeding, results should vary within a batch and across multiple
+    requests.
+    """
+    results = _generate_two_outputs(**locals())
+
+    results_1, results_2 = results[0], results[1]
+
+    # Verify at least one result differs within the batch
+    if batch_size > 1:
+        any_different = False
+        for i in range(batch_size):
+            if i + 1 >= batch_size:
+                break
+            if results_1[i]["text"] != results_1[i + 1]["text"]:
+                any_different = True
+                break
+        assert any_different, "Unseeded outputs should produce different results within a batch"
+
+    # Verify at least one result differs between requests
+    assert len(results_1) == len(results_2) == batch_size
+
+    any_different = False
+    for i in range(batch_size):
+        if results_1[i]["text"] != results_2[i]["text"]:
+            any_different = True
+            break
+
+    assert any_different, "Unseeded outputs should produce different results between requests"
+
+
+# Made with Bob


### PR DESCRIPTION
# Description

Test seeded random sampling behavior for both single and batched requests by comparing across requests instead of within a request.

`test_seed` test was made `runtime_xfail` in https://github.com/vllm-project/vllm-spyre/pull/661/changes/791b8b5e4d64ece45d9d5becb040399ca81a9243 because it was observed to fail with FP8 + Chunked Prefill. Due to numerical differences in batch processing, individual items within a batch may differ even when seeded; this is particularly true for FP8 and Chunked Prefill which increase the variance. However, entire batches should be reproducible across multiple requests when using the same seed.