### PR TITLE
:arrow_up: upgrade vllm to 0.19.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "ibm-fms>=1.9.0,<2",
     # NB: use strict < with the next patch version to not exclude versions with
     # build metadata suffixes
-    "vllm>=0.19.0,<0.19.1",
+    "vllm>=0.19.0,<0.19.2",
     
     # Specific torch version overrides handled by uv
     "torch",
@@ -87,7 +87,7 @@ build-constraint-dependencies = ["torch==2.10.0"]
 extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "empty" } }
 
 [tool.uv.sources]
-vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.19.0" }
+vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.19.1" }
 torch = [
   { index = "pytorch-cpu" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -30,7 +30,7 @@ overrides = [
     { name = "setuptools", specifier = ">=82" },
     { name = "torch", specifier = "==2.10.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "triton", marker = "sys_platform == 'never'" },
-    { name = "vllm", marker = "platform_machine not in 's390x, ppc64le'", git = "https://github.com/vllm-project/vllm?rev=v0.19.0" },
+    { name = "vllm", marker = "platform_machine not in 's390x, ppc64le'", git = "https://github.com/vllm-project/vllm?rev=v0.19.1" },
 ]
 build-constraints = [{ name = "torch", specifier = "==2.10.0", index = "https://download.pytorch.org/whl/cpu" }]
 
@@ -4592,8 +4592,8 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.19.0"
-source = { git = "https://github.com/vllm-project/vllm?rev=v0.19.0#2a69949bdadf0e8942b7a1619b229cb475beef20" }
+version = "0.19.1"
+source = { git = "https://github.com/vllm-project/vllm?rev=v0.19.1#b1388b1fbf5aaef47937fabe98931211684666a6" }
 dependencies = [
     { name = "aiohttp" },
     { name = "anthropic" },
@@ -4691,7 +4691,7 @@ requires-dist = [
     { name = "ibm-fms", specifier = ">=1.9.0,<2" },
     { name = "torch", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torchvision", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "vllm", git = "https://github.com/vllm-project/vllm?rev=v0.19.0" },
+    { name = "vllm", git = "https://github.com/vllm-project/vllm?rev=v0.19.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This PR updates the uv lock for vllm to 0.19.1

## Related Issues


## Test Plan

cpu unit tests, spyre unit tests, spyre integration tests

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
