### PR TITLE
feat: implement profile_prefix

### DIFF
--- a/tests/e2e/test_profiler.py
+++ b/tests/e2e/test_profiler.py
@@ -46,9 +46,8 @@ def test_profiler_prefix(
     max_num_batched_tokens: int,
     tmp_path,
 ):
-    """Test that profile_prefix is reflected in the trace file names."""
+    """Test that profile_prefix is applied to each call."""
     prompts = get_chicken_soup_prompts(2)
-    prefix = "my_prefix"
 
     envs_spyre.override("VLLM_SPYRE_DYNAMO_BACKEND", "eager")
 
@@ -64,10 +63,11 @@ def test_profiler_prefix(
         ),
     )
 
-    spyre_model.start_profile(profile_prefix=prefix)
-    spyre_model.generate(prompts=prompts)
-    spyre_model.stop_profile()
+    for prefix in ("first", "second"):
+        spyre_model.start_profile(profile_prefix=prefix)
+        spyre_model.generate(prompts=prompts)
+        spyre_model.stop_profile()
 
-    trace_files = list(tmp_path.glob("*.pt.trace.json*"))
-    assert len(trace_files) > 0
-    assert all(f.name.startswith(prefix) for f in trace_files)
+    for prefix in ("first", "second"):
+        trace_files = list(tmp_path.glob(f"{prefix}*.pt.trace.json*"))
+        assert len(trace_files) > 0, f"No trace files found for prefix '{prefix}'"

--- a/tests/e2e/test_profiler.py
+++ b/tests/e2e/test_profiler.py
@@ -36,3 +36,38 @@ def test_profiler(
 
     trace_files = list(tmp_path.glob("*.pt.trace.json*"))
     assert len(trace_files) > 0
+
+
+@pytest.mark.cpu
+def test_profiler_prefix(
+    model: ModelInfo,
+    max_model_len: int,
+    max_num_seqs: int,
+    max_num_batched_tokens: int,
+    tmp_path,
+):
+    """Test that profile_prefix is reflected in the trace file names."""
+    prompts = get_chicken_soup_prompts(2)
+    prefix = "my_prefix"
+
+    envs_spyre.override("VLLM_SPYRE_DYNAMO_BACKEND", "eager")
+
+    spyre_model = LLM(
+        model=model.name,
+        revision=model.revision,
+        max_model_len=max_model_len,
+        max_num_seqs=max_num_seqs,
+        max_num_batched_tokens=max_num_batched_tokens,
+        profiler_config=ProfilerConfig(
+            profiler="torch",
+            torch_profiler_dir=str(tmp_path),
+        ),
+    )
+
+    spyre_model.start_profile(profile_prefix=prefix)
+    spyre_model.generate(prompts=prompts)
+    spyre_model.stop_profile()
+
+    trace_files = list(tmp_path.glob("*.pt.trace.json*"))
+    assert len(trace_files) > 0
+    assert all(f.name.startswith(prefix) for f in trace_files)

--- a/tests/v1/worker/test_spyre_worker_profile.py
+++ b/tests/v1/worker/test_spyre_worker_profile.py
@@ -60,30 +60,6 @@ def _make_worker(monkeypatch, vllm_config):
 
 @pytest.mark.cpu
 @pytest.mark.worker
-def test_profile_start(monkeypatch, mock_vllm_config):
-    """Test that profile() starts the profiler."""
-    worker = _make_worker(monkeypatch, mock_vllm_config)
-    worker.profiler = Mock()
-
-    worker.profile(is_start=True)
-
-    worker.profiler.start.assert_called_once()
-
-
-@pytest.mark.cpu
-@pytest.mark.worker
-def test_profile_stop(monkeypatch, mock_vllm_config):
-    """Test that profile(is_start=False) stops the profiler."""
-    worker = _make_worker(monkeypatch, mock_vllm_config)
-    worker.profiler = Mock()
-
-    worker.profile(is_start=False)
-
-    worker.profiler.stop.assert_called_once()
-
-
-@pytest.mark.cpu
-@pytest.mark.worker
 def test_profile_raises_when_profiler_not_enabled(monkeypatch, mock_vllm_config):
     """Test that profile() raises RuntimeError when profiler is not enabled."""
     mock_vllm_config.profiler_config = ProfilerConfig(profiler=None)

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -274,36 +274,24 @@ class SpyreWorker(WorkerBase):
         #   --profiler-config.torch_profiler_dir=/path/to/save/trace)
         # OR
         #   --profiler-config '{"profiler": "torch", "torch_profiler_dir": "/path/to/save/trace"}'
-        profiler_config = vllm_config.profiler_config
-        if profiler_config.profiler == "torch":
-            worker_name = f"{vllm_config.instance_id}-rank-{self.rank}"
-            self.profiler: TorchProfilerWrapper | None = TorchProfilerWrapper(
-                profiler_config,
-                worker_name=worker_name,
-                local_rank=self.local_rank,
-                activities=["CPU"],
+        self.profiler_config = vllm_config.profiler_config
+        self.profiler: TorchProfilerWrapper | None = None
+        if self.profiler_config.profiler == "torch" and SpyrePlatform.is_backend_sendnn_enabled():
+            logger.info_once(
+                "Traces will contain AIU events if PyTorch with AIU profiling support is installed."
             )
+            os.environ["ProfilerActivity"] = "PrivateUse1"  # noqa: SIM112
 
-            if SpyrePlatform.is_backend_sendnn_enabled():
-                logger.info_once(
-                    "Traces will contain AIU events if PyTorch with"
-                    " AIU profiling support is installed."
+            # Get the current value of DT_OPT and autopilot
+            dt_opt = os.environ.get("DT_OPT", "")
+            options = dict(opt.split("=") for opt in dt_opt.split(",") if "=" in opt)
+            autopilot_opt = options.get("autopilot", "1")  # autopilot defaults to 1 if not set
+            if autopilot_opt == "1":
+                logger.warning_once(
+                    "autopilot on detected with profiling enabled. Add "
+                    "autopilot=0 to DT_OPT to see individual AIU-kernel "
+                    "execution in the trace."
                 )
-                os.environ["ProfilerActivity"] = "PrivateUse1"  # noqa: SIM112
-
-                # Get the current value of DT_OPT and autopilot
-                dt_opt = os.environ.get("DT_OPT", "")
-                options = dict(opt.split("=") for opt in dt_opt.split(",") if "=" in opt)
-                autopilot_opt = options.get("autopilot", "1")  # autopilot defaults to 1 if not set
-                if autopilot_opt == "1":
-                    logger.warning_once(
-                        "autopilot on detected with profiling enabled. Add "
-                        "autopilot=0 to DT_OPT to see individual AIU-kernel "
-                        "execution in the trace."
-                    )
-
-        else:
-            self.profiler = None
 
     def init_distributed_environment(self) -> None:
         """Initialize the distributed environment."""
@@ -731,7 +719,7 @@ class SpyreWorker(WorkerBase):
         self.execute_model(scheduler_output)  # Prefill
 
     def profile(self, is_start: bool = True, profile_prefix: str | None = None):
-        if self.profiler is None:
+        if self.profiler_config.profiler is None:
             raise RuntimeError(
                 "Profiling is not enabled. Please set --profiler-config to enable "
                 "profiling. Example: "
@@ -739,6 +727,17 @@ class SpyreWorker(WorkerBase):
                 "=YOUR_DIR_PATH_TO_DUMP_TRACE'"
             )
         if is_start:
+            if self.profiler is None:
+                worker_name = f"{self.vllm_config.instance_id}-rank-{self.rank}"
+                if profile_prefix:
+                    worker_name = f"{profile_prefix}_{worker_name}"
+                self.profiler = TorchProfilerWrapper(
+                    self.profiler_config,
+                    worker_name=worker_name,
+                    local_rank=self.local_rank,
+                    activities=["CPU"],
+                )
+            assert self.profiler is not None
             self.profiler.start()
         else:
             if self.profiler is None:

--- a/vllm_spyre/v1/worker/spyre_worker.py
+++ b/vllm_spyre/v1/worker/spyre_worker.py
@@ -727,17 +727,16 @@ class SpyreWorker(WorkerBase):
                 "=YOUR_DIR_PATH_TO_DUMP_TRACE'"
             )
         if is_start:
-            if self.profiler is None:
-                worker_name = f"{self.vllm_config.instance_id}-rank-{self.rank}"
-                if profile_prefix:
-                    worker_name = f"{profile_prefix}_{worker_name}"
-                self.profiler = TorchProfilerWrapper(
-                    self.profiler_config,
-                    worker_name=worker_name,
-                    local_rank=self.local_rank,
-                    activities=["CPU"],
-                )
-            assert self.profiler is not None
+            # Recreate the wrapper each time
+            worker_name = f"{self.vllm_config.instance_id}-rank-{self.rank}"
+            if profile_prefix:
+                worker_name = f"{profile_prefix}_{worker_name}"
+            self.profiler = TorchProfilerWrapper(
+                self.profiler_config,
+                worker_name=worker_name,
+                local_rank=self.local_rank,
+                activities=["CPU"],
+            )
             self.profiler.start()
         else:
             if self.profiler is None:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

- Implements `profile_prefix` in `SpyreWorker.profile()`. 
  - `TorchProfilerWrapper` is now created lazily on the first profile call (instead of in `__init__`), so profile_prefix can be pulled into the trace name

- Adds an e2e test for profile_prefix

## Related Issues

Follow up to #915, closes #920 

## Test Plan

- Added e2e test

## Checklist

- [x] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [x] My code follows the project's code style (run `bash format.sh`)
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
