### PR TITLE
fix: add test and fix for removal of init_cached_hf_modules in 0.14.0

### DIFF
--- a/tests/e2e/test_spyre_basic.py
+++ b/tests/e2e/test_spyre_basic.py
@@ -200,3 +200,46 @@ def test_max_model_len_override(model: ModelInfo, backend, warmup_shapes, mode: 
         )
     else:
         assert model_config.max_model_len == max_model_len
+
+
+# Use a single model/backend combination to minimize test time
+@pytest.mark.parametrize(
+    "model",
+    [
+        pytest.param(
+            ModelInfo(
+                name="ibm-ai-platform/micro-g3.3-8b-instruct-1b",
+                revision="6e9c6465a9d7e5e9fa35004a29f0c90befa7d23f",
+            ),
+            id="micro-g3.3-8b",
+        )
+    ],
+)
+@pytest.mark.parametrize("backend", [pytest.param("eager", id="eager")])
+def test_trust_remote_code(model: ModelInfo, backend: str, monkeypatch: pytest.MonkeyPatch):
+    """Test that trust_remote_code=True works correctly.
+
+    This test ensures backwards compatibility with Hugging Face's
+    trust_remote_code setting across different vLLM versions.
+    """
+    monkeypatch.setenv("VLLM_SPYRE_DYNAMO_BACKEND", backend)
+
+    # Create engine with trust_remote_code=True
+    vllm_config = EngineArgs(
+        model=model.name,
+        revision=model.revision,
+        trust_remote_code=True,
+    ).create_engine_config()
+
+    # Verify the config was set correctly
+    assert vllm_config.model_config.trust_remote_code is True
+
+    # Initialize executor to trigger worker initialization
+    # This will exercise the trust_remote_code handling code in spyre_worker.py
+    executor_class = Executor.get_class(vllm_config)
+    engine_core = EngineCore(
+        vllm_config=vllm_config, executor_class=executor_class, log_stats=False
+    )
+
+    # If we got here without errors, the trust_remote_code path worked
+    assert engine_core is not None

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -288,10 +288,18 @@ class SpyreWorker(WorkerBase):
             try:
                 # pre 0.11.1 compatibility
                 from vllm.utils import init_cached_hf_modules  # ty: ignore[unresolved-import]
-            except ImportError:
-                from vllm.utils.import_utils import init_cached_hf_modules  # ty: ignore[unresolved-import]
 
-            init_cached_hf_modules()
+                init_cached_hf_modules()
+            except ImportError:
+                # 0.11.1 to 0.13.0 compatibility
+                try:
+                    from vllm.utils.import_utils import init_cached_hf_modules  # ty: ignore[unresolved-import]
+
+                    init_cached_hf_modules()
+                except ImportError:
+                    # >=0.14.0, init_cached_hf_modules is no longer needed
+                    pass
+
         self.model_runner: Union[
             StaticBatchingSpyreModelRunner,
             ContinuousBatchingSpyreModelRunner,


### PR DESCRIPTION
## Description

Currently, using `--trust-remote-code` with `vllm >= 0.14.0` results in an ImportError and prevents the server from starting. We didn't have any tests for this configuration, so it was missed when doing version upgrades.

## Related Issues

This fixes issue `#1683` from our internal tracker.

## Test Plan

- Test added that uses `trust_remote_code=True`
- Verified that test failed without the fix, then passed with the fix (on vLLM v0.15.1)
