### PR TITLE
:bug: fixup graph test for 2.10 compatibility

### DIFF
--- a/tests/aftu/test_compare_graphs.py
+++ b/tests/aftu/test_compare_graphs.py
@@ -14,7 +14,7 @@ from graph_compare_utils import (
     get_model_path,
     run_inference_py_and_get_graphs,
 )
-from spyre_util import ModelInfo, patch_environment
+from spyre_util import ModelInfo, environ_checkpoint, patch_environment
 from vllm import LLM
 
 
@@ -99,14 +99,15 @@ def test_compare_graphs_chunked_prefill(
             os.chdir(tmpdir)
 
             # We only need to load the model
-            LLM(
-                model=model.name,
-                revision=model.revision,
-                max_model_len=adjusted_max_model_len,
-                tensor_parallel_size=1,
-                max_num_batched_tokens=chunk_size,
-                max_num_seqs=max_num_seqs,
-            )
+            with environ_checkpoint():
+                LLM(
+                    model=model.name,
+                    revision=model.revision,
+                    max_model_len=adjusted_max_model_len,
+                    tensor_parallel_size=1,
+                    max_num_batched_tokens=chunk_size,
+                    max_num_seqs=max_num_seqs,
+                )
 
             vllm_graphs = collect_graph_files(tmpdir)
     finally:

--- a/tests/utils/test_platform_validation.py
+++ b/tests/utils/test_platform_validation.py
@@ -5,6 +5,7 @@ from SamplingParams during request validation.
 """
 
 import sys
+import os
 from unittest.mock import MagicMock
 import pytest
 from types import SimpleNamespace
@@ -234,3 +235,28 @@ class TestSendnnConfigurationValidation:
             "Error reading torch_sendnn backend state for validation" in r.message
             for r in warning_records
         )
+
+    def test_flex_device_set_for_sendnn_compile_only(self, monkeypatch):
+        """Test that FLEX_DEVICE is set to COMPILE when backend is sendnn_compile_only."""
+        # Set up the backend
+        monkeypatch.setenv("VLLM_SPYRE_DYNAMO_BACKEND", "sendnn_compile_only")
+
+        # Remove FLEX_DEVICE if it exists to ensure clean test
+        monkeypatch.delenv("FLEX_DEVICE", raising=False)
+
+        # Create mock configs
+        mock_vllm_config = MagicMock()
+        mock_vllm_config.model_config.runner_type = "generate"
+        mock_vllm_config.model_config.is_multimodal_model = False
+        mock_vllm_config.parallel_config.world_size = 1
+        mock_vllm_config.scheduler_config.max_num_batched_tokens = 64
+        mock_vllm_config.model_config.max_model_len = 128
+        mock_vllm_config.scheduler_config.max_num_seqs = 2
+
+        # Call check_and_update_config which should set FLEX_DEVICE
+        SpyrePlatform.check_and_update_config(
+            vllm_config=mock_vllm_config,
+        )
+
+        # Verify FLEX_DEVICE was set to COMPILE
+        assert os.environ.get("FLEX_DEVICE") == "COMPILE"


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Currently we cannot run fp8 models on cpu on pytorch 2.10. This breaks both the `eager` and `sendnn_compile_only` backends.

The graph comparison tests use `sendnn_compile_only`, but run under the `spyre` marker. This change swaps back to the `sendnn` backend for fp8 only in this test, allowing the `spyre` marker to continue passing on pytorch 2.10 builds. The `cpu` marker is expected to continue to fail until we get this problem fixed, that's not addressed here.

## Related Issues


## Test Plan

- Run tests/aftu on spyre

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
