### PR TITLE
Fix MM cache hit rate reporting for Spyre

### DIFF
--- a/sendnn_inference/v1/core/scheduler.py
+++ b/sendnn_inference/v1/core/scheduler.py
@@ -635,6 +635,8 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         """Update the scheduler stats from the base scheduler.
         In sendnn-inference the last chunk is always recomputed, even though
         the space is not duplicated.
+        Spyre does not support cross-request MM cache reuse today, so MM cache
+        hit reporting is forced to 0.0%.
         """
         base_stats = super().make_stats(*args, **kwargs)
 
@@ -642,5 +644,10 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
             base_stats.prefix_cache_stats.hits = self.adjust_hit(
                 base_stats.prefix_cache_stats.queries, base_stats.prefix_cache_stats.hits
             )
+
+        if base_stats is not None:
+            mm_cache_stats = getattr(base_stats, "mm_cache_stats", None)
+            if mm_cache_stats is not None:
+                mm_cache_stats.hits = 0
 
         return base_stats

--- a/tests/v1/worker/test_scheduler_tkv_limits.py
+++ b/tests/v1/worker/test_scheduler_tkv_limits.py
@@ -10,6 +10,8 @@ from scheduling_utils import create_request_for_scheduler_test, random_prompt
 from v1.worker.mock_model import InstrumentedModelRunner
 from spyre_util import REFERENCE_MODELS
 from sendnn_inference.platform import SpyrePlatform
+from types import SimpleNamespace
+from sendnn_inference.v1.core.scheduler import SpyreScheduler
 
 
 @pytest.mark.cpu
@@ -183,3 +185,80 @@ def test_scheduler_tkv_limits_ongoing_batch(monkeypatch: pytest.MonkeyPatch):
         scheduler.update_from_output(sched_output, output)
         if len(scheduler.running) == 0:
             break
+
+
+@pytest.mark.cpu
+@pytest.mark.chunked_prefill
+def test_chunked_prefill_make_stats_zeros_mm_cache_hits(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    Regression test: Spyre forces MM cache hit reporting to zero in make_stats().
+
+    Spyre does not support cross-request MM cache reuse today. This test
+    verifies that ChunkedPrefillSpyreScheduler.make_stats() forces
+    mm_cache_stats.hits to zero while still applying the existing
+    prefix-cache hit correction.
+    """
+    model_runner = InstrumentedModelRunner.build(
+        monkeypatch=monkeypatch,
+        max_num_batched_tokens=512,
+        max_num_seqs=32,
+        max_model_len=32768,
+        available_blocks=32768,
+    )
+    scheduler = model_runner.scheduler
+
+    fake_stats = SimpleNamespace(
+        prefix_cache_stats=SimpleNamespace(queries=256, hits=128),
+        mm_cache_stats=SimpleNamespace(hits=5),
+    )
+
+    monkeypatch.setattr(
+        SpyreScheduler,
+        "make_stats",
+        lambda self, *args, **kwargs: fake_stats,
+    )
+
+    stats = scheduler.make_stats()
+
+    assert stats is fake_stats
+    assert stats.mm_cache_stats.hits == 0
+    assert stats.prefix_cache_stats.hits == scheduler.adjust_hit(256, 128)
+
+
+@pytest.mark.cpu
+@pytest.mark.chunked_prefill
+def test_chunked_prefill_make_stats_without_mm_cache_stats(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    Regression test: make_stats() handles stats objects without mm_cache_stats.
+
+    This verifies that the defensive getattr() guard avoids attribute errors
+    when the returned stats object does not expose mm_cache_stats, while the
+    existing prefix-cache correction still applies.
+    """
+    model_runner = InstrumentedModelRunner.build(
+        monkeypatch=monkeypatch,
+        max_num_batched_tokens=512,
+        max_num_seqs=32,
+        max_model_len=32768,
+        available_blocks=32768,
+    )
+    scheduler = model_runner.scheduler
+
+    fake_stats = SimpleNamespace(
+        prefix_cache_stats=SimpleNamespace(queries=256, hits=128),
+    )
+
+    monkeypatch.setattr(
+        SpyreScheduler,
+        "make_stats",
+        lambda self, *args, **kwargs: fake_stats,
+    )
+
+    stats = scheduler.make_stats()
+
+    assert stats is fake_stats
+    assert stats.prefix_cache_stats.hits == scheduler.adjust_hit(256, 128)


### PR DESCRIPTION
Relates to issue: <nope>

Spyre currently reports a non-zero MM cache hit rate even though it does not support cross-request multimodal cache reuse. This change fixes the reporting so that MM cache hits are forced to 0, which makes the reported MM cache hit rate show 0.0%.

Changes:
update [ChunkedPrefillSpyreScheduler.make_stats()](vscode-webview://08qbuiao1v8n6ld23f20m5t2i0bda5kpcsevbflq3v7tpfbqn3vs/sendnn_inference/v1/core/scheduler.py:634) to zero MM cache hits when MM cache stats are present
add regression tests in [tests/v1/worker/test_scheduler_tkv_limits.py](vscode-webview://08qbuiao1v8n6ld23f20m5t2i0bda5kpcsevbflq3v7tpfbqn3vs/tests/v1/worker/test_scheduler_tkv_limits.py)
Testing:
[uv run pytest -q tests/v1/worker/test_scheduler_tkv_limits.py](vscode-webview://08qbuiao1v8n6ld23f20m5t2i0bda5kpcsevbflq3v7tpfbqn3vs/tests/v1/worker/test_scheduler_tkv_limits.py) → 4 passed
[uv run ruff check --fix](vscode-webview://08qbuiao1v8n6ld23f20m5t2i0bda5kpcsevbflq3v7tpfbqn3vs/index.html?id=b92f0073-7536-4bab-9c96-748f10f0bc01&parentId=5&origin=b4241180-f43c-4018-a9c5-2122df1b754c&swVersion=4&extensionId=IBM.bob-code&platform=electron&vscode-resource-base-authority=vscode-resource.vscode-cdn.net&parentOrigin=vscode-file%3A%2F%2Fvscode-app&purpose=webviewView) → passed
[uv run ruff format](vscode-webview://08qbuiao1v8n6ld23f20m5t2i0bda5kpcsevbflq3v7tpfbqn3vs/index.html?id=b92f0073-7536-4bab-9c96-748f10f0bc01&parentId=5&origin=b4241180-f43c-4018-a9c5-2122df1b754c&swVersion=4&extensionId=IBM.bob-code&platform=electron&vscode-resource-base-authority=vscode-resource.vscode-cdn.net&parentOrigin=vscode-file%3A%2F%2Fvscode-app&purpose=webviewView) → no changes
./format.sh → passed
