### PR TITLE
Tkv limit bug

### DIFF
--- a/sendnn_inference/v1/core/scheduler.py
+++ b/sendnn_inference/v1/core/scheduler.py
@@ -20,12 +20,15 @@ else:
 
 logger = init_logger(__name__)
 
+# Ensure that block_size is 64
+# This ensures the rounding function is correct
+assert SpyrePlatform.get_block_size() == 64
+
 
 def round_up_to_block_size(n: int) -> int:
     # Helper function to round up to the nearest block size
     # Uses bitwise alignment for better performance
-    block_size = SpyrePlatform.get_block_size()
-    return (n + block_size - 1) & ~(block_size - 1)
+    return (n + 63) & ~63
 
 
 class SpyreScheduler(Scheduler):
@@ -538,7 +541,7 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         """
 
         # Compute the effective token length of the new request
-        # Rounded up to the nearest block size
+        # Rounded up to the nearest block size to account for potential padding
         new_req_max_tkv = round_up_to_block_size(new_req_tkv + request.max_tokens - 1)
 
         # Compute token lengths for all running requests (decode batch)
@@ -547,6 +550,7 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         dec_req_tkv = max(self.tkv, request.num_prompt_tokens)
         for req in running:
             n_generated_output_tokens = req.num_computed_tokens - req.num_prompt_tokens
+            # Rounded up to the nearest block size to account for potential padding
             dec_req_max_tkv = round_up_to_block_size(
                 dec_req_tkv + (req.max_tokens - n_generated_output_tokens) - 1
             )

--- a/sendnn_inference/v1/core/scheduler.py
+++ b/sendnn_inference/v1/core/scheduler.py
@@ -515,7 +515,7 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         return num_prefills < max_concurrent_prefills
 
     def check_batch_tkv_limit_cp(
-        self, request: Request, new_req_tkv: int, n_blocks: int, running
+        self, request: Request, new_req_tkv: int, running
     ) -> bool:
         """
         Check whether adding a new sequence to the decode batch would violate

--- a/sendnn_inference/v1/core/scheduler.py
+++ b/sendnn_inference/v1/core/scheduler.py
@@ -20,6 +20,9 @@ else:
 
 logger = init_logger(__name__)
 
+def round_up_to_block_size(n: int) -> int:
+    block_size = SpyrePlatform.get_block_size()
+    return (n + block_size - 1) & ~(block_size - 1)
 
 class SpyreScheduler(Scheduler):
     """Base class inheriting from the V1 scheduler to support static
@@ -531,7 +534,7 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         """
 
         # Compute the effective token length of the new request
-        new_req_max_tkv = new_req_tkv + request.max_tokens - 1
+        new_req_max_tkv = round_up_to_block_size(new_req_tkv + request.max_tokens - 1)
 
         # Compute token lengths for all running requests (decode batch)
         decode_req_max_tkvs = []
@@ -539,9 +542,7 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         dec_req_tkv = max(self.tkv, request.num_prompt_tokens)
         for req in running:
             n_generated_output_tokens = req.num_computed_tokens - req.num_prompt_tokens
-            dec_req_max_tkv = dec_req_tkv + (req.max_tokens - n_generated_output_tokens) - 1
-            # Account for potential padding block
-            dec_req_max_tkv += self.block_size
+            dec_req_max_tkv = round_up_to_block_size(dec_req_tkv + (req.max_tokens - n_generated_output_tokens) - 1)
             decode_req_max_tkvs.append(dec_req_max_tkv)
 
         # Sort decode requests token lengths in ascending order

--- a/sendnn_inference/v1/core/scheduler.py
+++ b/sendnn_inference/v1/core/scheduler.py
@@ -20,11 +20,13 @@ else:
 
 logger = init_logger(__name__)
 
+
 def round_up_to_block_size(n: int) -> int:
     # Helper function to round up to the nearest block size
     # Uses bitwise alignment for better performance
     block_size = SpyrePlatform.get_block_size()
     return (n + block_size - 1) & ~(block_size - 1)
+
 
 class SpyreScheduler(Scheduler):
     """Base class inheriting from the V1 scheduler to support static
@@ -545,7 +547,9 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         dec_req_tkv = max(self.tkv, request.num_prompt_tokens)
         for req in running:
             n_generated_output_tokens = req.num_computed_tokens - req.num_prompt_tokens
-            dec_req_max_tkv = round_up_to_block_size(dec_req_tkv + (req.max_tokens - n_generated_output_tokens) - 1)
+            dec_req_max_tkv = round_up_to_block_size(
+                dec_req_tkv + (req.max_tokens - n_generated_output_tokens) - 1
+            )
             decode_req_max_tkvs.append(dec_req_max_tkv)
 
         # Sort decode requests token lengths in ascending order

--- a/sendnn_inference/v1/core/scheduler.py
+++ b/sendnn_inference/v1/core/scheduler.py
@@ -514,9 +514,7 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         num_prefills = len(self.waiting) + len(self.ongoing_prefills)
         return num_prefills < max_concurrent_prefills
 
-    def check_batch_tkv_limit_cp(
-        self, request: Request, new_req_tkv: int, running
-    ) -> bool:
+    def check_batch_tkv_limit_cp(self, request: Request, new_req_tkv: int, running) -> bool:
         """
         Check whether adding a new sequence to the decode batch would violate
         Spyre's maximum batch volume constraint for chunked prefill.

--- a/sendnn_inference/v1/core/scheduler.py
+++ b/sendnn_inference/v1/core/scheduler.py
@@ -21,6 +21,8 @@ else:
 logger = init_logger(__name__)
 
 def round_up_to_block_size(n: int) -> int:
+    # Helper function to round up to the nearest block size
+    # Uses bitwise alignment for better performance
     block_size = SpyrePlatform.get_block_size()
     return (n + block_size - 1) & ~(block_size - 1)
 
@@ -534,6 +536,7 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         """
 
         # Compute the effective token length of the new request
+        # Rounded up to the nearest block size
         new_req_max_tkv = round_up_to_block_size(new_req_tkv + request.max_tokens - 1)
 
         # Compute token lengths for all running requests (decode batch)

--- a/sendnn_inference/v1/core/scheduler.py
+++ b/sendnn_inference/v1/core/scheduler.py
@@ -490,7 +490,6 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         cond3 = lambda: self.check_batch_tkv_limit_cp(
             request=request,
             new_req_tkv=new_req_tkv,
-            n_blocks=n_blocks,
             running=decoding_requests,
         )
 

--- a/tests/v1/worker/test_scheduler_tkv_limits.py
+++ b/tests/v1/worker/test_scheduler_tkv_limits.py
@@ -81,6 +81,7 @@ def test_scheduler_tkv_limits(monkeypatch: pytest.MonkeyPatch):
         if len(scheduler.running) == 0:
             break
 
+
 @pytest.mark.cpu
 @pytest.mark.chunked_prefill
 def test_scheduler_tkv_limits_ongoing_batch(monkeypatch: pytest.MonkeyPatch):
@@ -114,7 +115,24 @@ def test_scheduler_tkv_limits_ongoing_batch(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VLLM_DT_MAX_BATCH_TKV_LIMIT", "131072")
 
     # Define prompt lengths for first set of requests
-    prompt_lengths_1 = [1018, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024]
+    prompt_lengths_1 = [
+        1018,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+    ]
     max_tokens_1 = 7168
 
     # Create and add first set of requests to the scheduler
@@ -150,7 +168,24 @@ def test_scheduler_tkv_limits_ongoing_batch(monkeypatch: pytest.MonkeyPatch):
                 break
 
     # Define prompt lengths for second set of requests
-    prompt_lengths_2 = [1018, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024]
+    prompt_lengths_2 = [
+        1018,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+        1024,
+    ]
     max_tokens_2 = 900
 
     # Create and add second set requests to the scheduler

--- a/tests/v1/worker/test_scheduler_tkv_limits.py
+++ b/tests/v1/worker/test_scheduler_tkv_limits.py
@@ -89,6 +89,14 @@ def test_scheduler_tkv_limits_ongoing_batch(monkeypatch: pytest.MonkeyPatch):
     Test that the scheduler correctly enforces the TKV limit constraint
     when new requests are added during an ongoing batch.
 
+    This test schedules a 16x8k batch that will fully fill the 128k TKV limit.
+    Then inject a batch of smaller requests partway through processing,
+    which should be able to schedule only because they are guaranteed to
+    finish processing just before the TKV is long enough to overrun the
+    limit with the larger batch size. This flexes the logic for injecting
+    shorter requests into a running batch, which is not tested by the
+    other test case in this file.
+
     Expected behavior (when bug is fixed):
     - Test should pass without exceeding hardware constraints
 
@@ -114,30 +122,14 @@ def test_scheduler_tkv_limits_ongoing_batch(monkeypatch: pytest.MonkeyPatch):
     SpyrePlatform._max_batch_tkv_limit = 131072
     monkeypatch.setenv("VLLM_DT_MAX_BATCH_TKV_LIMIT", "131072")
 
-    # Define prompt lengths for first set of requests
-    prompt_lengths_1 = [
-        1018,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-    ]
+    # Define prompt lengths and max tokens for requests
+    prompt_lengths = [1018] + [1024] * 15
     max_tokens_1 = 7168
+    max_tokens_2 = 900
 
     # Create and add first set of requests to the scheduler
     requests = []
-    for request_id, prompt_length in enumerate(prompt_lengths_1):
+    for request_id, prompt_length in enumerate(prompt_lengths):
         prompt = random_prompt(model=model, seed=request_id, length=prompt_length)
         request = create_request_for_scheduler_test(
             model=model,
@@ -167,29 +159,8 @@ def test_scheduler_tkv_limits_ongoing_batch(monkeypatch: pytest.MonkeyPatch):
             if generated >= target_generated_tokens:
                 break
 
-    # Define prompt lengths for second set of requests
-    prompt_lengths_2 = [
-        1018,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-        1024,
-    ]
-    max_tokens_2 = 900
-
     # Create and add second set requests to the scheduler
-    for request_id, prompt_length in enumerate(prompt_lengths_2):
+    for request_id, prompt_length in enumerate(prompt_lengths):
         prompt = random_prompt(model=model, seed=request_id + 16, length=prompt_length)
         request = create_request_for_scheduler_test(
             model=model,

--- a/tests/v1/worker/test_scheduler_tkv_limits.py
+++ b/tests/v1/worker/test_scheduler_tkv_limits.py
@@ -80,3 +80,100 @@ def test_scheduler_tkv_limits(monkeypatch: pytest.MonkeyPatch):
         scheduler.update_from_output(sched_output, output)
         if len(scheduler.running) == 0:
             break
+
+@pytest.mark.cpu
+@pytest.mark.chunked_prefill
+def test_scheduler_tkv_limits_ongoing_batch(monkeypatch: pytest.MonkeyPatch):
+    """
+    Test that the scheduler correctly enforces the TKV limit constraint
+    when new requests are added during an ongoing batch.
+
+    Expected behavior (when bug is fixed):
+    - Test should pass without exceeding hardware constraints
+
+    Current behavior (with bug):
+    - Scheduler accepts invalid batch configurations
+    - Test will fail with assertion errors
+    """
+    # Setup: Use the default test model
+    model = REFERENCE_MODELS[InstrumentedModelRunner.DEFAULT_TEST_MODEL]
+
+    # Build model runner with specific constraints
+    model_runner = InstrumentedModelRunner.build(
+        monkeypatch=monkeypatch,
+        max_num_batched_tokens=512,
+        max_num_seqs=32,
+        max_model_len=32768,
+        available_blocks=32768,
+    )
+
+    # Configure the TKV limit
+    scheduler = model_runner.scheduler
+    scheduler.max_batch_tkv_limit = 131072
+    SpyrePlatform._max_batch_tkv_limit = 131072
+    monkeypatch.setenv("VLLM_DT_MAX_BATCH_TKV_LIMIT", "131072")
+
+    # Define prompt lengths for first set of requests
+    prompt_lengths_1 = [1018, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024]
+    max_tokens_1 = 7168
+
+    # Create and add first set of requests to the scheduler
+    requests = []
+    for request_id, prompt_length in enumerate(prompt_lengths_1):
+        prompt = random_prompt(model=model, seed=request_id, length=prompt_length)
+        request = create_request_for_scheduler_test(
+            model=model,
+            request_id=request_id,
+            add_step=0,
+            max_tokens=max_tokens_1,
+            prompt=prompt,
+            use_golden_token_injection=False,
+            generate_hf_results=False,
+        ).request
+        requests.append(request)
+        scheduler.add_request(request)
+
+    # Failure was observed in testing when first request generated 2920 tokens
+    target_generated_tokens = 2920
+
+    # Run the scheduler loop until first set of requests have generated tokens
+    while True:
+        sched_output = scheduler.schedule()
+        output = model_runner.execute_model(sched_output)
+        scheduler.update_from_output(sched_output, output)
+
+        target_req = requests[0]
+
+        if target_req:
+            generated = target_req.num_computed_tokens - target_req.num_prompt_tokens
+            if generated >= target_generated_tokens:
+                break
+
+    # Define prompt lengths for second set of requests
+    prompt_lengths_2 = [1018, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024]
+    max_tokens_2 = 900
+
+    # Create and add second set requests to the scheduler
+    for request_id, prompt_length in enumerate(prompt_lengths_2):
+        prompt = random_prompt(model=model, seed=request_id + 16, length=prompt_length)
+        request = create_request_for_scheduler_test(
+            model=model,
+            request_id=request_id + 16,
+            add_step=0,
+            max_tokens=max_tokens_2,
+            prompt=prompt,
+            use_golden_token_injection=False,
+            generate_hf_results=False,
+        ).request
+        requests.append(request)
+        scheduler.add_request(request)
+
+    # Run the scheduler loop until all requests complete
+    # With the bug present, the scheduler will incorrectly accept a batch
+    # configuration that exceeds the TKV limit
+    while True:
+        sched_output = scheduler.schedule()
+        output = model_runner.execute_model(sched_output)
+        scheduler.update_from_output(sched_output, output)
+        if len(scheduler.running) == 0:
+            break


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This PR addresses a bug in the scheduler code where the scheduler would allow requests that would eventually exceed the max batch tkv limit during an ongoing batch. The PR includes a new test case to reproduce the error and the fix for said error.

## Related Issues

## Test Plan

Run the test file with: `pytest tests/v1/worker/test_scheduler_tkv_limits.py -sv`
Second test case will pass with changes in `sendnn_inference/v1/core/scheduler.py` included in this PR, and will fail without.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [x] My code follows the project's code style (run `bash format.sh`)
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
