### PR TITLE
⬆️ bump vllm lower bound in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = {text = "Apache 2"}
 dependencies = [
     "fms-model-optimizer[fp8]>=0.8.0",
     "ibm-fms>=1.6.0,<2.0",
-    "vllm>=0.11.0,<=0.14.1",
+    "vllm>=0.14.1,<=0.14.1",
 ]
 requires-python = ">=3.11"
 dynamic = ["version"]


### PR DESCRIPTION
looks like we forgot to update the vllm lower bound in #714? 

this also makes my complain in #719 obsolete... 