### PR TITLE
Ministral offline fix

### DIFF
--- a/tests/utils/test_platform_validation.py
+++ b/tests/utils/test_platform_validation.py
@@ -272,6 +272,12 @@ class TestPreRegisterAndUpdate:
         yield
         ConditionalDefaultManager.clear()
 
+        # Re-import huggingface_hub constants to reset any patched env vars
+        import importlib
+        import huggingface_hub.constants
+
+        importlib.reload(huggingface_hub.constants)
+
     @pytest.fixture
     def arg_parsers(self):
         """Create main parser and serve subparser like vLLM's CLI structure.

--- a/tests/utils/test_platform_validation.py
+++ b/tests/utils/test_platform_validation.py
@@ -258,3 +258,73 @@ class TestSendnnConfigurationValidation:
 
         # Verify FLEX_DEVICE was set to COMPILE
         assert os.environ.get("FLEX_DEVICE") == "COMPILE"
+
+
+class TestPreRegisterAndUpdate:
+    """Test SpyrePlatform.pre_register_and_update conditional defaults."""
+
+    @pytest.fixture(autouse=True)
+    def clear_conditional_defaults(self):
+        """Clear conditional defaults before each test to ensure isolation."""
+        from vllm_spyre.argparse_utils import ConditionalDefaultManager
+
+        ConditionalDefaultManager.clear()
+        yield
+        ConditionalDefaultManager.clear()
+
+    def create_test_parser(self):
+        """Create a parser with the arguments used by pre_register_and_update."""
+        from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+        parser = FlexibleArgumentParser()
+        parser.add_argument("--config-format", dest="config_format", default="auto")
+        parser.add_argument("--tokenizer-mode", dest="tokenizer_mode", default="auto")
+        parser.add_argument("model_tag", nargs="?", default=None)
+        return parser
+
+    def test_config_format_defaults_to_mistral_when_model_tag_contains_mistral(self):
+        """Test that config_format defaults to 'mistral' when model_tag contains 'mistral'."""
+        # Parse with a mistral model
+        parser = self.create_test_parser()
+        SpyrePlatform.pre_register_and_update(parser)
+        args = parser.parse_args(["mistralai/Mistral-7B-Instruct-v0.1"])
+
+        assert args.config_format == "mistral"
+        assert args.tokenizer_mode == "mistral"
+
+    def test_config_format_defaults_to_mistral_when_params_json_exists(self, tmp_path):
+        """Test that config_format defaults to 'mistral' when model_tag points to dir with
+        params.json."""
+        # Create a temporary directory with params.json (NB: path does not have mistral in the name)
+        model_dir = tmp_path / "some_model"
+        model_dir.mkdir()
+        params_file = model_dir / "params.json"
+        params_file.write_text('{"dim": 4096, "n_layers": 32}')
+
+        # Parse with the local directory as model
+        parser = self.create_test_parser()
+        SpyrePlatform.pre_register_and_update(parser)
+        args = parser.parse_args([str(model_dir)])
+
+        assert args.config_format == "mistral"
+        assert args.tokenizer_mode == "mistral"
+
+    def test_config_format_defaults_to_auto_for_non_mistral_models(self):
+        """Test that config_format defaults to 'auto' for non-mistral models."""
+        parser = self.create_test_parser()
+        SpyrePlatform.pre_register_and_update(parser)
+        args = parser.parse_args(["facebook/opt-125m"])
+
+        assert args.config_format == "auto"
+        assert args.tokenizer_mode == "auto"
+
+    def test_explicit_config_format_not_overridden(self):
+        """Test that user-provided config_format is not overridden."""
+        parser = self.create_test_parser()
+        SpyrePlatform.pre_register_and_update(parser)
+        args = parser.parse_args(["--config-format", "hf", "mistralai/Mistral-7B-Instruct-v0.1"])
+
+        # User explicitly set config_format to "hf", it should not be overridden
+        assert args.config_format == "hf"
+        # tokenizer_mode should still be set (since it depends on the same logic)
+        assert args.tokenizer_mode == "mistral"

--- a/tests/utils/test_platform_validation.py
+++ b/tests/utils/test_platform_validation.py
@@ -272,57 +272,85 @@ class TestPreRegisterAndUpdate:
         yield
         ConditionalDefaultManager.clear()
 
-    def create_test_parser(self):
-        """Create a parser with the arguments used by pre_register_and_update."""
+    @pytest.fixture
+    def arg_parsers(self):
+        """Create main parser and serve subparser like vLLM's CLI structure.
+
+        Returns a tuple of (main_parser, serve_subparser). The subparser is
+        passed to pre_register_and_update, but parse_args should be called
+        on the main parser.
+        """
         from vllm.utils.argparse_utils import FlexibleArgumentParser
 
-        parser = FlexibleArgumentParser()
-        parser.add_argument("--config-format", dest="config_format", default="auto")
-        parser.add_argument("--tokenizer-mode", dest="tokenizer_mode", default="auto")
-        parser.add_argument("model_tag", nargs="?", default=None)
-        return parser
+        # Create main parser like vLLM's CLI
+        main_parser = FlexibleArgumentParser()
+        subparsers = main_parser.add_subparsers(dest="subcommand")
 
-    def test_config_format_defaults_to_mistral_when_model_tag_contains_mistral(self):
-        """Test that config_format defaults to 'mistral' when model_tag contains 'mistral'."""
-        # Parse with a mistral model
-        parser = self.create_test_parser()
-        SpyrePlatform.pre_register_and_update(parser)
-        args = parser.parse_args(["mistralai/Mistral-7B-Instruct-v0.1"])
+        # Create serve subparser with the actual arguments
+        serve_parser = subparsers.add_parser("serve", help="Serve model")
+        serve_parser.add_argument("--config-format", dest="config_format", default="auto")
+        serve_parser.add_argument("--tokenizer-mode", dest="tokenizer_mode", default="auto")
+        serve_parser.add_argument("--revision", dest="revision", default=None)
+        serve_parser.add_argument("--hf-token", dest="hf_token", default=None)
+        serve_parser.add_argument("model_tag", nargs="?", default=None)
 
-        assert args.config_format == "mistral"
-        assert args.tokenizer_mode == "mistral"
+        return main_parser, serve_parser
 
-    def test_config_format_defaults_to_mistral_when_params_json_exists(self, tmp_path):
+    def test_config_format_defaults_to_mistral_when_params_json_exists(self, tmp_path, arg_parsers):
         """Test that config_format defaults to 'mistral' when model_tag points to dir with
         params.json."""
+        main_parser, serve_parser = arg_parsers
+
         # Create a temporary directory with params.json (NB: path does not have mistral in the name)
         model_dir = tmp_path / "some_model"
         model_dir.mkdir()
         params_file = model_dir / "params.json"
         params_file.write_text('{"dim": 4096, "n_layers": 32}')
 
-        # Parse with the local directory as model
-        parser = self.create_test_parser()
-        SpyrePlatform.pre_register_and_update(parser)
-        args = parser.parse_args([str(model_dir)])
+        # Pass only the subparser to pre_register_and_update (like vLLM does)
+        SpyrePlatform.pre_register_and_update(serve_parser)
+        # But call parse_args on the main parser (like vLLM does)
+        args = main_parser.parse_args(["serve", str(model_dir)])
 
         assert args.config_format == "mistral"
         assert args.tokenizer_mode == "mistral"
 
-    def test_config_format_defaults_to_auto_for_non_mistral_models(self):
-        """Test that config_format defaults to 'auto' for non-mistral models."""
-        parser = self.create_test_parser()
-        SpyrePlatform.pre_register_and_update(parser)
-        args = parser.parse_args(["facebook/opt-125m"])
+    def test_config_format_defaults_to_auto_for_models_without_params_json(
+        self, tmp_path, arg_parsers
+    ):
+        """Test that config_format defaults to 'auto' for models without params.json."""
+        main_parser, serve_parser = arg_parsers
+
+        # Create a temporary directory without params.json
+        model_dir = tmp_path / "some_other_model"
+        model_dir.mkdir()
+
+        # Put some other files in it
+        (model_dir / "config.json").write_text('{"_name_or_path": "gpt2"}')
+        (model_dir / "pytorch_model.bin").touch()
+
+        # Pass only the subparser to pre_register_and_update (like vLLM does)
+        SpyrePlatform.pre_register_and_update(serve_parser)
+        # But call parse_args on the main parser (like vLLM does)
+        args = main_parser.parse_args(["serve", str(model_dir)])
 
         assert args.config_format == "auto"
         assert args.tokenizer_mode == "auto"
 
-    def test_explicit_config_format_not_overridden(self):
+    def test_explicit_config_format_not_overridden(self, tmp_path, arg_parsers):
         """Test that user-provided config_format is not overridden."""
-        parser = self.create_test_parser()
-        SpyrePlatform.pre_register_and_update(parser)
-        args = parser.parse_args(["--config-format", "hf", "mistralai/Mistral-7B-Instruct-v0.1"])
+        main_parser, serve_parser = arg_parsers
+
+        # Create a temporary directory with params.json
+        model_dir = tmp_path / "mistral_model"
+        model_dir.mkdir()
+        params_file = model_dir / "params.json"
+        params_file.write_text('{"dim": 4096, "n_layers": 32}')
+
+        # Pass only the subparser to pre_register_and_update (like vLLM does)
+        SpyrePlatform.pre_register_and_update(serve_parser)
+        # But call parse_args on the main parser (like vLLM does)
+        args = main_parser.parse_args(["serve", "--config-format", "hf", str(model_dir)])
 
         # User explicitly set config_format to "hf", it should not be overridden
         assert args.config_format == "hf"

--- a/tests/utils/test_platform_validation.py
+++ b/tests/utils/test_platform_validation.py
@@ -356,3 +356,58 @@ class TestPreRegisterAndUpdate:
         assert args.config_format == "hf"
         # tokenizer_mode should still be set (since it depends on the same logic)
         assert args.tokenizer_mode == "mistral"
+
+    def test_config_format_from_cached_hf_model_offline_mode(
+        self, tmp_path, arg_parsers, monkeypatch
+    ):
+        """Test that config_format is detected from cached HF model in offline mode.
+
+        This creates a mock HF hub cache structure with a mistral model that has
+        params.json cached, then runs with HF_HUB_OFFLINE=1 to verify the
+        detection works correctly.
+        """
+        main_parser, serve_parser = arg_parsers
+
+        # Create a mock HF hub cache structure
+        # Format: <cache_dir>/models--<org>--<model>/snapshots/<commit_hash>/<files>
+        cache_dir = tmp_path / "hf_cache"
+        cache_dir.mkdir()
+
+        repo_id = "mistralai/Mistral-7B-Instruct-v0.1"
+        repo_folder = cache_dir / "models--mistralai--Mistral-7B-Instruct-v0.1"
+        refs_folder = repo_folder / "refs"
+        snapshots_folder = repo_folder / "snapshots"
+
+        refs_folder.mkdir(parents=True)
+        snapshots_folder.mkdir(parents=True)
+
+        # Create a fake commit hash "main" reference
+        (refs_folder / "main").write_text("abc123def456789")
+
+        # Create snapshot directory with the fake commit hash
+        snapshot_folder = snapshots_folder / "abc123def456789"
+        snapshot_folder.mkdir()
+
+        # Create params.json in the snapshot (this marks it as a mistral model)
+        (snapshot_folder / "params.json").write_text('{\n  "dim": 4096,\n  "n_layers": 32\n}')
+        # Also create other typical model files
+        (snapshot_folder / "config.json").write_text('{"model_type": "mistral"}')
+
+        # Set up the cache environment and offline mode
+        monkeypatch.setenv("HF_HOME", str(tmp_path))
+        monkeypatch.setenv("HF_HUB_CACHE", str(cache_dir))
+        monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+
+        # Re-import huggingface_hub constants to pick up the new env vars
+        import importlib
+        import huggingface_hub.constants
+
+        importlib.reload(huggingface_hub.constants)
+
+        # Pass only the subparser to pre_register_and_update
+        SpyrePlatform.pre_register_and_update(serve_parser)
+        # Call parse_args on the main parser with the repo_id
+        args = main_parser.parse_args(["serve", repo_id])
+
+        assert args.config_format == "mistral"
+        assert args.tokenizer_mode == "mistral"

--- a/vllm_spyre/argparse_utils.py
+++ b/vllm_spyre/argparse_utils.py
@@ -25,18 +25,17 @@ from collections.abc import Sequence
 from typing import Any, Protocol
 
 import argparse
+import logging
 
 from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+logger = logging.getLogger(__name__)
 
 
 class ComputeDefaultFunc(Protocol):
     """Protocol for a callable that computes a default value from a namespace."""
 
     def __call__(self, namespace: argparse.Namespace) -> Any: ...
-
-
-# Track which parsers have been patched to avoid duplicate work
-_PATCHED_PARSERS: set[int] = set()
 
 
 class ConditionalDefaultAction(argparse.Action):
@@ -76,33 +75,6 @@ class ConditionalDefaultManager:
 
     def __init__(self, parser: FlexibleArgumentParser) -> None:
         self.parser = parser
-        self._conditional_defaults: list[dict[str, Any]] = []
-
-    def add_conditional_default(
-        self,
-        dest: str,
-        compute_default: ComputeDefaultFunc,
-        explicit_marker_attr: str | None = None,
-    ) -> None:
-        """
-        Register a conditional default for an argument.
-
-        Args:
-            dest: The argument destination name (e.g., 'config_format').
-            compute_default: A callable that takes the parsed namespace and
-                             returns the default value to use. Return None to
-                             skip applying a default.
-            explicit_marker_attr: Optional custom attribute name for tracking
-                                  whether the user explicitly set this argument.
-                                  Defaults to f"_{dest}_explicit".
-        """
-        self._conditional_defaults.append(
-            {
-                "dest": dest,
-                "compute_default": compute_default,
-                "explicit_marker_attr": explicit_marker_attr or f"_{dest}_explicit",
-            }
-        )
 
     def apply(self) -> None:
         """
@@ -112,16 +84,14 @@ class ConditionalDefaultManager:
         1. Replaces the action for each managed argument with ConditionalDefaultAction
         2. Patches the parser's parse_args method to apply conditional defaults
         """
-        # Avoid patching the same parser instance twice
-        parser_id = id(self.parser)
-        if parser_id in _PATCHED_PARSERS:
-            return
-        _PATCHED_PARSERS.add(parser_id)
+        logger.debug(
+            "Enabling conditional defaults with %d config(s)",
+            len(_all_conditional_defaults),
+        )
 
-        # Step 1: Replace actions for managed arguments (both local and global)
-        all_configs = self._conditional_defaults + _all_conditional_defaults
+        # Step 1: Replace actions for managed arguments
         seen_dests: set[str] = set()
-        for config in all_configs:
+        for config in _all_conditional_defaults:
             dest = config["dest"]
             if dest in seen_dests:
                 continue
@@ -141,7 +111,13 @@ class ConditionalDefaultManager:
 
         # Check if we've already patched the base class
         if getattr(_argparse.ArgumentParser, "_spyre_conditional_defaults_patched", False):
+            logger.debug("ArgumentParser.parse_args already patched, skipping")
             return
+
+        logger.debug(
+            "Patching ArgumentParser.parse_args to apply %d conditional default(s)",
+            len(_all_conditional_defaults),
+        )
 
         original_parse_args = _argparse.ArgumentParser.parse_args
 
@@ -153,27 +129,43 @@ class ConditionalDefaultManager:
             result = original_parse_args(self, args, namespace)
             assert result is not None  # type: ignore[redundant-expr]
 
+            if args is None or len(args) == 0:
+                # Don't override anything if there were no args parsed
+                return result
+
             # Apply conditional defaults for any managed arguments
             for config in _all_conditional_defaults:
-                explicit_marker = config["explicit_marker_attr"]
                 dest = config["dest"]
 
                 # Skip if already applied or if user explicitly set the value
                 applied_attr = f"_{dest}_conditional_default_applied"
                 if getattr(result, applied_attr, False):
                     continue
-                if getattr(result, explicit_marker, False):
+                explicit_attr = f"_{dest}_explicit"
+                if getattr(result, explicit_attr, False):
+                    logger.debug(
+                        "Skipping conditional default for '%s': user explicitly provided value",
+                        dest,
+                    )
                     continue
 
                 # Apply the conditional default
                 try:
                     value = config["compute_default"](result)
                     if value is not None:
+                        logger.info(
+                            "Applying conditional default for '%s': %r",
+                            dest,
+                            value,
+                        )
                         setattr(result, dest, value)
                         setattr(result, applied_attr, True)
-                except Exception:
-                    # If condition evaluation fails, skip this default
-                    pass
+                except Exception as e:
+                    logger.debug(
+                        "Failed to compute conditional default for '%s': %s",
+                        dest,
+                        e,
+                    )
 
             return result
 
@@ -188,7 +180,6 @@ _all_conditional_defaults: list[dict[str, Any]] = []
 def register_conditional_default(
     dest: str,
     compute_default: ComputeDefaultFunc,
-    explicit_marker_attr: str | None = None,
 ) -> None:
     """
     Register a conditional default that will be applied to any parser.
@@ -202,12 +193,10 @@ def register_conditional_default(
         compute_default: A callable that takes the parsed namespace and
                          returns the default value to use. Return None to
                          skip applying a default.
-        explicit_marker_attr: Optional custom attribute for tracking explicit values.
     """
     _all_conditional_defaults.append(
         {
             "dest": dest,
             "compute_default": compute_default,
-            "explicit_marker_attr": explicit_marker_attr or f"_{dest}_explicit",
         }
     )

--- a/vllm_spyre/argparse_utils.py
+++ b/vllm_spyre/argparse_utils.py
@@ -12,17 +12,27 @@ Example usage:
         # Register conditional defaults that apply globally
         register_conditional_default(
             dest='config_format',
-            compute_default=lambda ns: 'mistral' if 'mistral' in getattr(ns, 'model', '').lower() else 'auto',
+            compute_default=lambda args: 'mistral' if 'mistral' args.model.lower() else 'auto',
         )
 
         manager = ConditionalDefaultManager(parser)
         manager.apply()
 """
 
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Protocol
+
 import argparse
-from typing import Any, Callable
 
 from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+
+class ComputeDefaultFunc(Protocol):
+    """Protocol for a callable that computes a default value from a namespace."""
+
+    def __call__(self, namespace: argparse.Namespace) -> Any: ...
 
 
 # Track which parsers have been patched to avoid duplicate work
@@ -62,14 +72,6 @@ class ConditionalDefaultManager:
        ConditionalDefaultAction, which tracks if the user explicitly set it.
     2. Patching the parser's parse_args method to apply conditional defaults
        after all arguments have been parsed.
-
-    Example:
-        manager = ConditionalDefaultManager(parser)
-        manager.add_conditional_default(
-            dest='config_format',
-            compute_default=lambda ns: 'mistral' if 'mistral' in getattr(ns, 'model', '').lower() else 'auto',
-        )
-        manager.apply()
     """
 
     def __init__(self, parser: FlexibleArgumentParser) -> None:
@@ -79,7 +81,7 @@ class ConditionalDefaultManager:
     def add_conditional_default(
         self,
         dest: str,
-        compute_default: Callable[[argparse.Namespace], Any],
+        compute_default: ComputeDefaultFunc,
         explicit_marker_attr: str | None = None,
     ) -> None:
         """
@@ -145,10 +147,11 @@ class ConditionalDefaultManager:
 
         def patched_parse_args(
             self: argparse.ArgumentParser,
-            args: list[str] | None = None,
+            args: Sequence[str] | None = None,
             namespace: argparse.Namespace | None = None,
         ) -> argparse.Namespace:
             result = original_parse_args(self, args, namespace)
+            assert result is not None  # type: ignore[redundant-expr]
 
             # Apply conditional defaults for any managed arguments
             for config in _all_conditional_defaults:
@@ -174,8 +177,8 @@ class ConditionalDefaultManager:
 
             return result
 
-        _argparse.ArgumentParser.parse_args = patched_parse_args
-        _argparse.ArgumentParser._spyre_conditional_defaults_patched = True
+        _argparse.ArgumentParser.parse_args = patched_parse_args  # type: ignore[invalid-assignment]
+        _argparse.ArgumentParser._spyre_conditional_defaults_patched = True  # type: ignore[attr-defined]
 
 
 # Global registry for conditional defaults across all parsers
@@ -184,7 +187,7 @@ _all_conditional_defaults: list[dict[str, Any]] = []
 
 def register_conditional_default(
     dest: str,
-    compute_default: Callable[[argparse.Namespace], Any],
+    compute_default: ComputeDefaultFunc,
     explicit_marker_attr: str | None = None,
 ) -> None:
     """

--- a/vllm_spyre/argparse_utils.py
+++ b/vllm_spyre/argparse_utils.py
@@ -12,7 +12,7 @@ Example usage:
         # Register conditional defaults that apply globally
         ConditionalDefaultManager.register(
             dest='config_format',
-            compute_default=lambda ns: 'mistral' if 'mistral' in getattr(ns, 'model', '').lower() else 'auto',
+            compute_default=lambda args: 'mistral' if 'mistral' in args.model.lower() else 'auto',
         )
 
         # Apply the patches to this parser
@@ -77,6 +77,15 @@ class ConditionalDefaultManager:
     """
 
     _all_conditional_defaults: ClassVar[list[dict[str, Any]]] = []
+
+    @classmethod
+    def clear(cls) -> None:
+        """Clear all registered conditional defaults.
+
+        This is useful for testing to ensure clean state between tests.
+        Note that this does not unpatch ArgumentParser.parse_args.
+        """
+        cls._all_conditional_defaults.clear()
 
     @classmethod
     def register(

--- a/vllm_spyre/argparse_utils.py
+++ b/vllm_spyre/argparse_utils.py
@@ -128,11 +128,6 @@ class ConditionalDefaultManager:
         1. Replaces the action for each managed argument with ConditionalDefaultAction
         2. Patches the parser's parse_args method to apply conditional defaults
         """
-        logger.debug(
-            "Enabling conditional defaults with %d config(s)",
-            len(cls._all_conditional_defaults),
-        )
-
         # Step 1: Replace actions for managed arguments
         for dest in cls._all_conditional_defaults:
             for action in parser._actions:
@@ -178,6 +173,10 @@ class ConditionalDefaultManager:
                 # Skip if already applied or if user explicitly set the value
                 applied_attr = f"_{dest}_conditional_default_applied"
                 if getattr(result, applied_attr, False):
+                    logger.debug(
+                        "Conditional default for '%s' was already applied: skipping...",
+                        dest,
+                    )
                     continue
                 explicit_attr = f"_{dest}_explicit"
                 if getattr(result, explicit_attr, False):

--- a/vllm_spyre/argparse_utils.py
+++ b/vllm_spyre/argparse_utils.py
@@ -196,7 +196,7 @@ class ConditionalDefaultManager:
                         setattr(result, dest, value)
                         setattr(result, applied_attr, True)
                 except Exception as e:
-                    logger.debug(
+                    logger.error(
                         "Failed to compute conditional default for '%s': %s",
                         dest,
                         e,

--- a/vllm_spyre/argparse_utils.py
+++ b/vllm_spyre/argparse_utils.py
@@ -1,0 +1,228 @@
+"""
+Utilities for conditional argument defaults in argparse.
+
+This module provides a mechanism to set argument defaults that depend on
+the values of other arguments, which is not natively supported by argparse.
+
+Example usage:
+    from vllm_spyre.argparse_utils import ConditionalDefaultManager
+
+    @classmethod
+    def pre_register_and_update(cls, parser):
+        manager = ConditionalDefaultManager(parser)
+
+        # Add a conditional default: config_format depends on model
+        manager.add_conditional_default(
+            dest='config_format',
+            condition=lambda ns: 'mistral' in (getattr(ns, 'model', '') or '').lower(),
+            true_value='mistral',
+            false_value='auto',
+        )
+
+        # Mark the parser for patching
+        manager.apply()
+"""
+
+import argparse
+from typing import Any, Callable
+
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+
+# Track which parsers have been patched to avoid duplicate work
+_PATCHED_PARSERS: set[int] = set()
+
+
+class ConditionalDefaultAction(argparse.Action):
+    """
+    Action that marks an argument as explicitly set by the user.
+
+    This allows us to distinguish between user-provided values and
+    defaults (both static and conditional).
+    """
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Any,
+        option_string: str | None = None,
+    ) -> None:
+        # Mark this argument as explicitly provided by the user
+        explicit_attr = f"_{self.dest}_explicit"
+        setattr(namespace, explicit_attr, True)
+        setattr(namespace, self.dest, values)
+
+
+class ConditionalDefaultManager:
+    """
+    Manages conditional defaults for argparse arguments.
+
+    This class allows you to define argument defaults that depend on
+    the values of other arguments, which is not natively supported by argparse.
+
+    The mechanism works by:
+    1. Replacing the standard action for each managed argument with
+       ConditionalDefaultAction, which tracks if the user explicitly set it.
+    2. Patching the parser's parse_args method to apply conditional defaults
+       after all arguments have been parsed.
+
+    Example:
+        manager = ConditionalDefaultManager(parser)
+        manager.add_conditional_default(
+            dest='config_format',
+            condition=lambda ns: 'mistral' in getattr(ns, 'model', '').lower(),
+            true_value='mistral',
+            false_value='auto',
+        )
+        manager.apply()
+    """
+
+    def __init__(self, parser: FlexibleArgumentParser) -> None:
+        self.parser = parser
+        self._conditional_defaults: list[dict[str, Any]] = []
+
+    def add_conditional_default(
+        self,
+        dest: str,
+        condition: Callable[[argparse.Namespace], bool],
+        true_value: Any,
+        false_value: Any,
+        explicit_marker_attr: str | None = None,
+    ) -> None:
+        """
+        Register a conditional default for an argument.
+
+        Args:
+            dest: The argument destination name (e.g., 'config_format').
+            condition: A callable that takes the parsed namespace and returns
+                       True if the condition is met, False otherwise.
+            true_value: The value to use if condition returns True.
+            false_value: The value to use if condition returns False.
+            explicit_marker_attr: Optional custom attribute name for tracking
+                                  whether the user explicitly set this argument.
+                                  Defaults to f"_{dest}_explicit".
+        """
+        self._conditional_defaults.append(
+            {
+                "dest": dest,
+                "condition": condition,
+                "true_value": true_value,
+                "false_value": false_value,
+                "explicit_marker_attr": explicit_marker_attr or f"_{dest}_explicit",
+            }
+        )
+
+    def apply(self) -> None:
+        """
+        Apply the conditional default logic to the parser.
+
+        This method:
+        1. Replaces the action for each managed argument with ConditionalDefaultAction
+        2. Patches the parser's parse_args method to apply conditional defaults
+        """
+        # Avoid patching the same parser instance twice
+        parser_id = id(self.parser)
+        if parser_id in _PATCHED_PARSERS:
+            return
+        _PATCHED_PARSERS.add(parser_id)
+
+        # Step 1: Replace actions for managed arguments (both local and global)
+        all_configs = self._conditional_defaults + _all_conditional_defaults
+        seen_dests: set[str] = set()
+        for config in all_configs:
+            dest = config["dest"]
+            if dest in seen_dests:
+                continue
+            seen_dests.add(dest)
+            for action in self.parser._actions:
+                if hasattr(action, "dest") and action.dest == dest:
+                    action.__class__ = ConditionalDefaultAction
+                    break
+
+        # Step 2: Patch parse_args at the base ArgumentParser class level
+        # This ensures it works even when the parser is used as a sub-parser
+        self._patch_parse_args()
+
+    def _patch_parse_args(self) -> None:
+        """Patch ArgumentParser.parse_args to apply conditional defaults."""
+        import argparse as _argparse
+
+        # Check if we've already patched the base class
+        if getattr(_argparse.ArgumentParser, "_spyre_conditional_defaults_patched", False):
+            return
+
+        original_parse_args = _argparse.ArgumentParser.parse_args
+
+        def patched_parse_args(
+            self: argparse.ArgumentParser,
+            args: list[str] | None = None,
+            namespace: argparse.Namespace | None = None,
+        ) -> argparse.Namespace:
+            result = original_parse_args(self, args, namespace)
+
+            # Apply conditional defaults for any managed arguments
+            # We iterate through all registered conditional defaults and apply
+            # them if the corresponding explicit marker is not set
+            for config in _all_conditional_defaults:
+                explicit_marker = config["explicit_marker_attr"]
+                dest = config["dest"]
+
+                # Skip if already applied or if user explicitly set the value
+                applied_attr = f"_{dest}_conditional_default_applied"
+                if getattr(result, applied_attr, False):
+                    continue
+                if getattr(result, explicit_marker, False):
+                    continue
+
+                # Apply the conditional default
+                try:
+                    condition_met = config["condition"](result)
+                    value = config["true_value"] if condition_met else config["false_value"]
+                    setattr(result, dest, value)
+                    setattr(result, applied_attr, True)
+                except Exception:
+                    # If condition evaluation fails, skip this default
+                    pass
+
+            return result
+
+        _argparse.ArgumentParser.parse_args = patched_parse_args
+        _argparse.ArgumentParser._spyre_conditional_defaults_patched = True
+
+
+# Global registry for conditional defaults across all parsers
+_all_conditional_defaults: list[dict[str, Any]] = []
+
+
+def register_conditional_default(
+    dest: str,
+    condition: Callable[[argparse.Namespace], bool],
+    true_value: Any,
+    false_value: Any,
+    explicit_marker_attr: str | None = None,
+) -> None:
+    """
+    Register a conditional default that will be applied to any parser.
+
+    This is useful when you want to apply the same conditional default
+    across multiple parsers or when you don't have direct access to the
+    parser instance.
+
+    Args:
+        dest: The argument destination name.
+        condition: A callable that takes the parsed namespace and returns
+                   True if the condition is met.
+        true_value: The value to use if condition returns True.
+        false_value: The value to use if condition returns False.
+        explicit_marker_attr: Optional custom attribute for tracking explicit values.
+    """
+    _all_conditional_defaults.append(
+        {
+            "dest": dest,
+            "condition": condition,
+            "true_value": true_value,
+            "false_value": false_value,
+            "explicit_marker_attr": explicit_marker_attr or f"_{dest}_explicit",
+        }
+    )

--- a/vllm_spyre/argparse_utils.py
+++ b/vllm_spyre/argparse_utils.py
@@ -5,24 +5,24 @@ This module provides a mechanism to set argument defaults that depend on
 the values of other arguments, which is not natively supported by argparse.
 
 Example usage:
-    from vllm_spyre.argparse_utils import ConditionalDefaultManager, register_conditional_default
+    from vllm_spyre.argparse_utils import ConditionalDefaultManager
 
     @classmethod
     def pre_register_and_update(cls, parser):
         # Register conditional defaults that apply globally
-        register_conditional_default(
+        ConditionalDefaultManager.register(
             dest='config_format',
-            compute_default=lambda args: 'mistral' if 'mistral' args.model.lower() else 'auto',
+            compute_default=lambda ns: 'mistral' if 'mistral' in getattr(ns, 'model', '').lower() else 'auto',
         )
 
-        manager = ConditionalDefaultManager(parser)
-        manager.apply()
+        # Apply the patches to this parser
+        ConditionalDefaultManager.apply(parser)
 """
 
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any, Protocol
+from typing import Any, ClassVar, Protocol
 
 import argparse
 import logging
@@ -71,12 +71,37 @@ class ConditionalDefaultManager:
        ConditionalDefaultAction, which tracks if the user explicitly set it.
     2. Patching the parser's parse_args method to apply conditional defaults
        after all arguments have been parsed.
+
+    All methods are class methods since the state is global across all parsers
+    via the class variable _all_conditional_defaults.
     """
 
-    def __init__(self, parser: FlexibleArgumentParser) -> None:
-        self.parser = parser
+    _all_conditional_defaults: ClassVar[list[dict[str, Any]]] = []
 
-    def apply(self) -> None:
+    @classmethod
+    def register(
+        cls,
+        dest: str,
+        compute_default: ComputeDefaultFunc,
+    ) -> None:
+        """
+        Register a conditional default for an argument.
+
+        Args:
+            dest: The argument destination name (e.g., 'config_format').
+            compute_default: A callable that takes the parsed namespace and
+                             returns the default value to use. Return None to
+                             skip applying a default.
+        """
+        cls._all_conditional_defaults.append(
+            {
+                "dest": dest,
+                "compute_default": compute_default,
+            }
+        )
+
+    @classmethod
+    def apply(cls, parser: FlexibleArgumentParser) -> None:
         """
         Apply the conditional default logic to the parser.
 
@@ -86,26 +111,27 @@ class ConditionalDefaultManager:
         """
         logger.debug(
             "Enabling conditional defaults with %d config(s)",
-            len(_all_conditional_defaults),
+            len(cls._all_conditional_defaults),
         )
 
         # Step 1: Replace actions for managed arguments
         seen_dests: set[str] = set()
-        for config in _all_conditional_defaults:
+        for config in cls._all_conditional_defaults:
             dest = config["dest"]
             if dest in seen_dests:
                 continue
             seen_dests.add(dest)
-            for action in self.parser._actions:
+            for action in parser._actions:
                 if hasattr(action, "dest") and action.dest == dest:
                     action.__class__ = ConditionalDefaultAction
                     break
 
         # Step 2: Patch parse_args at the base ArgumentParser class level
         # This ensures it works even when the parser is used as a sub-parser
-        self._patch_parse_args()
+        cls._patch_parse_args()
 
-    def _patch_parse_args(self) -> None:
+    @classmethod
+    def _patch_parse_args(cls) -> None:
         """Patch ArgumentParser.parse_args to apply conditional defaults."""
         import argparse as _argparse
 
@@ -116,7 +142,7 @@ class ConditionalDefaultManager:
 
         logger.debug(
             "Patching ArgumentParser.parse_args to apply %d conditional default(s)",
-            len(_all_conditional_defaults),
+            len(cls._all_conditional_defaults),
         )
 
         original_parse_args = _argparse.ArgumentParser.parse_args
@@ -134,7 +160,7 @@ class ConditionalDefaultManager:
                 return result
 
             # Apply conditional defaults for any managed arguments
-            for config in _all_conditional_defaults:
+            for config in cls._all_conditional_defaults:
                 dest = config["dest"]
 
                 # Skip if already applied or if user explicitly set the value
@@ -171,32 +197,3 @@ class ConditionalDefaultManager:
 
         _argparse.ArgumentParser.parse_args = patched_parse_args  # type: ignore[invalid-assignment]
         _argparse.ArgumentParser._spyre_conditional_defaults_patched = True  # type: ignore[attr-defined]
-
-
-# Global registry for conditional defaults across all parsers
-_all_conditional_defaults: list[dict[str, Any]] = []
-
-
-def register_conditional_default(
-    dest: str,
-    compute_default: ComputeDefaultFunc,
-) -> None:
-    """
-    Register a conditional default that will be applied to any parser.
-
-    This is useful when you want to apply the same conditional default
-    across multiple parsers or when you don't have direct access to the
-    parser instance.
-
-    Args:
-        dest: The argument destination name.
-        compute_default: A callable that takes the parsed namespace and
-                         returns the default value to use. Return None to
-                         skip applying a default.
-    """
-    _all_conditional_defaults.append(
-        {
-            "dest": dest,
-            "compute_default": compute_default,
-        }
-    )

--- a/vllm_spyre/argparse_utils.py
+++ b/vllm_spyre/argparse_utils.py
@@ -5,21 +5,17 @@ This module provides a mechanism to set argument defaults that depend on
 the values of other arguments, which is not natively supported by argparse.
 
 Example usage:
-    from vllm_spyre.argparse_utils import ConditionalDefaultManager
+    from vllm_spyre.argparse_utils import ConditionalDefaultManager, register_conditional_default
 
     @classmethod
     def pre_register_and_update(cls, parser):
-        manager = ConditionalDefaultManager(parser)
-
-        # Add a conditional default: config_format depends on model
-        manager.add_conditional_default(
+        # Register conditional defaults that apply globally
+        register_conditional_default(
             dest='config_format',
-            condition=lambda ns: 'mistral' in (getattr(ns, 'model', '') or '').lower(),
-            true_value='mistral',
-            false_value='auto',
+            compute_default=lambda ns: 'mistral' if 'mistral' in getattr(ns, 'model', '').lower() else 'auto',
         )
 
-        # Mark the parser for patching
+        manager = ConditionalDefaultManager(parser)
         manager.apply()
 """
 
@@ -71,9 +67,7 @@ class ConditionalDefaultManager:
         manager = ConditionalDefaultManager(parser)
         manager.add_conditional_default(
             dest='config_format',
-            condition=lambda ns: 'mistral' in getattr(ns, 'model', '').lower(),
-            true_value='mistral',
-            false_value='auto',
+            compute_default=lambda ns: 'mistral' if 'mistral' in getattr(ns, 'model', '').lower() else 'auto',
         )
         manager.apply()
     """
@@ -85,9 +79,7 @@ class ConditionalDefaultManager:
     def add_conditional_default(
         self,
         dest: str,
-        condition: Callable[[argparse.Namespace], bool],
-        true_value: Any,
-        false_value: Any,
+        compute_default: Callable[[argparse.Namespace], Any],
         explicit_marker_attr: str | None = None,
     ) -> None:
         """
@@ -95,10 +87,9 @@ class ConditionalDefaultManager:
 
         Args:
             dest: The argument destination name (e.g., 'config_format').
-            condition: A callable that takes the parsed namespace and returns
-                       True if the condition is met, False otherwise.
-            true_value: The value to use if condition returns True.
-            false_value: The value to use if condition returns False.
+            compute_default: A callable that takes the parsed namespace and
+                             returns the default value to use. Return None to
+                             skip applying a default.
             explicit_marker_attr: Optional custom attribute name for tracking
                                   whether the user explicitly set this argument.
                                   Defaults to f"_{dest}_explicit".
@@ -106,9 +97,7 @@ class ConditionalDefaultManager:
         self._conditional_defaults.append(
             {
                 "dest": dest,
-                "condition": condition,
-                "true_value": true_value,
-                "false_value": false_value,
+                "compute_default": compute_default,
                 "explicit_marker_attr": explicit_marker_attr or f"_{dest}_explicit",
             }
         )
@@ -162,8 +151,6 @@ class ConditionalDefaultManager:
             result = original_parse_args(self, args, namespace)
 
             # Apply conditional defaults for any managed arguments
-            # We iterate through all registered conditional defaults and apply
-            # them if the corresponding explicit marker is not set
             for config in _all_conditional_defaults:
                 explicit_marker = config["explicit_marker_attr"]
                 dest = config["dest"]
@@ -177,10 +164,10 @@ class ConditionalDefaultManager:
 
                 # Apply the conditional default
                 try:
-                    condition_met = config["condition"](result)
-                    value = config["true_value"] if condition_met else config["false_value"]
-                    setattr(result, dest, value)
-                    setattr(result, applied_attr, True)
+                    value = config["compute_default"](result)
+                    if value is not None:
+                        setattr(result, dest, value)
+                        setattr(result, applied_attr, True)
                 except Exception:
                     # If condition evaluation fails, skip this default
                     pass
@@ -197,9 +184,7 @@ _all_conditional_defaults: list[dict[str, Any]] = []
 
 def register_conditional_default(
     dest: str,
-    condition: Callable[[argparse.Namespace], bool],
-    true_value: Any,
-    false_value: Any,
+    compute_default: Callable[[argparse.Namespace], Any],
     explicit_marker_attr: str | None = None,
 ) -> None:
     """
@@ -211,18 +196,15 @@ def register_conditional_default(
 
     Args:
         dest: The argument destination name.
-        condition: A callable that takes the parsed namespace and returns
-                   True if the condition is met.
-        true_value: The value to use if condition returns True.
-        false_value: The value to use if condition returns False.
+        compute_default: A callable that takes the parsed namespace and
+                         returns the default value to use. Return None to
+                         skip applying a default.
         explicit_marker_attr: Optional custom attribute for tracking explicit values.
     """
     _all_conditional_defaults.append(
         {
             "dest": dest,
-            "condition": condition,
-            "true_value": true_value,
-            "false_value": false_value,
+            "compute_default": compute_default,
             "explicit_marker_attr": explicit_marker_attr or f"_{dest}_explicit",
         }
     )

--- a/vllm_spyre/argparse_utils.py
+++ b/vllm_spyre/argparse_utils.py
@@ -9,10 +9,14 @@ Example usage:
 
     @classmethod
     def pre_register_and_update(cls, parser):
+        def _compute_config_format(namespace: argparse.Namespace) -> str:
+            model = getattr(namespace, 'model', '') or ''
+            return 'mistral' if 'mistral' in model.lower() else 'auto'
+
         # Register conditional defaults that apply globally
         ConditionalDefaultManager.register(
             dest='config_format',
-            compute_default=lambda args: 'mistral' if 'mistral' in args.model.lower() else 'auto',
+            compute_default=_compute_config_format,
         )
 
         # Apply the patches to this parser
@@ -76,7 +80,7 @@ class ConditionalDefaultManager:
     via the class variable _all_conditional_defaults.
     """
 
-    _all_conditional_defaults: ClassVar[list[dict[str, Any]]] = []
+    _all_conditional_defaults: ClassVar[dict[str, ComputeDefaultFunc]] = {}
 
     @classmethod
     def clear(cls) -> None:
@@ -101,13 +105,19 @@ class ConditionalDefaultManager:
             compute_default: A callable that takes the parsed namespace and
                              returns the default value to use. Return None to
                              skip applying a default.
+
+        Raises:
+            ValueError: If a conditional default for this dest is already registered.
         """
-        cls._all_conditional_defaults.append(
-            {
-                "dest": dest,
-                "compute_default": compute_default,
-            }
-        )
+        if (
+            dest in cls._all_conditional_defaults
+            and cls._all_conditional_defaults[dest] != compute_default
+        ):
+            raise ValueError(
+                f"Conditional default for '{dest}' is already registered. "
+                f"Each destination can only be registered once."
+            )
+        cls._all_conditional_defaults[dest] = compute_default
 
     @classmethod
     def apply(cls, parser: FlexibleArgumentParser) -> None:
@@ -124,12 +134,7 @@ class ConditionalDefaultManager:
         )
 
         # Step 1: Replace actions for managed arguments
-        seen_dests: set[str] = set()
-        for config in cls._all_conditional_defaults:
-            dest = config["dest"]
-            if dest in seen_dests:
-                continue
-            seen_dests.add(dest)
+        for dest in cls._all_conditional_defaults:
             for action in parser._actions:
                 if hasattr(action, "dest") and action.dest == dest:
                     action.__class__ = ConditionalDefaultAction
@@ -169,9 +174,7 @@ class ConditionalDefaultManager:
                 return result
 
             # Apply conditional defaults for any managed arguments
-            for config in cls._all_conditional_defaults:
-                dest = config["dest"]
-
+            for dest, compute_default in cls._all_conditional_defaults.items():
                 # Skip if already applied or if user explicitly set the value
                 applied_attr = f"_{dest}_conditional_default_applied"
                 if getattr(result, applied_attr, False):
@@ -186,7 +189,7 @@ class ConditionalDefaultManager:
 
                 # Apply the conditional default
                 try:
-                    value = config["compute_default"](result)
+                    value = compute_default(result)
                     if value is not None:
                         logger.info(
                             "Applying conditional default for '%s': %r",

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -22,7 +22,7 @@ import torch
 from vllm.logger import init_logger
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
-from vllm_spyre.argparse_utils import ConditionalDefaultManager, register_conditional_default
+from vllm_spyre.argparse_utils import ConditionalDefaultManager
 
 if TYPE_CHECKING:
     # NB: We can't eagerly import many things from vllm since vllm.config
@@ -523,20 +523,19 @@ class SpyrePlatform(Platform):
             return "mistral" if "mistral" in model.lower() or local_mistral_configs else "auto"
 
         # Register conditional defaults that apply globally
-        register_conditional_default(
+        ConditionalDefaultManager.register(
             dest="config_format",
             compute_default=_compute_config_format,
         )
-        register_conditional_default(
+        ConditionalDefaultManager.register(
             dest="tokenizer_mode",
             compute_default=_compute_config_format,
         )
 
-        # Apply the conditional default manager to this parser
+        # Apply the conditional default patches to this parser
         # This replaces the actions for managed arguments and patches
         # the base ArgumentParser.parse_args method
-        manager = ConditionalDefaultManager(parser)
-        manager.apply()
+        ConditionalDefaultManager.apply(parser)
 
     @classmethod
     def _check_threading_config(cls, worker_count: int):

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -19,6 +19,8 @@ import torch
 from vllm.logger import init_logger
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
+from vllm_spyre.argparse_utils import ConditionalDefaultManager, register_conditional_default
+
 if TYPE_CHECKING:
     # NB: We can't eagerly import many things from vllm since vllm.config
     # will import this file. These would lead to circular imports
@@ -490,12 +492,42 @@ class SpyrePlatform(Platform):
 
     @classmethod
     def pre_register_and_update(cls, parser: FlexibleArgumentParser | None = None) -> None:
-        if parser is not None:
-            parser.set_defaults(enable_prefix_caching=True)
-            parser.set_defaults(max_num_batched_tokens=cls.DEFAULT_CHUNK_SIZE)
-            parser.set_defaults(
-                enable_chunked_prefill=True
-            )  # set to pass vllm scheduler's max_model_len check
+        if parser is None:
+            return
+
+        parser.set_defaults(enable_prefix_caching=True)
+        parser.set_defaults(max_num_batched_tokens=cls.DEFAULT_CHUNK_SIZE)
+        parser.set_defaults(
+            enable_chunked_prefill=True
+        )  # set to pass vllm scheduler's max_model_len check
+
+        # Register conditional defaults for config_format and tokenizer_mode
+        # based on whether the model name contains "mistral"
+        def _is_mistral_model(namespace: object) -> bool:
+            # Check both 'model' and 'model_tag' since vLLM uses different
+            # attribute names in different contexts
+            model = getattr(namespace, "model_tag", None) or getattr(namespace, "model", "") or ""
+            return "mistral" in model.lower()
+
+        # Register conditional defaults that apply globally
+        register_conditional_default(
+            dest="config_format",
+            condition=_is_mistral_model,
+            true_value="mistral",
+            false_value="auto",
+        )
+        register_conditional_default(
+            dest="tokenizer_mode",
+            condition=_is_mistral_model,
+            true_value="mistral",
+            false_value="auto",
+        )
+
+        # Apply the conditional default manager to this parser
+        # This replaces the actions for managed arguments and patches
+        # the base ArgumentParser.parse_args method
+        manager = ConditionalDefaultManager(parser)
+        manager.apply()
 
     @classmethod
     def _check_threading_config(cls, worker_count: int):

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -10,6 +10,7 @@ if sys.platform.startswith("darwin"):
     if sys.modules.get("triton"):
         del sys.modules["triton"]
 
+import argparse
 import math
 import operator
 import os
@@ -503,24 +504,24 @@ class SpyrePlatform(Platform):
 
         # Register conditional defaults for config_format and tokenizer_mode
         # based on whether the model name contains "mistral"
-        def _is_mistral_model(namespace: object) -> bool:
+        def _compute_config_format(namespace: argparse.Namespace) -> str:
             # Check both 'model' and 'model_tag' since vLLM uses different
             # attribute names in different contexts
             model = getattr(namespace, "model_tag", None) or getattr(namespace, "model", "") or ""
-            return "mistral" in model.lower()
+            return "mistral" if "mistral" in model.lower() else "auto"
+
+        def _compute_tokenizer_mode(namespace: argparse.Namespace) -> str:
+            model = getattr(namespace, "model_tag", None) or getattr(namespace, "model", "") or ""
+            return "mistral" if "mistral" in model.lower() else "auto"
 
         # Register conditional defaults that apply globally
         register_conditional_default(
             dest="config_format",
-            condition=_is_mistral_model,
-            true_value="mistral",
-            false_value="auto",
+            compute_default=_compute_config_format,
         )
         register_conditional_default(
             dest="tokenizer_mode",
-            condition=_is_mistral_model,
-            true_value="mistral",
-            false_value="auto",
+            compute_default=_compute_tokenizer_mode,
         )
 
         # Apply the conditional default manager to this parser

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import sys
 
 
@@ -505,22 +504,33 @@ class SpyrePlatform(Platform):
         )  # set to pass vllm scheduler's max_model_len check
 
         def _compute_config_format(namespace: argparse.Namespace) -> str:
-            """This is a much more relaxed check than vllm has to decide if a model is in mistral
-            format or not. We simply look for "mistral" in the name or the existence of the
-            mistral-specific params.json file.
+            """Check if a model is in mistral format by looking for params.json.
 
-            This is required because in offline mode, vllm needs the consolidated safetensors file
-            to be cached locally in order to determine if a model is a mistral model. This is often
-            not the case as we load mistral models from the chunked safetensors files.
+            This uses any_pattern_in_repo_files which correctly handles both local paths
+            and HuggingFace cache, including offline mode support.
             """
+            from vllm.transformers_utils.repo_utils import any_pattern_in_repo_files
+
             # Check both 'model' and 'model_tag' since vLLM uses different
             # attribute names in different contexts
             model = getattr(namespace, "model_tag", None) or getattr(namespace, "model", "") or ""
-            maybe_local_path = Path(model)
-            local_mistral_configs = (
-                maybe_local_path.exists() and (maybe_local_path / "params.json").is_file()
-            )
-            return "mistral" if "mistral" in model.lower() or local_mistral_configs else "auto"
+
+            if not model:
+                return "auto"
+
+            # Get optional HF arguments
+            revision = getattr(namespace, "revision", None)
+            token = getattr(namespace, "hf_token", None)
+
+            # Look for params.json which indicates a mistral-format model
+            if any_pattern_in_repo_files(
+                model,
+                allow_patterns=["params.json"],
+                revision=revision,
+                token=token,
+            ):
+                return "mistral"
+            return "auto"
 
         # Register conditional defaults that apply globally
         ConditionalDefaultManager.register(

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -18,6 +18,7 @@ import os
 from typing import TYPE_CHECKING, cast, Literal
 
 import torch
+import huggingface_hub
 from vllm.logger import init_logger
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
@@ -503,35 +504,6 @@ class SpyrePlatform(Platform):
             enable_chunked_prefill=True
         )  # set to pass vllm scheduler's max_model_len check
 
-        def _compute_config_format(namespace: argparse.Namespace) -> str:
-            """Check if a model is in mistral format by looking for params.json.
-
-            This uses any_pattern_in_repo_files which correctly handles both local paths
-            and HuggingFace cache, including offline mode support.
-            """
-            from vllm.transformers_utils.repo_utils import any_pattern_in_repo_files
-
-            # Check both 'model' and 'model_tag' since vLLM uses different
-            # attribute names in different contexts
-            model = getattr(namespace, "model_tag", None) or getattr(namespace, "model", "") or ""
-
-            if not model:
-                return "auto"
-
-            # Get optional HF arguments
-            revision = getattr(namespace, "revision", None)
-            token = getattr(namespace, "hf_token", None)
-
-            # Look for params.json which indicates a mistral-format model
-            if any_pattern_in_repo_files(
-                model,
-                allow_patterns=["params.json"],
-                revision=revision,
-                token=token,
-            ):
-                return "mistral"
-            return "auto"
-
         # Register conditional defaults that apply globally
         ConditionalDefaultManager.register(
             dest="config_format",
@@ -788,3 +760,37 @@ class SpyrePlatform(Platform):
             cls._max_batch_tkv_limit = int(os.getenv("VLLM_DT_MAX_BATCH_TKV_LIMIT", "-1"))  #  ty: ignore
         except ValueError as e:
             raise ValueError("VLLM_DT_MAX_BATCH_TKV_LIMIT must be an integer") from e
+
+
+def _compute_config_format(namespace: argparse.Namespace) -> str:
+    """Check if a model is in mistral format by looking for params.json.
+
+    This uses any_pattern_in_repo_files which correctly handles both local paths
+    and HuggingFace cache, including offline mode support.
+    """
+    from vllm.transformers_utils.repo_utils import any_pattern_in_repo_files, get_model_path
+
+    # Check both 'model' and 'model_tag' since vLLM uses different
+    # attribute names in different contexts
+    model = getattr(namespace, "model_tag", None) or getattr(namespace, "model", "") or ""
+
+    if not model:
+        return "auto"
+
+    # Get optional HF arguments
+    revision = getattr(namespace, "revision", None)
+    token = getattr(namespace, "hf_token", None)
+
+    # Resolve local path in offline mode (if not already a local path)
+    if huggingface_hub.constants.HF_HUB_OFFLINE:
+        model = get_model_path(model, revision)
+
+    # Look for params.json which indicates a mistral-format model
+    if any_pattern_in_repo_files(
+        model,
+        allow_patterns=["params.json"],
+        revision=revision,
+        token=token,
+    ):
+        return "mistral"
+    return "auto"

--- a/vllm_spyre/platform.py
+++ b/vllm_spyre/platform.py
@@ -1,4 +1,6 @@
+from pathlib import Path
 import sys
+
 
 # When running this plugin on a Mac, we assume it's for local development
 # purposes. However, due to a compatibility issue with vLLM, which overrides
@@ -502,17 +504,23 @@ class SpyrePlatform(Platform):
             enable_chunked_prefill=True
         )  # set to pass vllm scheduler's max_model_len check
 
-        # Register conditional defaults for config_format and tokenizer_mode
-        # based on whether the model name contains "mistral"
         def _compute_config_format(namespace: argparse.Namespace) -> str:
+            """This is a much more relaxed check than vllm has to decide if a model is in mistral
+            format or not. We simply look for "mistral" in the name or the existence of the
+            mistral-specific params.json file.
+
+            This is required because in offline mode, vllm needs the consolidated safetensors file
+            to be cached locally in order to determine if a model is a mistral model. This is often
+            not the case as we load mistral models from the chunked safetensors files.
+            """
             # Check both 'model' and 'model_tag' since vLLM uses different
             # attribute names in different contexts
             model = getattr(namespace, "model_tag", None) or getattr(namespace, "model", "") or ""
-            return "mistral" if "mistral" in model.lower() else "auto"
-
-        def _compute_tokenizer_mode(namespace: argparse.Namespace) -> str:
-            model = getattr(namespace, "model_tag", None) or getattr(namespace, "model", "") or ""
-            return "mistral" if "mistral" in model.lower() else "auto"
+            maybe_local_path = Path(model)
+            local_mistral_configs = (
+                maybe_local_path.exists() and (maybe_local_path / "params.json").is_file()
+            )
+            return "mistral" if "mistral" in model.lower() or local_mistral_configs else "auto"
 
         # Register conditional defaults that apply globally
         register_conditional_default(
@@ -521,7 +529,7 @@ class SpyrePlatform(Platform):
         )
         register_conditional_default(
             dest="tokenizer_mode",
-            compute_default=_compute_tokenizer_mode,
+            compute_default=_compute_config_format,
         )
 
         # Apply the conditional default manager to this parser


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This PR adds a simple class that sets default values for vllm's CLI args based on other cli args provided by the user.

This fixes a bug where with `HF_HUB_OFFLINE=1`, vllm is unable to determine whether a model is a mistral model or not. This requires users to explicitly pass `--config-format mistral` and `--tokenizer-mode mistral`, which is _not_ required when hf hub is in online mode.

This instead sets the default values for `--config-format` and `--tokenizer-mode` to "mistral" if a `params.json` file is detected. This works if `--model` either:
- References an hf hub model name that currently has a `params.json` cached, like`--model mistralai/Mistral-7B-Instruct-v0.1`
- Points to a directory with `params.json`, like `--model /path/to/my/mounted/model`

Because these are only overriding the default values for the CLI args, any user-specified values are still always respected.

## Related Issues

<!-- Link related issues, e.g., `Fixes #` or `Relates to #456` -->

## Test Plan

<!-- Describe how you tested your changes. Include commands or steps to reproduce. -->

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
