### PR TITLE
Update vllm to include 0.18.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ override-dependencies = [
 extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "empty" } }
 
 [tool.uv.sources]
-vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.18.0" }
+vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.18.1" }
 
 [tool.ty.rules]
 possibly-missing-attribute = "ignore"

--- a/uv.lock
+++ b/uv.lock
@@ -28,7 +28,7 @@ overrides = [
     { name = "torchaudio", marker = "sys_platform == 'never'" },
     { name = "torchvision", marker = "sys_platform == 'never'" },
     { name = "triton", marker = "sys_platform == 'never'" },
-    { name = "vllm", marker = "platform_machine not in 's390x, ppc64le'", git = "https://github.com/vllm-project/vllm?rev=v0.18.0" },
+    { name = "vllm", marker = "platform_machine not in 's390x, ppc64le'", git = "https://github.com/vllm-project/vllm?rev=v0.18.1" },
 ]
 
 [[package]]
@@ -4406,8 +4406,8 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.18.0"
-source = { git = "https://github.com/vllm-project/vllm?rev=v0.18.0#bcf2be96120005e9aea171927f85055a6a5c0cf6" }
+version = "0.18.1"
+source = { git = "https://github.com/vllm-project/vllm?rev=v0.18.1#a26e8dc7ff2111a005144d775ecf9cebf56c45b2" }
 dependencies = [
     { name = "aiohttp" },
     { name = "anthropic" },
@@ -4497,7 +4497,7 @@ dev = [
 requires-dist = [
     { name = "fms-model-optimizer", extras = ["fp8"], specifier = ">=0.8.0" },
     { name = "ibm-fms", specifier = ">=1.8.0,<2.0" },
-    { name = "vllm", git = "https://github.com/vllm-project/vllm?rev=v0.18.0" },
+    { name = "vllm", git = "https://github.com/vllm-project/vllm?rev=v0.18.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This PR updates the vllm upper bound in pyproject.toml to include version 0.18.1.

Questions:
1. I kept it as a `<` operator and moved the upper bound to `0.18.2` to abide by the comment that is there. If that was the wrong choice let me know and I can switch it to `<=0.18.1`. 
2. I ran a `uv sync --upgrade-package vllm` but nothing in uv.lock changed... Is there something else I should run instead?

## Related Issues

<!-- Link related issues, e.g., `Fixes #` or `Relates to #456` -->

## Test Plan

<!-- Describe how you tested your changes. Include commands or steps to reproduce. -->

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
