### PR TITLE
Update model configurator for 2.0 branch

### DIFF
--- a/tests/config/test_integration.py
+++ b/tests/config/test_integration.py
@@ -50,23 +50,6 @@ class TestModelMatching:
         assert configurator.device_config is not None
         assert "VLLM_DT_MAX_BATCH_TKV_LIMIT" in configurator.device_config.env_vars
 
-    def test_match_granite_3_3_static_config(self, registry, granite_3_3_hf_config):
-        """Test matching granite-3.3-8b-instruct with static batching config."""
-        vllm_config = create_vllm_config(
-            hf_config=granite_3_3_hf_config,
-            world_size=4,
-        )
-
-        warmup_shapes = [(6144, 2048, 1)]
-        configurator = registry.get_configurator_for_runtime(vllm_config, warmup_shapes)
-
-        assert configurator is not None
-        assert isinstance(configurator, ModelConfigurator)
-        assert configurator.model_config.name == "ibm-granite/granite-3.3-8b-instruct"
-        assert (
-            configurator.device_config is None
-        )  # Static batching configs don't have device_config
-
     def test_match_granite_4_cb_config(self, registry, granite_4_hf_config):
         """Test matching granite-4-8b-dense with CB config."""
         vllm_config = create_vllm_config(
@@ -88,7 +71,7 @@ class TestModelMatching:
             max_num_seqs=None,  # Static batching
         )
 
-        warmup_shapes = [(512, 0, 64)]
+        warmup_shapes = [(512, 64)]
         configurator = registry.get_configurator_for_runtime(vllm_config, warmup_shapes)
 
         assert configurator is not None

--- a/tests/config/test_model_config.py
+++ b/tests/config/test_model_config.py
@@ -193,33 +193,31 @@ class TestWarmupShape:
 
     def test_create_warmup_shape(self):
         """Test creating warmup shape."""
-        shape = WarmupShape(prompt_len=64, new_tokens=20, batch_size=4)
+        shape = WarmupShape(prompt_len=64, batch_size=4)
         assert shape.prompt_len == 64
-        assert shape.new_tokens == 20
         assert shape.batch_size == 4
 
     def test_to_tuple(self):
         """Test converting warmup shape to tuple."""
-        shape = WarmupShape(prompt_len=64, new_tokens=20, batch_size=4)
-        assert shape.to_tuple() == (64, 20, 4)
+        shape = WarmupShape(prompt_len=64, batch_size=4)
+        assert shape.to_tuple() == (64, 4)
 
     def test_from_dict(self):
         """Test creating warmup shape from dict."""
-        data = {"prompt_len": 128, "new_tokens": 40, "batch_size": 2}
+        data = {"prompt_len": 128, "batch_size": 2}
         shape = WarmupShape.from_dict(data)
         assert shape.prompt_len == 128
-        assert shape.new_tokens == 40
         assert shape.batch_size == 2
 
     def test_from_dict_missing_key(self):
         """Test that missing keys raise ValueError."""
-        data = {"prompt_len": 128, "new_tokens": 40}
+        data = {"prompt_len": 128}
         with pytest.raises(ValueError, match="Missing key"):
             WarmupShape.from_dict(data)
 
     def test_from_dict_invalid_value(self):
         """Test that invalid values raise ValueError."""
-        data = {"prompt_len": "not_an_int", "new_tokens": 40, "batch_size": 2}
+        data = {"prompt_len": "not_an_int", "batch_size": 2}
         with pytest.raises(ValueError, match="must be valid integers"):
             WarmupShape.from_dict(data)
 
@@ -230,29 +228,29 @@ class TestStaticBatchingConfig:
     def test_create_config(self):
         """Test creating static batching config."""
         warmup_shapes = [
-            WarmupShape(prompt_len=64, new_tokens=20, batch_size=4),
-            WarmupShape(prompt_len=128, new_tokens=40, batch_size=2),
+            WarmupShape(prompt_len=64, batch_size=4),
+            WarmupShape(prompt_len=128, batch_size=2),
         ]
         config = StaticBatchingConfig(tp_size=1, warmup_shapes=warmup_shapes)
         assert config.tp_size == 1
         assert len(config.warmup_shapes) == 2
-        assert config.warmup_shapes[0].to_tuple() == (64, 20, 4)
-        assert config.warmup_shapes[1].to_tuple() == (128, 40, 2)
+        assert config.warmup_shapes[0].to_tuple() == (64, 4)
+        assert config.warmup_shapes[1].to_tuple() == (128, 2)
 
     def test_from_dict(self):
         """Test creating static batching config from dict."""
         data = {
             "tp_size": 1,
             "warmup_shapes": [
-                {"prompt_len": 64, "new_tokens": 20, "batch_size": 4},
-                {"prompt_len": 128, "new_tokens": 40, "batch_size": 2},
+                {"prompt_len": 64, "batch_size": 4},
+                {"prompt_len": 128, "batch_size": 2},
             ],
         }
         config = StaticBatchingConfig.from_dict(data)
         assert config.tp_size == 1
         assert len(config.warmup_shapes) == 2
-        assert config.warmup_shapes[0].to_tuple() == (64, 20, 4)
-        assert config.warmup_shapes[1].to_tuple() == (128, 40, 2)
+        assert config.warmup_shapes[0].to_tuple() == (64, 4)
+        assert config.warmup_shapes[1].to_tuple() == (128, 2)
 
 
 class TestContinuousBatchingConfig:
@@ -328,7 +326,7 @@ class TestModelConfig:
     def test_create_with_configs(self):
         """Test creating model config with configurations."""
         architecture = ArchitecturePattern(model_name="granite-model", model_type="granite")
-        warmup_shape = WarmupShape(prompt_len=64, new_tokens=20, batch_size=4)
+        warmup_shape = WarmupShape(prompt_len=64, batch_size=4)
         static_config = StaticBatchingConfig(tp_size=1, warmup_shapes=[warmup_shape])
         device_config = DeviceConfig(tp_size=4, env_vars={"TEST": "value"})
         cb_config = ContinuousBatchingConfig(
@@ -353,7 +351,7 @@ class TestModelConfig:
             "static_batching_configs": [
                 {
                     "tp_size": 1,
-                    "warmup_shapes": [{"prompt_len": 64, "new_tokens": 20, "batch_size": 4}],
+                    "warmup_shapes": [{"prompt_len": 64, "batch_size": 4}],
                 }
             ],
             "continuous_batching_configs": [],
@@ -382,7 +380,7 @@ class TestModelConfig:
             "static_batching_configs": [
                 {
                     "tp_size": 1,
-                    "warmup_shapes": [{"prompt_len": 64, "new_tokens": 20, "batch_size": 4}],
+                    "warmup_shapes": [{"prompt_len": 64, "batch_size": 4}],
                 }
             ],
             "continuous_batching_configs": [
@@ -393,7 +391,7 @@ class TestModelConfig:
         assert len(config.static_batching_configs) == 1
         assert len(config.continuous_batching_configs) == 1
         assert config.static_batching_configs[0].tp_size == 1
-        assert config.static_batching_configs[0].warmup_shapes[0].to_tuple() == (64, 20, 4)
+        assert config.static_batching_configs[0].warmup_shapes[0].to_tuple() == (64, 4)
         assert config.continuous_batching_configs[0].tp_size == 1
         assert config.continuous_batching_configs[0].max_model_len == 2048
 
@@ -404,7 +402,7 @@ class TestModelConfig:
             "static_batching_configs": [
                 {
                     "tp_size": 1,
-                    "warmup_shapes": [{"prompt_len": 64, "new_tokens": 20, "batch_size": 4}],
+                    "warmup_shapes": [{"prompt_len": 64, "batch_size": 4}],
                 }
             ],
             "continuous_batching_configs": [
@@ -434,7 +432,7 @@ class TestModelConfig:
             "static_batching_configs": [
                 {
                     "tp_size": 1,
-                    "warmup_shapes": [{"prompt_len": 512, "new_tokens": 0, "batch_size": 64}],
+                    "warmup_shapes": [{"prompt_len": 512, "batch_size": 64}],
                 }
             ],
             "continuous_batching_configs": [

--- a/tests/config/test_model_registry.py
+++ b/tests/config/test_model_registry.py
@@ -23,13 +23,10 @@ models:
       - tp_size: 1
         warmup_shapes:
           - prompt_len: 64
-            new_tokens: 20
             batch_size: 4
           - prompt_len: 128
-            new_tokens: 40
             batch_size: 2
           - prompt_len: 256
-            new_tokens: 80
             batch_size: 1
     """
     data = yaml.safe_load(yaml_content)
@@ -250,11 +247,11 @@ class TestWarmupShapesSubset:
     @pytest.mark.parametrize(
         "runtime_shapes,should_match,description",
         [
-            ([(64, 20, 4), (128, 40, 2)], True, "Subset of shapes should match"),
-            ([(256, 80, 1)], True, "Single shape should match if in config"),
-            ([(512, 100, 1)], False, "Non-matching shape should not match"),
-            ([(64, 20, 4), (512, 100, 1)], False, "Partial match should fail"),
-            ([(256, 80, 1), (64, 20, 4)], True, "Different order should match"),
+            ([(64, 4), (128, 2)], True, "Subset of shapes should match"),
+            ([(256, 1)], True, "Single shape should match if in config"),
+            ([(512, 1)], False, "Non-matching shape should not match"),
+            ([(64, 4), (512, 1)], False, "Partial match should fail"),
+            ([(256, 1), (64, 4)], True, "Different order should match"),
             ([], False, "Empty shapes should not match"),
         ],
         ids=["subset", "single", "no_match", "partial_fail", "order_independent", "empty"],
@@ -347,18 +344,14 @@ models:
       - tp_size: 1
         warmup_shapes:
           - prompt_len: 64
-            new_tokens: 20
             batch_size: 4
           - prompt_len: 128
-            new_tokens: 40
             batch_size: 2
       - tp_size: 1
         warmup_shapes:
           - prompt_len: 128
-            new_tokens: 40
             batch_size: 2
           - prompt_len: 64
-            new_tokens: 20
             batch_size: 4
         """
 
@@ -433,7 +426,6 @@ models:
       - tp_size: 1
         warmup_shapes:
           - prompt_len: 64
-            new_tokens: 20
             batch_size: 4
         """
         data = yaml.safe_load(yaml_content)
@@ -450,7 +442,7 @@ models:
         )
 
         # Provide warmup_shapes that DON'T match the static batching config
-        non_matching_warmup_shapes = [(128, 40, 2)]  # Not in static config
+        non_matching_warmup_shapes = [(128, 2)]  # Not in static config
 
         configurator = registry.get_configurator_for_runtime(
             vllm_config, warmup_shapes=non_matching_warmup_shapes
@@ -483,10 +475,8 @@ models:
       - tp_size: 1
         warmup_shapes:
           - prompt_len: 64
-            new_tokens: 20
             batch_size: 4
           - prompt_len: 128
-            new_tokens: 40
             batch_size: 2
         """
         data = yaml.safe_load(yaml_content)
@@ -503,7 +493,7 @@ models:
         )
 
         # Provide warmup_shapes that DO match the static batching config
-        matching_warmup_shapes = [(64, 20, 4)]
+        matching_warmup_shapes = [(64, 4)]
 
         configurator = registry.get_configurator_for_runtime(
             vllm_config, warmup_shapes=matching_warmup_shapes

--- a/tests/e2e/test_spyre_scoring.py
+++ b/tests/e2e/test_spyre_scoring.py
@@ -7,8 +7,8 @@ from spyre_util import get_spyre_backend_list, get_spyre_model_list
 @pytest.mark.parametrize("model", get_spyre_model_list(isScoring=True))
 @pytest.mark.parametrize(
     "warmup_shapes",
-    [  # (prompt_length/new_tokens/batch_size)
-        pytest.param([(64, 0, 4)]),
+    [  # (prompt_length/batch_size)
+        pytest.param([(64, 4)]),
     ],
 )
 @pytest.mark.parametrize("backend", get_spyre_backend_list())

--- a/vllm_spyre/config/README.md
+++ b/vllm_spyre/config/README.md
@@ -131,10 +131,12 @@ models:
       num_hidden_layers: 32  # Optional: for precise matching
       vocab_size: 128256  # Optional: for precise matching
 
-    # Static batching configuration (if supported)
+    # Static batching configuration (pooling models only)
     static_batching_configs:
       - tp_size: 1
-        warmup_shapes: [[2048, 1024, 16]]  # [prompt_len, new_tokens, batch_size]
+        warmup_shapes:
+          - prompt_len: 512
+            batch_size: 64
 
     # Continuous batching configuration (if supported)
     continuous_batching_configs:
@@ -178,18 +180,19 @@ architecture:
 
 ### Static Batching Configurations
 
-For models that support static batching (fixed batch sizes):
+For pooling models (embeddings, scoring) that use static batching:
 
 ```yaml
 static_batching_configs:
   - tp_size: 1
     warmup_shapes:
-      - [2048, 1024, 16]  # [prompt_length, new_tokens, batch_size]
-      - [4096, 512, 8]
-  - tp_size: 4
-    warmup_shapes:
-      - [6144, 2048, 1]
+      - prompt_len: 512
+        batch_size: 64
+      - prompt_len: 128
+        batch_size: 8
 ```
+
+**Note**: Decoder models (generation) only support continuous batching. Static batching is exclusively for pooling models.
 
 ### Continuous Batching Configurations
 
@@ -370,7 +373,9 @@ sentence-transformers/all-roberta-large-v1:
 
   static_batching_configs:
     - tp_size: 1
-      warmup_shapes: [[128, 0, 8]]
+      warmup_shapes:
+        - prompt_len: 128
+          batch_size: 8
 ```
 
 ### Complex Generation Model with Device Config
@@ -397,12 +402,6 @@ models:
       vocab_size: 49159
       num_key_value_heads: 8
       num_attention_heads: 32
-
-    static_batching_configs:
-      - tp_size: 1
-        warmup_shapes: [[2048, 1024, 16]]
-      - tp_size: 4
-        warmup_shapes: [[6144, 2048, 1]]
 
     continuous_batching_configs:
       - tp_size: 1

--- a/vllm_spyre/config/model_config.py
+++ b/vllm_spyre/config/model_config.py
@@ -115,25 +115,23 @@ class DeviceConfig:
 
 @dataclass
 class WarmupShape:
-    """Warmup shape configuration for static batching.
+    """Warmup shape configuration for static batching (pooling models only).
 
     Attributes:
         prompt_len: Prompt length
-        new_tokens: Number of new tokens to generate
         batch_size: Batch size
     """
 
     prompt_len: int
-    new_tokens: int
     batch_size: int
 
-    def to_tuple(self) -> tuple[int, int, int]:
+    def to_tuple(self) -> tuple[int, int]:
         """Convert WarmupShape to tuple format.
 
         Returns:
-            Tuple of (prompt_len, new_tokens, batch_size)
+            Tuple of (prompt_len, batch_size)
         """
-        return (self.prompt_len, self.new_tokens, self.batch_size)
+        return (self.prompt_len, self.batch_size)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "WarmupShape":
@@ -141,7 +139,7 @@ class WarmupShape:
 
         Args:
             data: Dictionary containing warmup shape data with keys:
-                  prompt_len, new_tokens, batch_size
+                  prompt_len, batch_size
 
         Returns:
             WarmupShape instance
@@ -153,13 +151,11 @@ class WarmupShape:
         try:
             return cls(
                 prompt_len=int(data["prompt_len"]),
-                new_tokens=int(data["new_tokens"]),
                 batch_size=int(data["batch_size"]),
             )
         except KeyError as e:
             raise ValueError(
-                f"Warmup shape must have 'prompt_len', 'new_tokens', and 'batch_size' keys. "
-                f"Missing key: {e}"
+                f"Warmup shape must have 'prompt_len' and 'batch_size' keys. Missing key: {e}"
             ) from e
         except (ValueError, TypeError) as e:
             raise ValueError(f"Warmup shape values must be valid integers: {e}") from e
@@ -167,7 +163,7 @@ class WarmupShape:
 
 @dataclass
 class StaticBatchingConfig:
-    """Static batching configuration.
+    """Static batching configuration (pooling models only).
 
     Attributes:
         tp_size: Tensor parallel size
@@ -236,8 +232,8 @@ class ModelConfig:
     Attributes:
         name: Model name/identifier
         architecture: Architecture pattern for matching
-        static_batching_configs: List of static batching configurations
-        continuous_batching_configs: List of continuous batching configurations
+        static_batching_configs: List of static batching configurations (pooling models only)
+        continuous_batching_configs: List of continuous batching configurations (decoder models)
             (each may have its own device_config)
     """
 

--- a/vllm_spyre/config/model_configs.yaml
+++ b/vllm_spyre/config/model_configs.yaml
@@ -34,24 +34,6 @@ models:
   ibm-granite/granite-3.3-8b-instruct:
     architecture: *granite_33_8b_architecture
 
-    # Static batching configurations
-    static_batching_configs:
-      - tp_size: 1
-        warmup_shapes:
-          - prompt_len: 2048
-            new_tokens: 1024
-            batch_size: 16
-      - tp_size: 4
-        warmup_shapes:
-          - prompt_len: 6144
-            new_tokens: 2048
-            batch_size: 1
-      - tp_size: 4
-        warmup_shapes:
-          - prompt_len: 7168
-            new_tokens: 1024
-            batch_size: 4
-
     # Continuous batching configurations
     continuous_batching_configs:
       - tp_size: 1
@@ -101,24 +83,6 @@ models:
       num_key_value_heads: 8
       num_attention_heads: 32
 
-    # Static batching configurations
-    static_batching_configs:
-      - tp_size: 1
-        warmup_shapes:
-          - prompt_len: 2048
-            new_tokens: 1024
-            batch_size: 16
-      - tp_size: 4
-        warmup_shapes:
-          - prompt_len: 6144
-            new_tokens: 2048
-            batch_size: 1
-      - tp_size: 4
-        warmup_shapes:
-          - prompt_len: 7168
-            new_tokens: 1024
-            batch_size: 4
-
     # Continuous batching configurations
     continuous_batching_configs:
       - tp_size: 1
@@ -146,7 +110,6 @@ models:
       - tp_size: 1
         warmup_shapes:
           - prompt_len: 512
-            new_tokens: 0
             batch_size: 64
 
   ibm-granite/granite-embedding-278m-multilingual:
@@ -159,7 +122,6 @@ models:
       - tp_size: 1
         warmup_shapes:
           - prompt_len: 512
-            new_tokens: 0
             batch_size: 64
 
   # Other supported models (static batching only)
@@ -173,7 +135,6 @@ models:
       - tp_size: 1
         warmup_shapes:
           - prompt_len: 512
-            new_tokens: 0
             batch_size: 64
 
   BAAI/bge-reranker-v2-m3:
@@ -187,7 +148,6 @@ models:
       - tp_size: 1
         warmup_shapes:
           - prompt_len: 8192
-            new_tokens: 0
             batch_size: 1
 
   BAAI/bge-reranker-large:
@@ -201,7 +161,6 @@ models:
       - tp_size: 1
         warmup_shapes:
           - prompt_len: 512
-            new_tokens: 0
             batch_size: 64
 
   sentence-transformers/all-roberta-large-v1:
@@ -214,7 +173,6 @@ models:
       - tp_size: 1
         warmup_shapes:
           - prompt_len: 128
-            new_tokens: 0
             batch_size: 8
 
 # Made with Bob

--- a/vllm_spyre/config/model_registry.py
+++ b/vllm_spyre/config/model_registry.py
@@ -177,7 +177,7 @@ class ModelConfigRegistry:
     def get_configurator_for_runtime(
         self,
         vllm_config: "VllmConfig",
-        warmup_shapes: list[tuple[int, int, int]] | None = None,
+        warmup_shapes: list[tuple[int, int]] | None = None,
     ) -> "ModelConfigurator | None":
         """Get configurator for a model with runtime-specific device config.
 
@@ -194,6 +194,7 @@ class ModelConfigRegistry:
         Args:
             vllm_config: vLLM configuration containing model and runtime parameters
             warmup_shapes: Optional warmup shapes for static batching validation
+                (prompt_len, batch_size) tuples for pooling models
 
         Returns:
             ModelConfigurator instance if model matches AND has supported runtime config,
@@ -221,7 +222,7 @@ class ModelConfigRegistry:
         self,
         model_config: ModelConfig,
         vllm_config: "VllmConfig",
-        warmup_shapes: list[tuple[int, int, int]] | None = None,
+        warmup_shapes: list[tuple[int, int]] | None = None,
     ) -> tuple[bool, "DeviceConfig | None"]:
         """Find matching runtime config and associated device config.
 
@@ -233,6 +234,7 @@ class ModelConfigRegistry:
             model_config: Model configuration
             vllm_config: vLLM configuration
             warmup_shapes: Optional warmup shapes for static batching validation
+                (prompt_len, batch_size) tuples for pooling models
 
         Returns:
             Tuple of (has_match, device_config) where:
@@ -264,14 +266,14 @@ class ModelConfigRegistry:
         self,
         model_config: ModelConfig,
         tp_size: int,
-        warmup_shapes: list[tuple[int, int, int]],
+        warmup_shapes: list[tuple[int, int]],
     ) -> bool:
         """Check if static batching config matches runtime parameters.
 
         Args:
             model_config: Model configuration
             tp_size: Tensor parallel size
-            warmup_shapes: Warmup shapes from runtime
+            warmup_shapes: Warmup shapes from runtime (prompt_len, batch_size) tuples
 
         Returns:
             True if a matching static batching config exists
@@ -321,7 +323,7 @@ class ModelConfigRegistry:
         return None
 
     def _warmup_shapes_compatible(
-        self, config_shapes: list["WarmupShape"], runtime_shapes: list[tuple[int, int, int]]
+        self, config_shapes: list["WarmupShape"], runtime_shapes: list[tuple[int, int]]
     ) -> bool:
         """Check if runtime warmup shapes are compatible with config warmup shapes.
 
@@ -330,7 +332,7 @@ class ModelConfigRegistry:
         Args:
             config_shapes: WarmupShapes from model config
             runtime_shapes: Warmup shapes from runtime
-                [(prompt_len, new_tokens, batch_size), ...]
+                [(prompt_len, batch_size), ...]
 
         Returns:
             True if all runtime shapes are in config shapes

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -209,13 +209,9 @@ class SpyrePlatform(Platform):
 
             registry = get_model_registry()
 
-            # For static batching, pass warmup shapes for validation
-
+            # For static batching (pooling models), pass warmup shapes for validation
             warmup_shape_tuples = (
-                [
-                    (ws["prompt_length"], ws["new_tokens"], ws["batch_size"])
-                    for ws in cls._warmup_shapes
-                ]
+                [(ws["prompt_length"], ws["batch_size"]) for ws in cls._warmup_shapes]
                 if cls._warmup_shapes and not envs_spyre.VLLM_SPYRE_USE_CB
                 else None
             )
@@ -473,14 +469,10 @@ class SpyrePlatform(Platform):
 
     @classmethod
     def _get_matching_warmup_shapes(
-        cls, prompt_len: int, max_tokens: int, warmup_shapes: tuple[dict[str, int], ...]
+        cls, prompt_len: int, warmup_shapes: tuple[dict[str, int], ...]
     ) -> list[dict[str, int]]:
-        """Return the subset of shapes that match this request"""
-        return [
-            shape
-            for shape in warmup_shapes
-            if prompt_len <= shape["prompt_length"] and max_tokens <= shape["new_tokens"]
-        ]
+        """Return the subset of shapes that match this request (pooling models only)"""
+        return [shape for shape in warmup_shapes if prompt_len <= shape["prompt_length"]]
 
     # Defined here for testing purposes
     DEFAULT_CHUNK_SIZE = 1024


### PR DESCRIPTION
# Description

Updates the Model Configuration overhaul for the 2.x release prep. Adjusts warmup shapes to remove the `new_tokens` dimension and only support static batching for pooling models.