### PR TITLE
:zap: don't set KV cache on model

### DIFF
--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -62,9 +62,8 @@ class SpyreCausalLM(nn.Module):
         # number of right pads
         self.n_pads_right = 0
 
-        self._mask_dtype = (
-            torch.float16 if SpyrePlatform.is_backend_sendnn_enabled() else torch.float32
-        )
+        self.on_spyre = SpyrePlatform.is_backend_sendnn_enabled()
+        self._mask_dtype = torch.float16 if self.on_spyre else torch.float32
 
         self.config = self.resolve_hf_config(vllm_config)
 
@@ -94,7 +93,7 @@ class SpyreCausalLM(nn.Module):
             max_prompt_length=max_prompt_length,
             max_decode_length=max_decode_length,
             distributed_strategy="tp" if self.parallel_config.world_size > 1 else None,
-            sendnn_dynamic=SpyrePlatform.is_backend_sendnn_enabled(),
+            sendnn_dynamic=self.on_spyre,
             rank=rank,
             world_size=self.parallel_config.world_size,
         )
@@ -140,8 +139,6 @@ class SpyreCausalLM(nn.Module):
         self.past_key_value_states: list[
             tuple[torch.Tensor | ScaledTensor, torch.Tensor | ScaledTensor]
         ] = []
-
-        self.on_spyre = SpyrePlatform.is_backend_sendnn_enabled()
 
     def load_weights(
         self,

--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -141,6 +141,8 @@ class SpyreCausalLM(nn.Module):
             tuple[torch.Tensor | ScaledTensor, torch.Tensor | ScaledTensor]
         ] = []
 
+        self.on_spyre = SpyrePlatform.is_backend_sendnn_enabled()
+
     def load_weights(
         self,
         model_config: ModelConfig,
@@ -435,7 +437,9 @@ class SpyreCausalLM(nn.Module):
         # However, on spyre these are ghost tensors- the data in these tensors does not reflect the
         # actual kv cache data on the device. They exist only for proper compilation, so we don't
         # waste any time assigning these tensors back to anything.
-        logits, _ = output
+        logits, kv_cache = output
+        if not self.on_spyre:
+            self.past_key_value_states = kv_cache
 
         if is_prompt:
             # assert that indeed received the last block of logits

--- a/vllm_spyre/model_executor/model_loader/spyre.py
+++ b/vllm_spyre/model_executor/model_loader/spyre.py
@@ -431,7 +431,11 @@ class SpyreCausalLM(nn.Module):
             attn_name=self.attention_name,
         )
 
-        logits, self.past_key_value_states = output
+        # The second item in the output tuple is the KV cache.
+        # However, on spyre these are ghost tensors- the data in these tensors does not reflect the
+        # actual kv cache data on the device. They exist only for proper compilation, so we don't
+        # waste any time assigning these tensors back to anything.
+        logits, _ = output
 
         if is_prompt:
             # assert that indeed received the last block of logits


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Based on recent profiling that saw ~1ms being spent on a `toch.nn.Module.setattr` call directly after the forward pass that we tracked down to setting `self.past_key_value_states`, this PR updates the model wrapper to ignore the kv cache "outputs" from the model.

These tensors don't contain the actual kv cache data, so we shouldn't waste time assigning them back to the model

## Related Issues

## Test Plan

perf benchmarking to validate the speedup.

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
