### PR TITLE
fix: GHA PR comment/labelling

### DIFF
--- a/.github/workflows/add_label_automerge.yml
+++ b/.github/workflows/add_label_automerge.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   add-label-on-auto-merge:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Add label
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/reminder_comment.yml
+++ b/.github/workflows/reminder_comment.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   pr_reminder:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Remind to run full CI on PR
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -15,7 +17,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: "👋 Hi! Thank you for contributing to vLLM support on Spyre.\n Just a reminder: Make sure that your code passes all the linting checks, otherwise your PR won't be able to be merged. To do so, run `./format.sh`. \nNow you are good to go 🚀.\n\nWe also recommend installing prek and configuring it to check your code before every local commit."
+              body: "👋 Hi! Thank you for contributing.\n Just a reminder: Make sure that your code passes all the linting checks, otherwise your PR won't be able to be merged. To do so, run `./format.sh`. \nNow you are good to go 🚀.\n\nWe also recommend installing prek and configuring it to check your code before every local commit."
             })
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

- Fixes the pr_reminder and automerge-label workflows that broke after migrating (or need to update the `GITHUB_TOKEN` perms in the repo)

## Test Plan

- Must be merged to verify (`pull_request_target`)
 
## Checklist

- [x] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [x] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
