### PR TITLE
:bug: fixup model config for poolers

### DIFF
--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -175,7 +175,7 @@ class SpyrePlatform(Platform):
             # For static batching (pooling models), pass warmup shapes for validation
             warmup_shape_tuples = (
                 [(ws["prompt_length"], ws["batch_size"]) for ws in cls._warmup_shapes]
-                if cls._warmup_shapes and not envs_spyre.VLLM_SPYRE_USE_CB
+                if cls._warmup_shapes
                 else None
             )
             configurator = registry.get_configurator_for_runtime(vllm_config, warmup_shape_tuples)


### PR DESCRIPTION
# Description

Cleaning up uses of `VLLM_SPYRE_USE_CB` and this one was leftover. I validated that this now works on a dev pod:

```
VLLM_SPYRE_REQUIRE_KNOWN_CONFIG=1 VLLM_SPYRE_WARMUP_BATCH_SIZES=8 VLLM_SPYRE_WARMUP_PROMPT_LENS=128 vllm serve sentence-transformers/all-roberta-large-v1
```