### PR TITLE
docs: Add excluded model list to mkdoc supported model generator

### DIFF
--- a/docs/mkdocs/hooks/generate_model_tables.py
+++ b/docs/mkdocs/hooks/generate_model_tables.py
@@ -16,6 +16,13 @@ GENERATIVE_END_MARKER = "<!-- GENERATED_GENERATIVE_MODELS_END -->"
 POOLING_START_MARKER = "<!-- GENERATED_POOLING_MODELS_START -->"
 POOLING_END_MARKER = "<!-- GENERATED_POOLING_MODELS_END -->"
 
+# Models to exclude from documentation
+EXCLUDED_MODELS = {
+    "ibm-granite/granite-4-8b-dense-hybrid",
+    "ibm-granite/granite-4-8b-dense",
+    "ibm-granite/granite-4-8b-dense-FP8",
+}
+
 
 def generate_model_table(models_data, config_type):
     """Generate a markdown table for models with the specified config type.
@@ -33,6 +40,8 @@ def generate_model_table(models_data, config_type):
 
     # First pass: collect all unique keys and organize by model
     for model_name, model_config in models_data.items():
+        if model_name in EXCLUDED_MODELS:
+            continue
         if config_type not in model_config:
             continue
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Since we generate the supported model tables straight from model configs, use a list of model names that we don't want to include in the official docs yet. This approach doesn't touch the model configuration schema.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [x] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [x] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
