### PR TITLE
:bug: Fix mistral tokenizer loads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,8 @@ jobs:
               name: "backward compat"
               markers: "compat or (cpu and basic and not quantized)"
               flags: "--timeout=300"
+              hf_model_2: ""
+              hf_model_2_rev: ""
             os: "ubuntu-latest"
             python_version: "3.12"
         #   # Intermediate versions of vllm to check basic support for as well

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,9 +116,9 @@ jobs:
         run: |
           rm -rf /usr/share/swift
           rm -rf /user/local/share/chromium
-          rm -rf /usr/local/lib/android
-          rm -rf "${AGENT_TOOLSDIRECTORY}/CodeQL"
-          rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf "${AGENT_TOOLSDIRECTORY}/CodeQL"
+          sudo rm -rf /usr/local/share/powershell
 
       - name: "Checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,8 +79,8 @@ jobs:
               name: "backward compat"
               markers: "compat or (cpu and basic and not quantized)"
               flags: "--timeout=300"
-              hf_model_2: ""
-              hf_model_2_rev: ""
+              hf_model_2: "sentence-transformers/all-roberta-large-v1"
+              hf_model_2_rev: "cf74d8acd4f198de950bf004b262e6accfed5d2c"
             os: "ubuntu-latest"
             python_version: "3.12"
         #   # Intermediate versions of vllm to check basic support for as well
@@ -206,7 +206,7 @@ jobs:
 
       - name: "Restore HF models cache for additional model"
         id: cache_restore_2
-        if: ( steps.changed-src-files.outputs.any_changed == 'true' && matrix.test_suite.hf_model_2 != '')
+        if: ( steps.changed-src-files.outputs.any_changed == 'true' && matrix.test_suite.hf_model_2 )
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.model_2_path }}
@@ -249,7 +249,7 @@ jobs:
           key: ${{ runner.os }}-hf-model-${{ env.model_key }}
 
       - name: "Save HF models cache for additional model"
-        if: ( steps.changed-src-files.outputs.any_changed == 'true' && matrix.test_suite.hf_model_2 != '' && github.event_name != 'pull_request' && steps.cache_restore_2.outputs.cache-hit != 'true' )
+        if: ( steps.changed-src-files.outputs.any_changed == 'true' && matrix.test_suite.hf_model_2 && github.event_name != 'pull_request' && steps.cache_restore_2.outputs.cache-hit != 'true' )
         uses: actions/cache/save@v4
         with:
           path: ${{ env.model_2_path }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
         run: |
           rm -rf /usr/share/swift
           rm -rf /user/local/share/chromium
-          rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/local/share/powershell
 
       - name: "Checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,6 +116,9 @@ jobs:
         run: |
           rm -rf /usr/share/swift
           rm -rf /user/local/share/chromium
+          rm -rf /usr/local/lib/android
+          rm -rf "${AGENT_TOOLSDIRECTORY}/CodeQL"
+          rm -rf /usr/local/share/powershell
 
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -205,7 +208,7 @@ jobs:
 
       - name: "Restore HF models cache for additional model"
         id: cache_restore_2
-        if: ( steps.changed-src-files.outputs.any_changed == 'true' && matrix.test_suite.hf_model_2 )
+        if: ( steps.changed-src-files.outputs.any_changed == 'true' && matrix.test_suite.hf_model_2 != '')
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.model_2_path }}
@@ -248,7 +251,7 @@ jobs:
           key: ${{ runner.os }}-hf-model-${{ env.model_key }}
 
       - name: "Save HF models cache for additional model"
-        if: ( steps.changed-src-files.outputs.any_changed == 'true' && matrix.test_suite.hf_model_2 && github.event_name != 'pull_request' && steps.cache_restore_2.outputs.cache-hit != 'true' )
+        if: ( steps.changed-src-files.outputs.any_changed == 'true' && matrix.test_suite.hf_model_2 != '' && github.event_name != 'pull_request' && steps.cache_restore_2.outputs.cache-hit != 'true' )
         uses: actions/cache/save@v4
         with:
           path: ${{ env.model_2_path }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,9 +116,7 @@ jobs:
         run: |
           rm -rf /usr/share/swift
           rm -rf /user/local/share/chromium
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf "${AGENT_TOOLSDIRECTORY}/CodeQL"
-          sudo rm -rf /usr/local/share/powershell
+          rm -rf /usr/local/share/powershell
 
       - name: "Checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,8 +79,6 @@ jobs:
               name: "backward compat"
               markers: "compat or (cpu and basic and not quantized)"
               flags: "--timeout=300"
-              hf_model_2: "sentence-transformers/all-roberta-large-v1"
-              hf_model_2_rev: "cf74d8acd4f198de950bf004b262e6accfed5d2c"
             os: "ubuntu-latest"
             python_version: "3.12"
         #   # Intermediate versions of vllm to check basic support for as well

--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -181,13 +181,6 @@ class SpyrePlatform(Platform):
 
         patch_async_llm_stat_loggers()
 
-        # 🌶️🌶️🌶️ Patch vllm.tokenizers.registry to suppress KeyError from get_config
-        # The tokenizer registry calls get_config() which can raise KeyError when
-        # an unknown model_type is encountered in LazyConfigDict. The original code
-        # only suppresses ValueError and OSError, but KeyError should also be
-        # suppressed since it's expected for models not in the registry.
-        cls._patch_tokenizer_registry_get_config()
-
         # In case vllm passes a default vllm_config to us.
         # This happens when get_current_vllm_config is called
         # without setting the vllm config through
@@ -827,3 +820,12 @@ def _compute_config_format(namespace: argparse.Namespace) -> str:
     ):
         return "mistral"
     return "auto"
+
+
+# 🌶️🌶️🌶️ Patch vllm.tokenizers.registry to suppress KeyError from get_config
+# The tokenizer registry calls get_config() which can raise KeyError when
+# an unknown model_type is encountered in LazyConfigDict. The original code
+# only suppresses ValueError and OSError, but KeyError should also be
+# suppressed since it's expected for models not in the registry.
+# This must be done at import time to be applied to spawned worker processes.
+SpyrePlatform._patch_tokenizer_registry_get_config()

--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -181,6 +181,13 @@ class SpyrePlatform(Platform):
 
         patch_async_llm_stat_loggers()
 
+        # 🌶️🌶️🌶️ Patch vllm.tokenizers.registry to suppress KeyError from get_config
+        # The tokenizer registry calls get_config() which can raise KeyError when
+        # an unknown model_type is encountered in LazyConfigDict. The original code
+        # only suppresses ValueError and OSError, but KeyError should also be
+        # suppressed since it's expected for models not in the registry.
+        cls._patch_tokenizer_registry_get_config()
+
         # In case vllm passes a default vllm_config to us.
         # This happens when get_current_vllm_config is called
         # without setting the vllm config through
@@ -662,6 +669,31 @@ class SpyrePlatform(Platform):
                 max_new_tokens = max(max_new_tokens, shape["new_tokens"])
 
         return max_new_tokens
+
+    @classmethod
+    def _patch_tokenizer_registry_get_config(cls) -> None:
+        """Patch get_config to suppress KeyError when called from tokenizer registry.
+
+        The tokenizer registry imports get_config via:
+            from vllm.transformers_utils.config import get_config
+
+        This creates a local reference, so we must patch the registry module's
+        reference directly, not just the source module.
+        """
+        import vllm.tokenizers.registry as tokenizer_registry
+
+        original_get_config = tokenizer_registry.get_config
+
+        def safe_get_config(*args, **kwargs):
+            try:
+                return original_get_config(*args, **kwargs)
+            except KeyError:
+                return None
+
+        # Patch the imported reference in the registry module
+        tokenizer_registry.get_config = safe_get_config
+
+        logger.debug("Patched get_config in vllm.tokenizers.registry to suppress KeyError")
 
     @classmethod
     def is_backend_sendnn_enabled(cls) -> bool:

--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -679,8 +679,16 @@ class SpyrePlatform(Platform):
 
         This creates a local reference, so we must patch the registry module's
         reference directly, not just the source module.
+
+        This patch is only applied if get_config exists in the tokenizer registry
+        module (it was added in vllm 0.19.1).
         """
         import vllm.tokenizers.registry as tokenizer_registry
+
+        # Only patch if get_config exists in this vLLM version
+        if not hasattr(tokenizer_registry, "get_config"):
+            logger.debug("Skipping get_config patch: not present in this vLLM version")
+            return
 
         original_get_config = tokenizer_registry.get_config
 

--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -691,7 +691,7 @@ class SpyrePlatform(Platform):
                 return None
 
         # Patch the imported reference in the registry module
-        tokenizer_registry.get_config = safe_get_config
+        tokenizer_registry.get_config = safe_get_config  # type:ignore[invalid-assignment]
 
         logger.debug("Patched get_config in vllm.tokenizers.registry to suppress KeyError")
 

--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -17,7 +17,7 @@ VLLM_VERSION = os.getenv("TEST_VLLM_VERSION", "default")
 def test_tokenizer_registry_get_config_patch():
     """
     When this test starts failing because get_config exists in the lowest supported vllm version,
-    the compatibility patch in platform.py can be removed.
+    the check to conditionally _not_ apply _patch_tokenizer_registry_get_config can be removed.
     """
     import vllm.tokenizers.registry as tokenizer_registry
 

--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -13,5 +13,17 @@ pytestmark = pytest.mark.compat
 
 VLLM_VERSION = os.getenv("TEST_VLLM_VERSION", "default")
 
-# We reset the minimum version, so no tests currently
-# Check git history of this file for examples of the tests
+
+def test_tokenizer_registry_get_config_patch():
+    """
+    When this test starts failing because get_config exists in the lowest supported vllm version,
+    the compatibility patch in platform.py can be removed.
+    """
+    import vllm.tokenizers.registry as tokenizer_registry
+
+    # Check if get_config exists in the tokenizer registry module
+    # (it was added in vllm 0.19.1)
+    if VLLM_VERSION == "vLLM:lowest":
+        assert not hasattr(tokenizer_registry, "get_config"), (
+            "Backwards compatibility code in _patch_tokenizer_registry_get_config can be removed"
+        )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This fixes a bug where mistral models fail to load a tokenizer, even if `--tokenizer-mode mistral` is supplied. This bug was introduced in vllm 0.19.1, where now a mistral tokenizer is loaded iff a `consolidated.safetensors` file exists in the model directory, regardless of CLI inputs.

We need to follow up to see if this is fixed in vllm main yet, and fix it upstream if it isn't.

## Related Issues


## Test Plan

ministral should load correctly again without requiring a cached consolidated.safetensors file or HF hub access.

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
