### PR TITLE
fix: add profile_prefix param to SpyreWorker.profile()

### DIFF
--- a/tests/e2e/test_profiler.py
+++ b/tests/e2e/test_profiler.py
@@ -1,0 +1,38 @@
+import pytest
+from vllm import LLM
+from vllm.config import ProfilerConfig
+
+from spyre_util import ModelInfo, get_chicken_soup_prompts
+from vllm_spyre import envs as envs_spyre
+
+
+@pytest.mark.cpu
+def test_profiler(
+    model: ModelInfo,
+    max_model_len: int,
+    max_num_seqs: int,
+    max_num_batched_tokens: int,
+    tmp_path,
+):
+    prompts = get_chicken_soup_prompts(2)
+
+    envs_spyre.override("VLLM_SPYRE_DYNAMO_BACKEND", "eager")
+
+    spyre_model = LLM(
+        model=model.name,
+        revision=model.revision,
+        max_model_len=max_model_len,
+        max_num_seqs=max_num_seqs,
+        max_num_batched_tokens=max_num_batched_tokens,
+        profiler_config=ProfilerConfig(
+            profiler="torch",
+            torch_profiler_dir=str(tmp_path),
+        ),
+    )
+
+    spyre_model.start_profile()
+    spyre_model.generate(prompts=prompts)
+    spyre_model.stop_profile()
+
+    trace_files = list(tmp_path.glob("*.pt.trace.json*"))
+    assert len(trace_files) > 0

--- a/tests/v1/worker/test_spyre_worker_profile.py
+++ b/tests/v1/worker/test_spyre_worker_profile.py
@@ -1,0 +1,105 @@
+import inspect
+
+import pytest
+from unittest.mock import Mock
+from vllm.config import (
+    VllmConfig,
+    ModelConfig,
+    CacheConfig,
+    ParallelConfig,
+    SchedulerConfig,
+    ProfilerConfig,
+)
+from vllm.v1.worker.gpu_worker import Worker as UpstreamWorker
+from vllm_spyre.v1.worker.spyre_worker import SpyreWorker
+
+
+@pytest.fixture
+def mock_vllm_config():
+    """Create a mock VllmConfig with profiler enabled."""
+    model_config = Mock(spec=ModelConfig)
+    model_config.model = "test-model"
+    model_config.runner_type = "generate"
+    model_config.seed = 0
+    model_config.max_model_len = 2048
+
+    cache_config = Mock(spec=CacheConfig)
+
+    parallel_config = Mock(spec=ParallelConfig)
+    parallel_config.world_size = 1
+    parallel_config.tensor_parallel_size = 1
+    parallel_config.pipeline_parallel_size = 1
+
+    scheduler_config = Mock(spec=SchedulerConfig)
+    scheduler_config.max_num_seqs = 256
+
+    vllm_config = Mock(spec=VllmConfig)
+    vllm_config.model_config = model_config
+    vllm_config.cache_config = cache_config
+    vllm_config.parallel_config = parallel_config
+    vllm_config.scheduler_config = scheduler_config
+    vllm_config.profiler_config = ProfilerConfig(
+        profiler="torch", torch_profiler_dir="/tmp/test_traces"
+    )
+    vllm_config.instance_id = "test-instance"
+
+    return vllm_config
+
+
+def _make_worker(monkeypatch, vllm_config):
+    monkeypatch.setattr("vllm_spyre.v1.worker.spyre_worker.ChunkedPrefillModelRunner", Mock())
+    monkeypatch.setattr("vllm_spyre.v1.worker.spyre_worker.perf_metrics", Mock())
+    return SpyreWorker(
+        vllm_config=vllm_config,
+        local_rank=0,
+        rank=0,
+        distributed_init_method="env://",
+        is_driver_worker=True,
+    )
+
+
+@pytest.mark.cpu
+@pytest.mark.worker
+def test_profile_start(monkeypatch, mock_vllm_config):
+    """Test that profile() starts the profiler."""
+    worker = _make_worker(monkeypatch, mock_vllm_config)
+    worker.profiler = Mock()
+
+    worker.profile(is_start=True)
+
+    worker.profiler.start.assert_called_once()
+
+
+@pytest.mark.cpu
+@pytest.mark.worker
+def test_profile_stop(monkeypatch, mock_vllm_config):
+    """Test that profile(is_start=False) stops the profiler."""
+    worker = _make_worker(monkeypatch, mock_vllm_config)
+    worker.profiler = Mock()
+
+    worker.profile(is_start=False)
+
+    worker.profiler.stop.assert_called_once()
+
+
+@pytest.mark.cpu
+@pytest.mark.worker
+def test_profile_raises_when_profiler_not_enabled(monkeypatch, mock_vllm_config):
+    """Test that profile() raises RuntimeError when profiler is not enabled."""
+    mock_vllm_config.profiler_config = ProfilerConfig(profiler=None)
+    worker = _make_worker(monkeypatch, mock_vllm_config)
+
+    assert worker.profiler is None
+
+    with pytest.raises(RuntimeError, match="Profiling is not enabled"):
+        worker.profile(is_start=True)
+
+
+def test_profile_signature_matches_upstream():
+    """Test that SpyreWorker.profile() signature matches the upstream vllm Worker."""
+    spyre_params = set(inspect.signature(SpyreWorker.profile).parameters)
+    upstream_params = set(inspect.signature(UpstreamWorker.profile).parameters)
+    assert spyre_params == upstream_params
+
+
+# Made with Bob

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -730,7 +730,7 @@ class SpyreWorker(WorkerBase):
         }
         self.execute_model(scheduler_output)  # Prefill
 
-    def profile(self, is_start: bool = True):
+    def profile(self, is_start: bool = True, profile_prefix: str | None = None):
         if self.profiler is None:
             raise RuntimeError(
                 "Profiling is not enabled. Please set --profiler-config to enable "


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This PR adds the missing `profile_prefix` parameter to `SpyreWorker.profile()` and introduces unit tests to prevent future regressions.

## Test Plan

Added new unit tests in `tests/v1/worker/test_spyre_worker_profile.py` covering starting, stopping, unconfigured, and comparing signatures parameter changes. 

## Checklist

- [x] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [x] My code follows the project's code style (run `bash format.sh`)
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
