### PR TITLE
:zap: Set chunk size default to 512 for perf improvement

### DIFF
--- a/docs/user_guide/configuration.md
+++ b/docs/user_guide/configuration.md
@@ -16,7 +16,7 @@ VLLM_SPYRE_USE_CHUNKED_PREFILL
 
 Configuring the static chunk size for chunked prefill is now only done via `--max-num-batched-tokens`.
 If your deployment had an override set with `VLLM_DT_CHUNK_LEN`, use the CLI argument instead.
-The default value for the chunk size is 1024.
+The default value for the chunk size is 512.
 
 Because prefix caching is enabled by default, the `--enable-prefix-caching` CLI arg can be removed from all deployments.
 To disable prefix caching, use `--no-enable-prefix-caching`.
@@ -56,7 +56,7 @@ For configuration and tuning guidance, see the [vLLM official documentation on c
 As in vLLM, the `max_num_batched_tokens` parameter controls how chunks are formed. While vLLM can dynamically schedule mixed batches of prefill and decode with arbitrary chunk sizes, the vLLM-Spyre implementation is limited to compiling prefill programs for a single fixed chunk size.
 vLLM-Spyre interleaves decode passes with these fixed-chunk-size prefill passes to emulate chunked prefill. The `max_num_batched_tokens` parameter controls this fixed chunk size for prefill passes in vLLM-Spyre.
 
-This parameter should be tuned according to your infrastructure, it is recommended to set it from `1024` to `4096` tokens and it **must** be multiple of the block size (currently fixed to `64`). For convenience, when using the model `ibm-granite/granite-3.3-8b-instruct` with `tp=4`, vLLM-Spyre automatically sets `max_num_batched_tokens` to `1024`, a value known to produce good hardware utilization in this setup.
+This parameter should be tuned according to your infrastructure, it is recommended to set it from `512` to `4096` tokens and it **must** be multiple of the block size (currently fixed to `64`). For convenience, when using the model `ibm-granite/granite-3.3-8b-instruct` with `tp=4`, vLLM-Spyre automatically sets `max_num_batched_tokens` to `512`, a value known to produce good hardware utilization in this setup.
 
 In chunked prefill mode, the `vllm:kv_cache_usage_perc` metric will report the correct KV cache usage on the Spyre cards for all active requests.
 

--- a/tests/utils/test_cli_args.py
+++ b/tests/utils/test_cli_args.py
@@ -10,7 +10,7 @@ from vllm_spyre.platform import SpyrePlatform
 from spyre_util import REFERENCE_MODELS, environ_checkpoint
 
 
-# Test that the default chunk size is 1024 when chunked prefill is enabled,
+# Test that the default chunk size is 512 when chunked prefill is enabled,
 # and that --max-num-batched-tokens overrides this default.
 def test_chunk_size_default(monkeypatch: pytest.MonkeyPatch) -> None:
     # Use the sendnn backend to activate the model configurator
@@ -35,12 +35,12 @@ def test_chunk_size_default(monkeypatch: pytest.MonkeyPatch) -> None:
     ]
 
     with environ_checkpoint():
-        # Test default chunk size is 1024
+        # Test default chunk size is 512
         engine_args = _build_engine_args(common_args)
-        assert engine_args.max_num_batched_tokens == 1024
+        assert engine_args.max_num_batched_tokens == 512
         vllm_config = engine_args.create_engine_config()
-        assert vllm_config.scheduler_config.max_num_batched_tokens == 1024
-        assert os.environ.get("VLLM_DT_CHUNK_LEN") == "1024"
+        assert vllm_config.scheduler_config.max_num_batched_tokens == 512
+        assert os.environ.get("VLLM_DT_CHUNK_LEN") == "512"
 
     with environ_checkpoint():
         # Test that --max-num-batched-tokens overrides the default

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -480,7 +480,7 @@ class SpyrePlatform(Platform):
         return [shape for shape in warmup_shapes if prompt_len <= shape["prompt_length"]]
 
     # Defined here for testing purposes
-    DEFAULT_CHUNK_SIZE = 1024
+    DEFAULT_CHUNK_SIZE = 512
 
     @classmethod
     def pre_register_and_update(cls, parser: FlexibleArgumentParser | None = None) -> None:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

After extensive benchmarking on product use cases, it has been determined that a chunk size of 512 is generally more performant than a chunk size of 1024. This seems to be largely due to the better prefix cache re-use on the smaller chunk size.

## Related Issues


## Test Plan


## Checklist

- [ ] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
