### PR TITLE
[WIP] fix check_batch_tkv_limit_cp conservatively

### DIFF
--- a/sendnn_inference/v1/core/scheduler.py
+++ b/sendnn_inference/v1/core/scheduler.py
@@ -540,6 +540,9 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         # Compute the effective token length of the new request
         # Rounded up to the nearest block size to account for potential padding
         new_req_max_tkv = round_up_to_block_size(new_req_tkv + request.max_tokens - 1)
+        # Extra block of slack: left-padding can push a sequence's runtime tkv up to
+        # one block past the scheduler's estimate when the batch re-aligns on admission.
+        new_req_max_tkv += self.block_size
 
         # Compute token lengths for all running requests (decode batch)
         decode_req_max_tkvs = []
@@ -551,6 +554,10 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
             dec_req_max_tkv = round_up_to_block_size(
                 dec_req_tkv + (req.max_tokens - n_generated_output_tokens) - 1
             )
+            # Extra block of slack: left-padding can push a sequence's runtime tkv up to
+            # one block past the scheduler's estimate when the batch re-aligns on admission.
+            dec_req_max_tkv += self.block_size
+
             decode_req_max_tkvs.append(dec_req_max_tkv)
 
         # Sort decode requests token lengths in ascending order


### PR DESCRIPTION
added an extra block of slack (left-padding can push a sequence's runtime tkv up to one block past the scheduler's estimate when the batch re-aligns on admission) for both new and decode requests. 
