### PR TITLE
[Spyre-Next] Use vllm version from [tool.uv.sources]

### DIFF
--- a/vllm_spyre_next/pyproject.toml
+++ b/vllm_spyre_next/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 license = {text = "Apache 2"}
 dependencies = [
     "torch-spyre",
-    "vllm==0.15.1+cpu",
+    "vllm",
 
     # Listing as direct deps to ensure they're picked up from the correct index.
     # Versions intentionally left out because these are dependencies of dependencies.

--- a/vllm_spyre_next/pyproject.toml
+++ b/vllm_spyre_next/pyproject.toml
@@ -94,7 +94,7 @@ extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "cpu" } }
 # vLLM and torch-spyre must be pulled from github to be built from source
 # NB: torch-spyre can only be compiled where `sendnn` is available
 [tool.uv.sources]
-vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.17.1" }
+vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.15.1" }
 # see https://github.com/torch-spyre/torch-spyre/pull/746
 torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "c1f67bb4701630179d53dbfc060dde62fc2d7d18" }
 torch = [

--- a/vllm_spyre_next/pyproject.toml
+++ b/vllm_spyre_next/pyproject.toml
@@ -94,7 +94,7 @@ extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "cpu" } }
 # vLLM and torch-spyre must be pulled from github to be built from source
 # NB: torch-spyre can only be compiled where `sendnn` is available
 [tool.uv.sources]
-vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.15.1" }
+vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.17.1" }
 # see https://github.com/torch-spyre/torch-spyre/pull/746
 torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "c1f67bb4701630179d53dbfc060dde62fc2d7d18" }
 torch = [


### PR DESCRIPTION
## Description

The current version of vllm dependency (v0.15.1) is wrong and conflicting with the version 0.17.1 specified in `[tool.uv.sources]`. That latter one should be used. We can remove the version specification entirely in `dependencies = [...` to have the version in a single place. 

## Test Plan

bot:next-test should still have two tests passing

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
