### PR TITLE
[Spyre-Next] [Bug] Fixed dtype for embedding

### DIFF
--- a/vllm_spyre_next/vllm_spyre_next/custom_ops/vocab_parallel_embedding.py
+++ b/vllm_spyre_next/vllm_spyre_next/custom_ops/vocab_parallel_embedding.py
@@ -87,7 +87,10 @@ class SpyreVocabParallelEmbedding(VocabParallelEmbedding):
         logger.debug("Building custom VocabParallelEmbedding for Spyre")
 
         self._target_device = torch.device("spyre")
-        self._target_dtype = None
+        # The inputs for spyre need to be torch.int64
+        self._input_target_dtype = torch.int64
+        # The weights for spyre need to be torch.float16
+        self._weight_target_dtype = torch.float16
         self.maybe_compiled_forward_spyre = self.maybe_compile(self.forward_spyre)
 
         self._layer_name = register_layer(self, "spyre_vocab_parallel_embedding")
@@ -154,8 +157,8 @@ class SpyreVocabParallelEmbedding(VocabParallelEmbedding):
         out_device = x.device
 
         out = self.maybe_compiled_forward_spyre(
-            convert(x, dtype=self._target_dtype, device=self._target_device),
-            convert(self.weight.data, dtype=self._target_dtype, device=self._target_device),
+            convert(x, dtype=self._input_target_dtype, device=self._target_device),
+            convert(self.weight.data, dtype=self._weight_target_dtype, device=self._target_device),
         )
 
         # Transfer back to original device and restore original dtype


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This PR ensures that the correct dtypes are used for spyre for the embedding layer.

cc @coderfornow  

## Related Issues

https://github.com/vllm-project/vllm-spyre/issues/753

## Test Plan

I ran E2E test and confirmed they are working. Furthermore, we will use the current upstream tests that we have to check.

## Checklist

- [X] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [X] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [X] My commits include a `Signed-off-by:` line (DCO compliance)
