### PR TITLE
:wrench: bump vllm bounds to allow midstream patches

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = {text = "Apache 2"}
 dependencies = [
     "fms-model-optimizer[fp8]>=0.8.0",
     "ibm-fms>=1.7.0,<2.0",
-    "vllm>=0.11.0,<=0.16.0",
+    "vllm>=0.11.0,<0.16.1",
 ]
 requires-python = ">=3.11"
 dynamic = ["version"]


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Bumps the vllm bound from `<=0.16.0` to `<0.16.1` to allow post-releases of 0.16.0 from midstream builds.

No syncing or lockfile updates.

## Related Issues


## Test Plan


## Checklist

- [ ] I have read the [contributing guidelines](https://blog.vllm.ai/vllm-spyre/contributing/)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
