### PR TITLE
[Spyre-Next] feat: add script to sync upstream test deps

### DIFF
--- a/vllm_spyre_next/scripts/sync_upstream_tests.py
+++ b/vllm_spyre_next/scripts/sync_upstream_tests.py
@@ -21,15 +21,15 @@ PROJECT_ROOT = Path(__file__).parent.parent
 def extract_vllm_commit(pyproject_path: Path) -> str:
     """
     Extract the vLLM git commit/tag from pyproject.toml.
-    
+
     Returns the commit hash or tag specified in [tool.uv.sources].
     """
     with open(pyproject_path, "rb") as f:
         data = tomllib.load(f)
-    
+
     try:
         vllm_source = data["tool"]["uv"]["sources"]["vllm"]
-        
+
         # Handle both single source and list of sources
         if isinstance(vllm_source, list):
             # If it's a list, find the one with git and rev
@@ -43,7 +43,7 @@ def extract_vllm_commit(pyproject_path: Path) -> str:
             raise ValueError("vLLM source does not have both 'git' and 'rev' fields")
         else:
             raise ValueError(f"Unexpected vllm source type: {type(vllm_source)}")
-    
+
     except KeyError as e:
         raise ValueError(
             f"Could not find vLLM git rev in pyproject.toml [tool.uv.sources]: missing key {e}"
@@ -53,24 +53,24 @@ def extract_vllm_commit(pyproject_path: Path) -> str:
 def download_test_requirements(commit: str, cache_dir: Path) -> Path:
     """
     Download the test.in file from vLLM repository at the specified commit.
-    
+
     Returns the path to the downloaded file.
     """
     url = f"https://raw.githubusercontent.com/vllm-project/vllm/{commit}/requirements/test.in"
     cache_file = cache_dir / f"vllm-{commit[:8]}-test.in"
-    
+
     print(f"Downloading test requirements from vLLM commit {commit[:8]}...")
-    
+
     try:
         with urllib.request.urlopen(url) as response:
             content = response.read()
-        
+
         with open(cache_file, "wb") as f:
             f.write(content)
-        
+
         print(f"Downloaded to: {cache_file}")
         return cache_file
-    
+
     except urllib.error.HTTPError as e:
         raise RuntimeError(
             f"Failed to download test.in from vLLM commit {commit}: {e}\n"
@@ -121,18 +121,18 @@ def main():
         # Extract vLLM commit from pyproject.toml
         vllm_commit = extract_vllm_commit(pyproject_path)
         print(f"Found vLLM commit: {vllm_commit}")
-        
+
         # Create cache directory for downloaded files
         cache_dir = PROJECT_ROOT / ".cache"
         cache_dir.mkdir(exist_ok=True)
-        
+
         # Download test.in from the vLLM repository
         test_in = download_test_requirements(vllm_commit, cache_dir)
-        
+
         # Clear existing upstream-tests section
         print("Clearing existing upstream-tests section...")
         clear_upstream_tests_section(pyproject_path)
-        
+
         # Add dependencies using uv
         print(f"Adding dependencies from {test_in}...")
         result = subprocess.run(
@@ -141,17 +141,17 @@ def main():
             stderr=subprocess.PIPE,
             text=True,
         )
-        
+
         if result.returncode != 0:
             print(f"Error: uv command failed with exit code {result.returncode}", file=sys.stderr)
             if result.stderr:
                 print(result.stderr, file=sys.stderr)
             return 1
-        
+
         print("Done.")
         print("Review changes to pyproject.toml and uv.lock before committing.")
         return 0
-    
+
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Adds `scripts/sync_upstream_tests.py` to help keep the `upstream-tests` dependency
group in sync with vLLM's test dependencies.

Prek integration can be a follow-up PR

## Related Issues

Closes torch-spyre/spyre-inference#54 

## Test Plan


## Checklist

- [x] I have read the [contributing guidelines](https://blog.vllm.ai/vllm-spyre/contributing/)
- [x] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
