### PR TITLE
fix: don't use check on generated _version

### DIFF
--- a/vllm_spyre/compilation_utils.py
+++ b/vllm_spyre/compilation_utils.py
@@ -153,7 +153,8 @@ def handle_disable_compilation(vllm_config: VllmConfig, is_decoder: bool):
                 )
         except ImportError:
             logger.warning(
-                "[PRECOMPILED_WARN] Cannot validate vllm_spyre version against pre-compiled model config"
+                "[PRECOMPILED_WARN] Cannot validate vllm_spyre version against "
+                "pre-compiled model config"
             )
 
         # Check model name


### PR DESCRIPTION
## Description

setuptools_scm v10 no longer generates a _version file by default. We should be using importlib anyways though.

## Related Issues

<!-- Link related issues, e.g., `Fixes #` or `Relates to #456` -->

## Test Plan

Manually verified both methods of obtaining the verion match:
```
from vllm_spyre._version import version as vllm_spyre_version
import importlib.metadata

vllm_spyre_version == importlib.metadata.version("vllm_spyre")
```

Also did a quick test with a manually generated precompiled model.
