### PR TITLE
[Spyre-Next] Reworked rms_norm

### DIFF
--- a/vllm_spyre_next/vllm_spyre_next/custom_ops/rms_norm.py
+++ b/vllm_spyre_next/vllm_spyre_next/custom_ops/rms_norm.py
@@ -134,18 +134,7 @@ class SpyreRMSNorm(RMSNorm):
             x.shape, variance_epsilon, dtype=torch.float16, device=x.device
         )
 
-        if variance_size_override is None:
-            x_var = x
-        else:
-            if hidden_size < variance_size_override:
-                raise ValueError(
-                    "Expected hidden_size to be at least "
-                    f"{variance_size_override}, but found: {hidden_size}"
-                )
-
-            x_var = x[:, :, :variance_size_override]
-
-        variance = x_var.pow(2).mean(dim=-1, keepdim=True)
+        variance = x.pow(2).mean(dim=-1, keepdim=True)
 
         x = x * torch.rsqrt(variance + variance_epsilon)
 
@@ -204,7 +193,6 @@ class SpyreRMSNorm(RMSNorm):
             if self.has_weight
             else None,
             convert(residual, self._target_device, self._target_dtype),
-            self.variance_size_override,
         )
 
         # Transfer back to CPU and restore original shape


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This PR removes the transpose + .contiguous() operation from rms_norm, making it even closer to the native upstream implementation. However, I currently observe small numerical differences and I prepared a repro script for that.

```
import torch

x = torch.randn(1024, 4096, device="cpu", dtype=torch.float16)
hidden_size = 4096
eps = 1e-05
weight = torch.randn(4096, device="cpu", dtype=torch.float16)

def rms_old(x, hidden_size, variance_epsilon, weight):
    if x.shape[-1] != hidden_size:
        raise ValueError(f"Expected hidden_size to be {hidden_size}, but found: {x.shape[-1]}")

    x = x.transpose(-1, -2).contiguous()

    variance_epsilon = torch.full(
        x.shape, variance_epsilon, dtype=torch.float16, device=x.device
    )

    x_var = x

    # After transpose, hidden dim is now dim=0
    variance = x_var.pow(2).mean(dim=0, keepdim=True)
    # variance = x_var.pow(2).mean(dim=-1, keepdim=True)

    x = x * torch.rsqrt(variance + variance_epsilon)
    x = x.transpose(-1, -2).contiguous()

    if weight is not None:
        x = x * weight
    return x

def rms_new(x, hidden_size, variance_epsilon, weight):
    if x.shape[-1] != hidden_size:
        raise ValueError(f"Expected hidden_size to be {hidden_size}, but found: {x.shape[-1]}")


    variance_epsilon = torch.full(
        x.shape, variance_epsilon, dtype=torch.float16, device=x.device
    )

    x_var = x

    variance = x_var.pow(2).mean(dim=-1, keepdim=True)

    x = x * torch.rsqrt(variance + variance_epsilon)

    if weight is not None:
        x = x * weight
    return x

x = x.to("spyre")
weight = weight.to("spyre")

out1 = torch.compile(rms_old, dynamic=False)(x, hidden_size, eps, weight).cpu()
out2 = torch.compile(rms_new, dynamic=False)(x, hidden_size, eps, weight).cpu()

torch.testing.assert_close(out1, out2, atol=0.001, rtol=0.001)

print('Tensors are close')
```

cc @romitjain 

## Related Issues

Corresponding change in torch-spyre:
https://github.com/torch-spyre/torch-spyre/pull/1236.

## Test Plan

Change is non user-facing and all existing tests should pass

## Checklist

- [X] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [X] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [X] My commits include a `Signed-off-by:` line (DCO compliance)
