### PR TITLE
feat(trust-remote-code):  Pass trust_remote_code from vLLM config to FMS model loader

### DIFF
--- a/sendnn_inference/model_executor/model_loader/spyre.py
+++ b/sendnn_inference/model_executor/model_loader/spyre.py
@@ -193,6 +193,7 @@ class SpyreCausalLM(nn.Module):
                 distributed_strategy=distributed_strategy,
                 group=dist.group.WORLD,
                 fused_weights=False,
+                trust_remote_code=model_config.trust_remote_code,
                 **model_kwargs,
             )
 


### PR DESCRIPTION

<!-- markdownlint-disable -->

## Description

This PR ensures the --trust-remote-code CLI flag from vLLM is properly propagated to the FMS model loader when loading HuggingFace checkpoints on Spyre/AIU hardware.

## Related Issues

Fixes issue 1832 in our internal board.

Connected to https://github.com/foundation-model-stack/foundation-model-stack/pull/526

## Impact:

Users can now load custom HuggingFace models that require `trust_remote_code`=`True` when running inference on Spyre platforms using the `--trust-remote-code` flag.


## Checklist

- [x] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [x] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
