### PR TITLE
Add model config for Mistral-Small-3.2-24B-Instruct-2506

### DIFF
--- a/vllm_spyre/config/model_configs.yaml
+++ b/vllm_spyre/config/model_configs.yaml
@@ -50,6 +50,8 @@ _templates:
 
   mistral3_24b_architecture: &mistral3_24b_architecture
     model_type: pixtral
+    # NB: vLLM remaps multimodal mistral configs while loading and updates the model_type from "mistral3" to "pixtral"
+    # see: https://github.com/vllm-project/vllm/blob/v0.16.0/vllm/transformers_utils/configs/mistral.py#L100
     text_config:
       num_hidden_layers: 40
       max_position_embeddings: 131072


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Added model architecture and config for Mistral-Small-3.2-24B-Instruct-2506

## Related Issues


## Test Plan

Started a vLLM server with 4 card 32x32k using VLLM_SPYRE_REQUIRE_KNOWN_CONFIG=1. vLLM server picked up the correct config and started up correctly.

## Checklist

- [x] I have read the [contributing guidelines](https://blog.vllm.ai/vllm-spyre/contributing/)
- [x] My code follows the project's code style (run `bash format.sh`)
- [x] I have added tests for my changes (if applicable)
- [x] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
