### PR TITLE
Alternative fix for max_num_batched_tokens verification

### DIFF
--- a/tests/utils/test_cli_args.py
+++ b/tests/utils/test_cli_args.py
@@ -33,12 +33,12 @@ def test_chunk_size_default(monkeypatch: pytest.MonkeyPatch) -> None:
     ]
 
     with environ_checkpoint():
-        # Test default chunk size is 512
+        # Test default chunk size is 2048
         engine_args = _build_engine_args(common_args)
-        assert engine_args.max_num_batched_tokens == 512
+        assert engine_args.max_num_batched_tokens == 2048
         vllm_config = engine_args.create_engine_config()
-        assert vllm_config.scheduler_config.max_num_batched_tokens == 512
-        assert os.environ.get("VLLM_DT_CHUNK_LEN") == "512"
+        assert vllm_config.scheduler_config.max_num_batched_tokens == 2048
+        assert os.environ.get("VLLM_DT_CHUNK_LEN") == "2048"
 
     with environ_checkpoint():
         # Test that --max-num-batched-tokens overrides the default

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -483,13 +483,17 @@ class SpyrePlatform(Platform):
         return [shape for shape in warmup_shapes if prompt_len <= shape["prompt_length"]]
 
     # Defined here for testing purposes
-    DEFAULT_CHUNK_SIZE = 512
+    DEFAULT_CHUNK_SIZE = 2048
+    DEFAULT_MAX_MODEL_LEN = 1024
+    DEFAULT_MAX_NUM_SEQS = 2
 
     @classmethod
     def pre_register_and_update(cls, parser: FlexibleArgumentParser | None = None) -> None:
         if parser is not None:
             parser.set_defaults(enable_prefix_caching=True)
             parser.set_defaults(max_num_batched_tokens=cls.DEFAULT_CHUNK_SIZE)
+            parser.set_defaults(max_model_len=cls.DEFAULT_MAX_MODEL_LEN)
+            parser.set_defaults(max_num_seqs=cls.DEFAULT_MAX_NUM_SEQS)
 
     @classmethod
     def _check_threading_config(cls, worker_count: int):


### PR DESCRIPTION
Also change the defaults for max_num_tokens and max_num_seqs so that the pre-model loading verification in SchedulerConfig doesn't fail.
