### PR TITLE
:bug: fixup the test ordering for real

### DIFF
--- a/tests/e2e/test_sampling_params.py
+++ b/tests/e2e/test_sampling_params.py
@@ -5,7 +5,7 @@ from llm_cache import get_cached_llm
 from spyre_util import ModelInfo
 from vllm import LLM, SamplingParams
 
-pytestmark = [pytest.mark.prefix_caching]
+pytestmark = [pytest.mark.chunked_prefill]
 
 
 def test_spyre_temperature(
@@ -24,7 +24,6 @@ def test_spyre_temperature(
         max_num_batched_tokens=max_num_batched_tokens,
         backend=backend,
         monkeypatch=monkeypatch,
-        use_pc=True,
     )
 
     prompt = "The capital of the United Kingdom is"
@@ -55,7 +54,6 @@ def test_spyre_max_tokens(
         max_num_batched_tokens=max_num_batched_tokens,
         backend=backend,
         monkeypatch=monkeypatch,
-        use_pc=True,
     )
 
     prompt = "Count to twenty"
@@ -89,7 +87,6 @@ def test_spyre_stop_sequence(
         max_num_batched_tokens=max_num_batched_tokens,
         backend=backend,
         monkeypatch=monkeypatch,
-        use_pc=True,
     )
     stop_str = "7"
     prompt = "1 2 3 4 5 "
@@ -129,7 +126,6 @@ def test_spyre_presence_penalty(
         max_num_batched_tokens=max_num_batched_tokens,
         backend=backend,
         monkeypatch=monkeypatch,
-        use_pc=True,
     )
     prompt = "REPEAT OVER AND OVER AGAIN THE MINIMUM TIMES POSSIBLE: one one one one one"
 
@@ -162,7 +158,6 @@ def test_spyre_frequency_penalty(
         max_num_batched_tokens=max_num_batched_tokens,
         backend=backend,
         monkeypatch=monkeypatch,
-        use_pc=True,
     )
 
     prompt = "repeat the word hi ten times:"
@@ -195,7 +190,6 @@ def test_spyre_n_generations(
         max_num_batched_tokens=max_num_batched_tokens,
         backend=backend,
         monkeypatch=monkeypatch,
-        use_pc=True,
     )
     prompt = "The three most popular sports in the world are: "
 
@@ -250,7 +244,6 @@ def test_spyre_top_p(
         max_num_batched_tokens=max_num_batched_tokens,
         backend=backend,
         monkeypatch=monkeypatch,
-        use_pc=True,
     )
     prompt = "The first three letters of the alphabet are"
     params1 = SamplingParams(top_p=0.01, temperature=1, max_tokens=10)
@@ -277,7 +270,6 @@ def test_spyre_top_k(
         max_num_batched_tokens=max_num_batched_tokens,
         backend=backend,
         monkeypatch=monkeypatch,
-        use_pc=True,
     )
     prompt = "The opposite of hot is"
     params1 = SamplingParams(temperature=1, top_k=1, max_tokens=5)
@@ -303,7 +295,6 @@ def test_spyre_logit_bias(
         max_num_batched_tokens=max_num_batched_tokens,
         backend=backend,
         monkeypatch=monkeypatch,
-        use_pc=True,
     )
     tokenizer = spyre_model.get_tokenizer()
     banned_word = "train"
@@ -350,7 +341,6 @@ def test_spyre_min_tokens(
         max_num_batched_tokens=max_num_batched_tokens,
         backend=backend,
         monkeypatch=monkeypatch,
-        use_pc=True,
     )
     prompt = "What is the capital of the USA?"
     tokenizer = spyre_model.get_tokenizer()
@@ -385,7 +375,6 @@ def test_spyre_ignore_eos(
         max_num_batched_tokens=max_num_batched_tokens,
         backend=backend,
         monkeypatch=monkeypatch,
-        use_pc=True,
     )
     tokenizer = spyre_model.get_tokenizer()
     eos_id = tokenizer.eos_token_id
@@ -420,7 +409,6 @@ def test_spyre_min_p(
         max_num_batched_tokens=max_num_batched_tokens,
         backend=backend,
         monkeypatch=monkeypatch,
-        use_pc=True,
     )
     prompt = "The opposite of black is"
     params1 = SamplingParams(min_p=0.5, temperature=1, max_tokens=5)
@@ -447,7 +435,6 @@ def test_spyre_bad_words(
         max_num_batched_tokens=max_num_batched_tokens,
         backend=backend,
         monkeypatch=monkeypatch,
-        use_pc=True,
     )
     prompt = "The capital of France is"
     params1 = SamplingParams(
@@ -479,7 +466,6 @@ def test_spyre_detokenize(
         max_num_batched_tokens=max_num_batched_tokens,
         backend=backend,
         monkeypatch=monkeypatch,
-        use_pc=True,
     )
     prompt = "Hello, world!"
     params = SamplingParams(max_tokens=5, temperature=0, detokenize=False)
@@ -505,7 +491,6 @@ def test_spyre_logprobs(
         max_num_batched_tokens=max_num_batched_tokens,
         backend=backend,
         monkeypatch=monkeypatch,
-        use_pc=True,
     )
     num_logprobs = 5
     prompt = "The sky is"

--- a/tests/e2e/test_sampling_params.py
+++ b/tests/e2e/test_sampling_params.py
@@ -5,7 +5,7 @@ from llm_cache import get_cached_llm
 from spyre_util import ModelInfo
 from vllm import LLM, SamplingParams
 
-pytestmark = [pytest.mark.chunked_prefill]
+pytestmark = [pytest.mark.prefix_caching]
 
 
 def test_spyre_temperature(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

#903 had a mismatch between the llm cache key and the actual config for `uses_pc`. I fixed that one, but failed to see the same problem in the sampling params tests. Because the tests from 903 insert themselves right after the sampling params ones, they uncover the problem with the sampling params test that was previously hidden

```
E       AssertionError: Runtime config {'model': ModelInfo(name='ibm-ai-platform/micro-g3.3-8b-instruct-1b', revision='6e9c6465a9d7e5e9fa35004a29f0c90befa7d23f', is_quantized=False), 'tensor_parallel_size': 1, 'backend': 'sendnn', 'use_cp': True, 'use_pc': True, 'max_num_batched_tokens': 128, 'max_model_len': 512, 'max_num_seqs': 4} was previously cached for type [<class 'vllm.entrypoints.llm.LLM'>], error in test ordering!
```

NB: We could fix this by marking these tests with `@pytest.mark.prefix_caching` and leave prefix caching on, but prefix caching doesn't really matter for sampling params nor would these prompts hit prefix cache 🤷 

## Related Issues

## Test Plan

`pytest -m "cpu and uses_llm" -vx` needs to pass


## Checklist

- [ ] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
