### PR TITLE
Add SENDNN_INFERENCE_CPU_MM_DTYPE for configurable CPU dtype handling in multimodal parameters.

### DIFF
--- a/sendnn_inference/envs.py
+++ b/sendnn_inference/envs.py
@@ -1,7 +1,11 @@
 import os
+import platform
 from typing import TYPE_CHECKING, Any, Callable
 
+import torch
 from vllm.logger import init_logger
+
+from sendnn_inference.utils import parse_cpu_mm_dtype
 
 if TYPE_CHECKING:
     SENDNN_INFERENCE_DYNAMO_BACKEND: str = "sendnn"
@@ -20,11 +24,13 @@ if TYPE_CHECKING:
     SENDNN_INFERENCE_NUM_CPUS: int = 0
     SENDNN_INFERENCE_REQUIRE_KNOWN_CONFIG: bool = False
     SENDNN_INFERENCE_MODEL_CONFIG_FILE: str | None = None
-    SENDNN_INFERENCE_CPU_MM_DTYPE: str = "float16"
+    SENDNN_INFERENCE_CPU_MM_DTYPE: torch.dtype = torch.float16
 
 logger = init_logger(__name__)
 
 _cache: dict[str, Any] = {}
+
+_CPU_MM_DTYPE_PLATFORM_DEFAULTS = {"s390x": "float32", "ppc64le": "bfloat16"}
 
 
 def override(name: str, value: str) -> None:
@@ -138,10 +144,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Path to custom model_configs.yaml file. If not set, uses the default
     # location at sendnn_inference/config/model_configs.yaml
     "SENDNN_INFERENCE_MODEL_CONFIG_FILE": lambda: os.getenv("SENDNN_INFERENCE_MODEL_CONFIG_FILE"),
-    # Dtype for multimodal vision_tower and multi_modal_projector params
-    # that run on CPU. Valid values: "float32", "float16", "bfloat16".
-    # Default: "float16".
-    "SENDNN_INFERENCE_CPU_MM_DTYPE": lambda: os.getenv("SENDNN_INFERENCE_CPU_MM_DTYPE", "float16"),
+    # Dtype for multimodal vision_tower / multi_modal_projector params (CPU).
+    # One of "float32" | "float16" | "bfloat16"; default per platform.
+    "SENDNN_INFERENCE_CPU_MM_DTYPE": lambda: parse_cpu_mm_dtype(
+        os.getenv(
+            "SENDNN_INFERENCE_CPU_MM_DTYPE",
+            _CPU_MM_DTYPE_PLATFORM_DEFAULTS.get(platform.machine(), "float16"),
+        )
+    ),
 }
 # --8<-- [end:env-vars-definition]
 

--- a/sendnn_inference/envs.py
+++ b/sendnn_inference/envs.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     SENDNN_INFERENCE_NUM_CPUS: int = 0
     SENDNN_INFERENCE_REQUIRE_KNOWN_CONFIG: bool = False
     SENDNN_INFERENCE_MODEL_CONFIG_FILE: str | None = None
+    SENDNN_INFERENCE_CPU_MM_DTYPE: str = "float16"
 
 logger = init_logger(__name__)
 
@@ -137,6 +138,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Path to custom model_configs.yaml file. If not set, uses the default
     # location at sendnn_inference/config/model_configs.yaml
     "SENDNN_INFERENCE_MODEL_CONFIG_FILE": lambda: os.getenv("SENDNN_INFERENCE_MODEL_CONFIG_FILE"),
+    # Dtype for multimodal vision_tower and multi_modal_projector params
+    # that run on CPU. Valid values: "float32", "float16", "bfloat16".
+    # Default: "float16".
+    "SENDNN_INFERENCE_CPU_MM_DTYPE": lambda: os.getenv("SENDNN_INFERENCE_CPU_MM_DTYPE", "float16"),
 }
 # --8<-- [end:env-vars-definition]
 

--- a/sendnn_inference/model_executor/model_loader/spyre.py
+++ b/sendnn_inference/model_executor/model_loader/spyre.py
@@ -32,6 +32,12 @@ except ImportError:
 
 BACKEND_LIST = ["sendnn", "sendnn_compile_only", "inductor"]
 
+# FMS parameter-name prefixes for the vision encoder and projector, which
+# run on CPU. Their dtype is controlled by SENDNN_INFERENCE_CPU_MM_DTYPE via
+# _cast_to_mm_type. Trailing '.' bounds the prefix to the module itself so
+# sibling names with a shared stem never match.
+CPU_MM_PREFIXES = ("vision_tower.", "multi_modal_projector.")
+
 logger = init_logger(__name__)
 
 
@@ -233,8 +239,10 @@ class SpyreCausalLM(nn.Module):
             )
 
         if envs_spyre.SENDNN_INFERENCE_DYNAMO_BACKEND in BACKEND_LIST:
-            # When running on Spyre cards for either non-quantized (bf16) models
-            # or quantized (fp8) models, we cast any bf16 params down
+            # On Spyre, bf16 params are type cast to fp16. Vision encoder + projector
+            # run on CPU and take their own dtype from SENDNN_INFERENCE_CPU_MM_DTYPE —
+            # apply that first, then type cast remaining bf16 params to fp16.
+            self._cast_to_mm_type()
             self._cast_bf16_to_f16()
             options = {"sendnn.dynamic": True} if sendnn_dynamic else {}
 
@@ -267,18 +275,48 @@ class SpyreCausalLM(nn.Module):
         self.is_multimodal = self.mm_model_utils is not None
         logger.debug("Model weights loaded successfully.")
 
-    def _cast_bf16_to_f16(self):
-        """Cast all bf16 params in the model to f16."""
+    def _cast_to_mm_type(self):
+        """Cast the vision encoder and multi_modal_projector params to the
+        dtype configured by SENDNN_INFERENCE_CPU_MM_DTYPE. These params run on
+        CPU for vision inputs; Spyre hosts only the text decoder.
+        """
+        cpu_mm_dtype_map = {
+            "float32": torch.float32,
+            "float16": torch.float16,
+            "bfloat16": torch.bfloat16,
+        }
+        cpu_mm_dtype_str = envs_spyre.SENDNN_INFERENCE_CPU_MM_DTYPE
+        if cpu_mm_dtype_str not in cpu_mm_dtype_map:
+            raise ValueError(
+                "SENDNN_INFERENCE_CPU_MM_DTYPE must be one of "
+                f"{list(cpu_mm_dtype_map)}, got {cpu_mm_dtype_str!r}"
+            )
+        cpu_mm_dtype = cpu_mm_dtype_map[cpu_mm_dtype_str]
+
         for name, param in self.fms_model.named_parameters():
-            if param.dtype == torch.bfloat16:
+            if name.startswith(CPU_MM_PREFIXES) and param.dtype != cpu_mm_dtype:
+                param.data = param.data.to(dtype=cpu_mm_dtype)
                 logger.debug(
-                    "You are casting param %s to fp16, which"
-                    " will cause loss of accuracy. This is required for"
-                    " spyre cards that don't support bf16. You can ignore"
-                    " this warning if this is intended.",
+                    "Casting vision encoder param %s to %s for CPU execution.",
                     name,
+                    cpu_mm_dtype_str,
                 )
-                param.data = param.data.to(dtype=torch.float16)
+
+    def _cast_bf16_to_f16(self):
+        """Cast bf16 params in the model to f16. Vision encoder + projector
+        params are skipped — their dtype is managed by _cast_to_mm_type.
+        """
+        for name, param in self.fms_model.named_parameters():
+            if param.dtype != torch.bfloat16 or name.startswith(CPU_MM_PREFIXES):
+                continue
+            logger.debug(
+                "You are casting param %s to fp16, which"
+                " will cause loss of accuracy. This is required for"
+                " spyre cards that don't support bf16. You can ignore"
+                " this warning if this is intended.",
+                name,
+            )
+            param.data = param.data.to(dtype=torch.float16)
 
     def _cast_to_f32(self):
         """Cast model parameters to f32."""

--- a/sendnn_inference/model_executor/model_loader/spyre.py
+++ b/sendnn_inference/model_executor/model_loader/spyre.py
@@ -32,12 +32,6 @@ except ImportError:
 
 BACKEND_LIST = ["sendnn", "sendnn_compile_only", "inductor"]
 
-# FMS parameter-name prefixes for the vision encoder and projector, which
-# run on CPU. Their dtype is controlled by SENDNN_INFERENCE_CPU_MM_DTYPE via
-# _cast_to_mm_type. Trailing '.' bounds the prefix to the module itself so
-# sibling names with a shared stem never match.
-CPU_MM_PREFIXES = ("vision_tower.", "multi_modal_projector.")
-
 logger = init_logger(__name__)
 
 
@@ -238,12 +232,17 @@ class SpyreCausalLM(nn.Module):
                 max_decode_length,
             )
 
+        # Initialize mm utils before the cast (reads mm_parameter_prefixes)
+        # and before torch.compile wraps fms_model (reads fms_model.config).
+        self.mm_model_utils = spyre_mm.maybe_get_mm_utils(
+            model_path=model_path,
+            fms_config=self.fms_model.config,
+            hf_config=self.config,
+        )
+        self.is_multimodal = self.mm_model_utils is not None
+
         if envs_spyre.SENDNN_INFERENCE_DYNAMO_BACKEND in BACKEND_LIST:
-            # On Spyre, bf16 params are type cast to fp16. Vision encoder + projector
-            # run on CPU and take their own dtype from SENDNN_INFERENCE_CPU_MM_DTYPE —
-            # apply that first, then type cast remaining bf16 params to fp16.
-            self._cast_to_mm_type()
-            self._cast_bf16_to_f16()
+            self._cast_params_for_spyre()
             options = {"sendnn.dynamic": True} if sendnn_dynamic else {}
 
             # Lazy import to avoid load torch_sendnn runtime before it is really
@@ -265,58 +264,31 @@ class SpyreCausalLM(nn.Module):
                 assert self.dtype == torch.float32
                 self._cast_to_f32()
 
-        # If it's multimodal, create an instance of the
-        # corresponding mm utils helper; this is arch specific.
-        self.mm_model_utils = spyre_mm.maybe_get_mm_utils(
-            model_path=model_path,
-            fms_config=self.fms_model.config,
-            hf_config=self.config,
-        )
-        self.is_multimodal = self.mm_model_utils is not None
         logger.debug("Model weights loaded successfully.")
 
-    def _cast_to_mm_type(self):
-        """Cast the vision encoder and multi_modal_projector params to the
-        dtype configured by SENDNN_INFERENCE_CPU_MM_DTYPE. These params run on
-        CPU for vision inputs; Spyre hosts only the text decoder.
-        """
-        cpu_mm_dtype_map = {
-            "float32": torch.float32,
-            "float16": torch.float16,
-            "bfloat16": torch.bfloat16,
-        }
-        cpu_mm_dtype_str = envs_spyre.SENDNN_INFERENCE_CPU_MM_DTYPE
-        if cpu_mm_dtype_str not in cpu_mm_dtype_map:
-            raise ValueError(
-                "SENDNN_INFERENCE_CPU_MM_DTYPE must be one of "
-                f"{list(cpu_mm_dtype_map)}, got {cpu_mm_dtype_str!r}"
-            )
-        cpu_mm_dtype = cpu_mm_dtype_map[cpu_mm_dtype_str]
+    def _cast_params_for_spyre(self):
+        """Cast mm params to SENDNN_INFERENCE_CPU_MM_DTYPE; remaining bf16 params to fp16."""
+        cpu_mm_dtype = envs_spyre.SENDNN_INFERENCE_CPU_MM_DTYPE
+        mm_prefixes = self.mm_model_utils.mm_parameter_prefixes if self.mm_model_utils else ()
 
         for name, param in self.fms_model.named_parameters():
-            if name.startswith(CPU_MM_PREFIXES) and param.dtype != cpu_mm_dtype:
-                param.data = param.data.to(dtype=cpu_mm_dtype)
+            if name.startswith(mm_prefixes):
+                if param.dtype != cpu_mm_dtype:
+                    logger.debug(
+                        "Casting vision encoder param %s to %s for CPU execution.",
+                        name,
+                        cpu_mm_dtype,
+                    )
+                    param.data = param.data.to(dtype=cpu_mm_dtype)
+            elif param.dtype == torch.bfloat16:
                 logger.debug(
-                    "Casting vision encoder param %s to %s for CPU execution.",
+                    "You are casting param %s to fp16, which"
+                    " will cause loss of accuracy. This is required for"
+                    " spyre cards that don't support bf16. You can ignore"
+                    " this warning if this is intended.",
                     name,
-                    cpu_mm_dtype_str,
                 )
-
-    def _cast_bf16_to_f16(self):
-        """Cast bf16 params in the model to f16. Vision encoder + projector
-        params are skipped — their dtype is managed by _cast_to_mm_type.
-        """
-        for name, param in self.fms_model.named_parameters():
-            if param.dtype != torch.bfloat16 or name.startswith(CPU_MM_PREFIXES):
-                continue
-            logger.debug(
-                "You are casting param %s to fp16, which"
-                " will cause loss of accuracy. This is required for"
-                " spyre cards that don't support bf16. You can ignore"
-                " this warning if this is intended.",
-                name,
-            )
-            param.data = param.data.to(dtype=torch.float16)
+                param.data = param.data.to(dtype=torch.float16)
 
     def _cast_to_f32(self):
         """Cast model parameters to f32."""

--- a/sendnn_inference/multimodal/mm_mappings/base.py
+++ b/sendnn_inference/multimodal/mm_mappings/base.py
@@ -1,6 +1,6 @@
 import functools
 from abc import ABC, abstractmethod
-from typing import NamedTuple
+from typing import ClassVar, NamedTuple
 
 import torch
 from fms.utils.config import ModelConfig
@@ -27,6 +27,13 @@ class MMUtilsBase(ABC):
     refer to the FMS model config & hf_config to refer to the transformers
     config (i.e., avoid ambiguous terms like model_config for readability).
     """
+
+    # FMS parameter prefixes whose dtype is controlled by
+    # SENDNN_INFERENCE_CPU_MM_DTYPE. Override in subclasses if a model renames them.
+    mm_parameter_prefixes: ClassVar[tuple[str, ...]] = (
+        "vision_tower.",
+        "multi_modal_projector.",
+    )
 
     def __init__(self, model_path: str, fms_config: ModelConfig, hf_config: PretrainedConfig):
         self._validate_configs(fms_config, hf_config)

--- a/sendnn_inference/utils.py
+++ b/sendnn_inference/utils.py
@@ -45,3 +45,14 @@ def exact_div(a: int, b: int) -> int:
     if r != 0:
         raise ValueError(f"{a} is not exactly divisible by {b}")
     return q
+
+
+_CPU_MM_DTYPES = ("float32", "float16", "bfloat16")
+
+
+def parse_cpu_mm_dtype(value: str) -> torch.dtype:
+    if value not in _CPU_MM_DTYPES:
+        raise ValueError(
+            f"SENDNN_INFERENCE_CPU_MM_DTYPE must be one of {list(_CPU_MM_DTYPES)}, got {value!r}"
+        )
+    return getattr(torch, value)

--- a/tests/model_loader/test_spyre.py
+++ b/tests/model_loader/test_spyre.py
@@ -1,0 +1,98 @@
+"""Tests for SpyreCausalLM._cast_params_for_spyre dtype casting."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sendnn_inference import envs
+from sendnn_inference.model_executor.model_loader.spyre import SpyreCausalLM
+
+pytestmark = pytest.mark.cpu
+
+
+class _FakeFmsModel:
+    """Minimal stand-in exposing only named_parameters()."""
+
+    def __init__(self, specs):
+        self._params = [
+            (name, torch.nn.Parameter(torch.zeros(2, 2, dtype=dtype))) for name, dtype in specs
+        ]
+
+    def named_parameters(self):
+        return iter(self._params)
+
+
+class _FakeMMUtils:
+    def __init__(self, prefixes):
+        self.mm_parameter_prefixes = prefixes
+
+
+def _cast(fms_model, mm_model_utils):
+    SpyreCausalLM._cast_params_for_spyre(
+        SimpleNamespace(fms_model=fms_model, mm_model_utils=mm_model_utils)
+    )
+
+
+def _set_cpu_mm_dtype(monkeypatch, value):
+    monkeypatch.setenv("SENDNN_INFERENCE_CPU_MM_DTYPE", value)
+    envs.clear_env_cache()
+
+
+def _dtype_of(fms, name):
+    return dict(fms.named_parameters())[name].dtype
+
+
+@pytest.mark.parametrize(
+    "initial_dtype,cpu_mm_dtype,expected",
+    [
+        (torch.bfloat16, "float32", torch.float32),
+        (torch.float16, "float16", torch.float16),
+    ],
+)
+def test_mm_params_match_cpu_mm_dtype(monkeypatch, initial_dtype, cpu_mm_dtype, expected):
+    _set_cpu_mm_dtype(monkeypatch, cpu_mm_dtype)
+    fms = _FakeFmsModel([("vision_tower.weight", initial_dtype)])
+    _cast(fms, _FakeMMUtils(("vision_tower.", "multi_modal_projector.")))
+    assert _dtype_of(fms, "vision_tower.weight") == expected
+
+
+def test_bf16_non_mm_params_cast_to_fp16(monkeypatch):
+    _set_cpu_mm_dtype(monkeypatch, "float32")
+    fms = _FakeFmsModel([("decoder.layers.0.weight", torch.bfloat16)])
+    _cast(fms, _FakeMMUtils(("vision_tower.",)))
+    assert _dtype_of(fms, "decoder.layers.0.weight") == torch.float16
+
+
+def test_no_mm_utils_still_casts_bf16_decoder_params(monkeypatch):
+    _set_cpu_mm_dtype(monkeypatch, "float32")
+    fms = _FakeFmsModel([("decoder.layers.0.weight", torch.bfloat16)])
+    _cast(fms, None)
+    assert _dtype_of(fms, "decoder.layers.0.weight") == torch.float16
+
+
+def test_non_bf16_non_mm_param_untouched(monkeypatch):
+    _set_cpu_mm_dtype(monkeypatch, "float32")
+    fms = _FakeFmsModel([("decoder.layers.0.weight", torch.float32)])
+    _cast(fms, _FakeMMUtils(("vision_tower.",)))
+    assert _dtype_of(fms, "decoder.layers.0.weight") == torch.float32
+
+
+def test_mixed_params_all_branches(monkeypatch):
+    _set_cpu_mm_dtype(monkeypatch, "float32")
+    fms = _FakeFmsModel(
+        [
+            ("vision_tower.weight", torch.bfloat16),
+            ("multi_modal_projector.bias", torch.float32),
+            ("decoder.layers.0.weight", torch.bfloat16),
+            ("decoder.layers.0.bias", torch.float16),
+        ]
+    )
+    _cast(fms, _FakeMMUtils(("vision_tower.", "multi_modal_projector.")))
+    dtypes = {name: p.dtype for name, p in fms.named_parameters()}
+    assert dtypes == {
+        "vision_tower.weight": torch.float32,
+        "multi_modal_projector.bias": torch.float32,
+        "decoder.layers.0.weight": torch.float16,
+        "decoder.layers.0.bias": torch.float16,
+    }

--- a/tests/utils/test_envs.py
+++ b/tests/utils/test_envs.py
@@ -3,6 +3,7 @@
 import os
 
 import pytest
+import torch
 
 from sendnn_inference import envs
 
@@ -41,3 +42,33 @@ def test_env_vars_override_with_bad_value(monkeypatch):
 def test_env_vars_override_for_invalid_config():
     with pytest.raises(ValueError, match=r"not a known setting"):
         envs.override("SENDNN_INFERENCE_NOT_A_CONFIG", "nothing")
+
+
+@pytest.mark.parametrize(
+    "machine,expected",
+    [
+        ("s390x", torch.float32),
+        ("ppc64le", torch.bfloat16),
+        ("x86_64", torch.float16),
+        ("aarch64", torch.float16),
+    ],
+)
+def test_cpu_mm_dtype_platform_default(monkeypatch, machine, expected):
+    monkeypatch.delenv("SENDNN_INFERENCE_CPU_MM_DTYPE", raising=False)
+    monkeypatch.setattr("platform.machine", lambda: machine)
+    envs.clear_env_cache()
+    assert expected == envs.SENDNN_INFERENCE_CPU_MM_DTYPE
+
+
+def test_cpu_mm_dtype_env_var_wins_over_platform_default(monkeypatch):
+    monkeypatch.setenv("SENDNN_INFERENCE_CPU_MM_DTYPE", "bfloat16")
+    monkeypatch.setattr("platform.machine", lambda: "s390x")
+    envs.clear_env_cache()
+    assert torch.bfloat16 == envs.SENDNN_INFERENCE_CPU_MM_DTYPE
+
+
+def test_cpu_mm_dtype_invalid_value_raises(monkeypatch):
+    monkeypatch.setenv("SENDNN_INFERENCE_CPU_MM_DTYPE", "foo")
+    envs.clear_env_cache()
+    with pytest.raises(ValueError, match=r"SENDNN_INFERENCE_CPU_MM_DTYPE must be one of"):
+        _ = envs.SENDNN_INFERENCE_CPU_MM_DTYPE


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Multimodal models in this codebase run the vision encoder (vision_tower) and projector (multi_modal_projector) on CPU — Spyre hosts only the text decoder. Previously, every bf16 parameter was cast down
to fp16 regardless of where it executed. That is correct for the decoder (Spyre requires fp16) but it penalizes CPU multimodal inference on platforms whose CPU BLAS has no fast float16 matrix-multiply
kernel. On s390x (OpenBLAS-only) this made vision requests: the float16 matmul fell back to a scalar reference implementation, while float32 ran on the optimized CPU path.
This PR adds SENDNN_INFERENCE_CPU_MM_DTYPE (values: float32, float16, bfloat16; default float16) so the dtype of CPU-bound multimodal params can be chosen independently of the Spyre decoder cast.
The default preserves existing behavior on every platform; s390x deployments can set float32 to pick up the fast CPU path.

## Related Issues

<!-- Link related issues, e.g., `Fixes #` or `Relates to #456` -->

## Test Plan

Used testing script to test for response time and attached loggers to see correct type casting is happenning:


Test Script 

```

#!/usr/bin/env bash
# Smoke tests for SENDNN_INFERENCE_CPU_MM_DTYPE. Each curl prints wall time.
set -u

HOST="${HOST:-localhost:8000}"
MODEL="${MODEL:-mistralai/Ministral-3-14B-Instruct-2512-BF16}"
SMALL_IMG="${SMALL_IMG:-/data/spyre-debug/coco-dataset/000000149770.jpg}"
LARGE_IMG="${LARGE_IMG:-/data/spyre-debug/coco-dataset/000000269682.jpg}"

post() {
  echo "=== $1 ==="
  local f tim
  f=$(mktemp)
  tim=$(curl -sS --max-time 3600 -o "$f" \
    -w 'http=%{http_code} total=%{time_total}s' \
    -X POST "http://$HOST$2" -H 'Content-Type: application/json' -d @-)
  jq '.choices[0]' "$f"
  echo "$tim"
  rm -f "$f"
}

img_body() {
  jq -nc --arg m "$MODEL" --arg p "$2" --argjson max "$3" \
         --arg uri "data:image/jpeg;base64,$(base64 < "$1" | tr -d '\n')" \
    '{model:$m, max_tokens:$max, temperature:0,
      messages:[{role:"user", content:[
        {type:"image_url", image_url:{url:$uri}},
        {type:"text", text:$p}]}]}'
}

jq -nc --arg m "$MODEL" '{model:$m, max_tokens:64, temperature:0,
  messages:[{role:"user", content:"One sentence: what is a capacitor?"}]}' \
  | post "text chat" /v1/chat/completions

jq -nc --arg m "$MODEL" '{model:$m, max_tokens:16, temperature:0,
  prompt:"The capital of France is"}' \
  | post "text completions" /v1/completions

img_body "$SMALL_IMG" "Describe this image in one sentence." 80 \
  | post "coco smallest $(basename "$SMALL_IMG")" /v1/chat/completions

img_body "$LARGE_IMG" "What is shown in this image?" 120 \
  | post "coco largest $(basename "$LARGE_IMG")" /v1/chat/completions

```


Response


```
=== text chat ===
{
  "index": 0,
  "message": {
    "role": "assistant",
    "content": "A **capacitor** is an electronic component that stores electrical energy in an electric field, created by two conductive plates separated by a dielectric material.",
    "refusal": null,
    "annotations": null,
    "audio": null,
    "function_call": null,
    "tool_calls": [],
    "reasoning": null
  },
  "logprobs": null,
  "finish_reason": "stop",
  "stop_reason": null,
  "token_ids": null
}
http=200 total=2.737892s
=== text completions ===
{
  "index": 0,
  "text": " Paris. The capital of the United States is Washington, D.C. The capital",
  "logprobs": null,
  "finish_reason": "length",
  "stop_reason": null,
  "token_ids": null,
  "prompt_logprobs": null,
  "prompt_token_ids": null
}
http=200 total=1.533972s
=== coco smallest 000000149770.jpg ===
{
  "index": 0,
  "message": {
    "role": "assistant",
    "content": "The image shows a surfer crouched low and riding a wave on a surfboard.",
    "refusal": null,
    "annotations": null,
    "audio": null,
    "function_call": null,
    "tool_calls": [],
    "reasoning": null
  },
  "logprobs": null,
  "finish_reason": "stop",
  "stop_reason": null,
  "token_ids": null
}
http=200 total=5.523895s
=== coco largest 000000269682.jpg ===
{
  "index": 0,
  "message": {
    "role": "assistant",
    "content": "This image depicts an intersection with traffic lights and street signs. The scene is set under a cloudy sky, suggesting overcast weather.\n\nKey elements in the image include:\n1. **Street Signs**: The sign in the foreground reads \"Meredith St,\" indicating the name of the street.\n2. **Traffic Lights**: Multiple traffic lights are visible, some of which are hanging from horizontal poles and others from vertical poles.\n3. **No Entry Sign**: There is a \"No Entry\" sign visible on the right side of the image.\n4. **Street Lights and Poles**: The",
    "refusal": null,
    "annotations": null,
    "audio": null,
    "function_call": null,
    "tool_calls": [],
    "reasoning": null
  },
  "logprobs": null,
  "finish_reason": "length",
  "stop_reason": null,
  "token_ids": null
}
http=200 total=39.028155s

```

Logs:


```
### Runtime env
SENDNN_INFERENCE_DYNAMO_BACKEND=sendnn
SENDNN_INFERENCE_CPU_MM_DTYPE=float32

### Sample cast logs

(Worker_TP0 pid=146) DEBUG 04-24 14:10:41 [sendnn_inference/.../model_loader/spyre.py:299] Casting vision encoder param vision_tower.patch_conv.weight to float32 for CPU execution.
(Worker_TP0 pid=146) DEBUG 04-24 14:10:41 [sendnn_inference/.../model_loader/spyre.py:299] Casting vision encoder param vision_tower.ln_pre.weight to float32 for CPU execution.
(Worker_TP0 pid=146) DEBUG 04-24 14:10:41 [sendnn_inference/.../model_loader/spyre.py:299] Casting vision encoder param vision_tower.transformer.layers.0.attention_norm.weight to float32 for CPU execution.
(Worker_TP0 pid=146) DEBUG 04-24 14:10:41 [sendnn_inference/.../model_loader/spyre.py:299] Casting vision encoder param vision_tower.transformer.layers.0.attn.in_proj.query.weight to float32 for CPU execution.
(Worker_TP0 pid=146) DEBUG 04-24 14:10:41 [sendnn_inference/.../model_loader/spyre.py:299] Casting vision encoder param vision_tower.transformer.layers.0.attn.in_proj.key.weight to float32 for CPU execution.
```

## Checklist

- [x] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [x] My code follows the project's code style (run `bash format.sh`)
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
