### PR TITLE
Relax vllm constraint to allow 0.11.0.x versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = {text = "Apache 2"}
 dependencies = [
     "fms-model-optimizer[fp8]>=0.6.0",
     "ibm-fms>=1.4.0,<2.0",
-    "vllm>=0.10.2,<=0.11.0",
+    "vllm>=0.10.2,<0.11.1",
     "pytest-mock>=3.15.0",
 ]
 requires-python = ">=3.11"


### PR DESCRIPTION
# Description

This allows downstream forks of vllm 0.11.0 to be created with additional versions (such as 0.11.0.1) that are compatible with 0.11.0 but preferred in the range "<0.11.1".

Note that this branch was created from the v1.2.3 tag, and is not intended to be merged to main. The only action required here is to tag this commit as `v1.2.3.post1` so that it can be fetched as a specific version that includes the fix submitted here.