### PR TITLE
ci: set ty version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
   hooks:
     - id: ty
       name: ty check
-      entry: uvx ty check vllm_spyre
+      entry: uvx ty@0.0.16 check vllm_spyre
       # `system` here instead of python so that we avoid running inside an isolated venv created by
       # prek, and instead have access to the .venv created by uv for the project
       language: system


### PR DESCRIPTION
`ty` released a new version with some new checks/errors. This causes our pre-commit hook to fail. This PR pins the verison of ty so that linting/formatting still passes.