### PR TITLE
vllm_spyre_next: Compile torch-spyre and vllm from source

### DIFF
--- a/vllm_spyre_next/pyproject.toml
+++ b/vllm_spyre_next/pyproject.toml
@@ -85,8 +85,10 @@ extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "cpu" } }
 # vLLM and torch-spyre must be pulled from github to be built from source
 # NB: torch-spyre can only be compiled where `sendnn` is available
 [tool.uv.sources]
+# This is the unreleased v0.16.0 tag with 2.10 support
 vllm = { git = "https://github.com/vllm-project/vllm", rev = "2d5be1dd5ce2e44dfea53ea03ff61143da5137eb" }
-torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "c73942b71918e4ebea4673b315d96f9dfdc7243e" }
+# see https://github.com/torch-spyre/torch-spyre/pull/746
+torch-spyre = { git = "https://github.com/joerunde/torch-spyre", rev = "f36c0517eb4ff4fa1c05a3e806c79ac8ffe1132e" }
 torch = [
   { index = "pytorch-cpu" },
 ]

--- a/vllm_spyre_next/uv.lock
+++ b/vllm_spyre_next/uv.lock
@@ -3890,7 +3890,7 @@ wheels = [
 [[package]]
 name = "torch-spyre"
 version = "0.0.1"
-source = { git = "https://github.com/torch-spyre/torch-spyre?rev=c73942b71918e4ebea4673b315d96f9dfdc7243e#c73942b71918e4ebea4673b315d96f9dfdc7243e" }
+source = { git = "https://github.com/joerunde/torch-spyre?rev=f36c0517eb4ff4fa1c05a3e806c79ac8ffe1132e#f36c0517eb4ff4fa1c05a3e806c79ac8ffe1132e" }
 dependencies = [
     { name = "numpy" },
     { name = "psutil" },
@@ -4241,7 +4241,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "torch", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "torch-spyre", git = "https://github.com/torch-spyre/torch-spyre?rev=c73942b71918e4ebea4673b315d96f9dfdc7243e" },
+    { name = "torch-spyre", git = "https://github.com/joerunde/torch-spyre?rev=f36c0517eb4ff4fa1c05a3e806c79ac8ffe1132e" },
     { name = "torchvision", index = "https://download.pytorch.org/whl/cpu" },
     { name = "vllm", git = "https://github.com/vllm-project/vllm?rev=2d5be1dd5ce2e44dfea53ea03ff61143da5137eb" },
 ]


### PR DESCRIPTION
# Description

This PR updates vllm_spyre_next to:
- Compile the vLLM CPU backend from source
- Compile torch-spyre from source
- Constrain the `torch` version used at build time for all dependencies to `2.10.0+cpu`

Unfortunately this will not work on any machine that does not have `sendnn` installed, as it's required to compile `torch-spyre`.

This required a patch to torch-spyre to work around a bug, see: https://github.com/torch-spyre/torch-spyre/pull/746

~~Update dependencies in vllm_spyre_next to include torch-spyre. Internal dev images for torch-spyre use a system-level torch install, so this PR also configures the dependencies to allow using system torch when building vLLM (removing build isolation with `uv`).~~

~~These changes support an internal image build on the `torch-aiu-runtime-dev` image using system torch and installing vllm-spyre and vllm-spyre-next in separate venvs.~~

~~NOTE: torch-spyre commit is set right now corresponding to the internal image version I was testing with. I'll work on testing with the latest version next.~~