### PR TITLE
Add [Spyre-Next] PR title tagging workflow

### DIFF
--- a/.github/workflows/amend-pr-title.yml
+++ b/.github/workflows/amend-pr-title.yml
@@ -1,0 +1,34 @@
+name: Amend PR Title for Spyre-Next
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+    branches:
+      - main
+    paths:
+      - 'vllm_spyre_next/**'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  amend-pr-title:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Add [Spyre-Next] tag and verify
+        run: |
+          if ! echo "$PR_TITLE" | grep -iq "\[spyre-next\]"; then
+            gh pr edit "$PR_NUMBER" --title "[Spyre-Next] $PR_TITLE" --repo "$REPO"
+          fi
+
+          FINAL_TITLE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json title --jq '.title')
+
+          if ! echo "$FINAL_TITLE" | grep -iq "\[spyre-next\]"; then
+            echo "::error::PR title is missing [Spyre-Next] tag. Please add it manually if needed."
+            exit 1
+          fi


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Adds a workflow to amend `[Spyre-Next]` to the title of PRs that touch `vllm_spyre_next` if it doesn't include it already.

## Related Issues

Closes torch-spyre/spyre-inference#61 
