### PR TITLE
Upgrade fms-mo and aftu to remove llmcompressor dependecy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description = "vLLM plugin for Spyre hardware support"
 readme = "README.md"
 license = {text = "Apache 2"}
 dependencies = [
-    "fms-model-optimizer[fp8]>=0.8.2,<0.9",
+    "fms-model-optimizer[fp8-infer]>=0.8.3,<0.9",
     "ibm-fms>=1.9.0,<2",
     # NB: use strict < with the next patch version to not exclude versions with
     # build metadata suffixes
@@ -75,10 +75,6 @@ override-dependencies = [
 
     # requests is used by many dependencies, make sure it's patched for CVEs
     "requests>=2.32.4",
-
-    # vllm 0.18.0 pins compressed-tensors==0.13.0; override to 0.14.0.1
-    # TODO: remove once minimum vllm is bumped past 0.18.0
-    "compressed-tensors==0.14.0.1",
 
     # llguidance>=1.7.3 fixes s390x endianness issues.
     # This conflicts with vLLM's version range (llguidance >= 1.3.0, < 1.4.0).
@@ -243,6 +239,6 @@ dev = [
     "pytest-timeout==2.3.1",
     "requests==2.32.3",
     "sentence-transformers==3.4.1",
-    "aiu-fms-testing-utils>=0.5.0",
+    "aiu-fms-testing-utils>=0.8.2",
     "pytest-mock>=3.15.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -20,7 +20,6 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "compressed-tensors", specifier = "==0.14.0.1" },
     { name = "intel-extension-for-pytorch", marker = "sys_platform == 'never'" },
     { name = "llguidance", specifier = ">=1.7.3" },
     { name = "llvmlite", marker = "platform_machine not in 's390x, ppc64le'", specifier = "==0.44.0" },
@@ -179,10 +178,10 @@ wheels = [
 
 [[package]]
 name = "aiu-fms-testing-utils"
-version = "0.8.1"
+version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fms-model-optimizer", extra = ["fp8"] },
+    { name = "fms-model-optimizer", extra = ["fp8-infer"] },
     { name = "ibm-fms" },
     { name = "numpy" },
     { name = "sentencepiece" },
@@ -191,7 +190,7 @@ dependencies = [
     { name = "transformers" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/ce/a1ea544eec2b9f707394a9d373cca0ea6135337c1853a3343a898e4bcea3/aiu_fms_testing_utils-0.8.1-py3-none-any.whl", hash = "sha256:3bd3826171819cbf59eae757b4fc8980e9eef959613c72e6e58c61af3809269e", size = 101676, upload-time = "2026-04-30T19:30:18.272Z" },
+    { url = "https://files.pythonhosted.org/packages/58/79/1a959469f8c4b1c44ffcce12dc17b083cdaf12c1b3e692300b95f88d3d83/aiu_fms_testing_utils-0.8.2-py3-none-any.whl", hash = "sha256:8642abbe43efb440489ce01f84a52e21cb4dc1fc9f3d9085611bae7e9a373f8a", size = 101681, upload-time = "2026-05-20T16:16:50.563Z" },
 ]
 
 [[package]]
@@ -289,26 +288,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
-]
-
-[[package]]
-name = "auto-round"
-version = "0.10.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "accelerate" },
-    { name = "datasets" },
-    { name = "numpy" },
-    { name = "py-cpuinfo" },
-    { name = "threadpoolctl" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'aarch64' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
-    { name = "tqdm" },
-    { name = "transformers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/36/cba4fc9acb678c3ec2b0c8ba24e964e9720819fa1f0f4d9674ad2388447f/auto_round-0.10.2.tar.gz", hash = "sha256:f00a5fd484363d9ab9f5628f46ae70fd880b5fa91fcd15d55a556b8e36d39e24", size = 431371, upload-time = "2026-02-24T17:44:36.899Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/8d/3899ad057f9b4df481a2f32c15d32dca9366842a0eac51914fbe6e0179d8/auto_round-0.10.2-py3-none-any.whl", hash = "sha256:42172962aede60d7f05d0632ce49d4b05ac78a0620cd6d1a65b28c9f625e4175", size = 563635, upload-time = "2026-02-24T17:44:35.298Z" },
 ]
 
 [[package]]
@@ -646,7 +625,7 @@ wheels = [
 
 [[package]]
 name = "compressed-tensors"
-version = "0.14.0.1"
+version = "0.15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "loguru" },
@@ -655,9 +634,9 @@ dependencies = [
     { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/f1/4c9b01ceaf82ad58ad00919223e09b8e74d4073a2ba8e3ab2f97521ef65c/compressed_tensors-0.14.0.1.tar.gz", hash = "sha256:5ad3841184b6f5020e06059b2463191c5c57a144bb97cab9159978d8118839b1", size = 226393, upload-time = "2026-03-11T17:04:35.57Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/1b/c3c4a98ec5f2727656336f07a0c35862195c310d8eb0b2fa5b4be6848680/compressed_tensors-0.15.0.1.tar.gz", hash = "sha256:a8e93054e8a5ec49c980b09ed36c4c1249b4a8ee167920a8e461c4da26e78d99", size = 229412, upload-time = "2026-04-10T14:23:54.708Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/26/16a13993ecf4fdc9c39d63b3a6daabafd32a452cf68b81aa9eb3b8170913/compressed_tensors-0.14.0.1-py3-none-any.whl", hash = "sha256:46c4940a3a779d3d97108c294bfcd9acf4bd0491f7c6737c320f0e815ec732e4", size = 196454, upload-time = "2026-03-11T17:04:33.2Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/52/93833dc1610e017ac5b7dcd59b8304d8ef67d1114c2d124e728a2cbbea12/compressed_tensors-0.15.0.1-py3-none-any.whl", hash = "sha256:e1b1f322e82e475715e242bad46925a304ea8e5c98b5055a15b8eb22fb6bfea9", size = 194260, upload-time = "2026-04-10T14:23:53.098Z" },
 ]
 
 [[package]]
@@ -1004,7 +983,7 @@ wheels = [
 
 [[package]]
 name = "fms-model-optimizer"
-version = "0.8.2"
+version = "0.8.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "accelerate" },
@@ -1018,14 +997,13 @@ dependencies = [
     { name = "tqdm" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/af/e62b2b3745ef0c088f3c2edfc229bd738af5edc216443ecb0b5a0f0546cc/fms_model_optimizer-0.8.2.tar.gz", hash = "sha256:fffd6526dbc6e454d68ab424755b4b31e87205366af8d1f8af3ac7a9513b0646", size = 5186967, upload-time = "2026-04-03T16:02:29.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/b9/a665724888b8d415d55494beadfe88f2096575f7a60a67e885063c0469c7/fms_model_optimizer-0.8.3.tar.gz", hash = "sha256:33b5fdd44766424b0f1b96234b7cf89668e23114e17d8d2d2aecb7e4aa8bfe52", size = 5187181, upload-time = "2026-05-18T19:34:55.49Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/cc/aa91ee9fb16db2c5d1f8ff6de049422b6aaafd5f63027b48e20bda0254fe/fms_model_optimizer-0.8.2-py3-none-any.whl", hash = "sha256:4c145226b25e6326bea0ed4a214ab9eb11f7eda3b6b031bd1aa65bb9f150fc58", size = 361725, upload-time = "2026-04-03T16:02:28.565Z" },
+    { url = "https://files.pythonhosted.org/packages/42/26/17981e1dc2603067e725897c6a9d5c58eca2b896cfe46b5666528cc38e05/fms_model_optimizer-0.8.3-py3-none-any.whl", hash = "sha256:abf97460e4e438b7ed021ef31bc92338ed3ac046937241e7c7cae60914754798", size = 361741, upload-time = "2026-05-18T19:34:54.091Z" },
 ]
 
 [package.optional-dependencies]
-fp8 = [
-    { name = "llmcompressor" },
+fp8-infer = [
     { name = "torchao" },
 ]
 
@@ -1671,31 +1649,6 @@ wheels = [
 ]
 
 [[package]]
-name = "llmcompressor"
-version = "0.10.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "accelerate" },
-    { name = "auto-round" },
-    { name = "compressed-tensors" },
-    { name = "datasets" },
-    { name = "loguru" },
-    { name = "numpy" },
-    { name = "nvidia-ml-py" },
-    { name = "pillow" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'aarch64' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
-    { name = "tqdm" },
-    { name = "transformers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/ed/862518f9ea5c78e3b9534075b66d1f1d04911fcf77c48b5da4ec86d60d57/llmcompressor-0.10.0.2.tar.gz", hash = "sha256:bf9cf664ea9865920fb1ae6e71e4080d5d0ce6f6dd93d772b5eb24c0e9fb754e", size = 1932210, upload-time = "2026-05-01T13:20:43.327Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/a2/c50fdd5fcc14c942bb55a77137b56584d39f643b17185ee172ee75ebf8d7/llmcompressor-0.10.0.2-py3-none-any.whl", hash = "sha256:05a88730e42d7a4eafeb197ef73d35be4267e2cff1015d0743ba1e594f49230f", size = 295489, upload-time = "2026-05-01T13:20:41.718Z" },
-]
-
-[[package]]
 name = "lm-format-enforcer"
 version = "0.11.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2160,15 +2113,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/76/95/bef5b37f29fc5e739947e9ce5179ad402875633308504a52d188302319c8/numpy-2.2.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8e9ace4a37db23421249ed236fdcdd457d671e25146786dfc96835cd951aa7c1", size = 18385260, upload-time = "2025-05-17T21:43:05.189Z" },
     { url = "https://files.pythonhosted.org/packages/09/04/f2f83279d287407cf36a7a8053a5abe7be3622a4363337338f2585e4afda/numpy-2.2.6-cp313-cp313t-win32.whl", hash = "sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff", size = 6377225, upload-time = "2025-05-17T21:43:16.254Z" },
     { url = "https://files.pythonhosted.org/packages/67/0e/35082d13c09c02c011cf21570543d202ad929d961c02a147493cb0c2bdf5/numpy-2.2.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6031dd6dfecc0cf9f668681a37648373bddd6421fff6c66ec1624eed0180ee06", size = 12771374, upload-time = "2025-05-17T21:43:35.479Z" },
-]
-
-[[package]]
-name = "nvidia-ml-py"
-version = "13.590.48"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/a0/f4fc18cf72f06821a9a665085435b901449986855519d5b3843532db35e9/nvidia_ml_py-13.590.48.tar.gz", hash = "sha256:8184d1be52914ac7f0991cd1c0d946c65dc88a840c754cd12c274b77b88760dd", size = 49732, upload-time = "2026-01-22T01:14:56.456Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/72/fb2af0d259a651affdce65fd6a495f0e07a685a0136baf585c5065204ee7/nvidia_ml_py-13.590.48-py3-none-any.whl", hash = "sha256:fd43d30ee9cd0b7940f5f9f9220b68d42722975e3992b6c21d14144c48760e43", size = 50680, upload-time = "2026-01-22T01:14:55.281Z" },
 ]
 
 [[package]]
@@ -3903,7 +3847,7 @@ wheels = [
 name = "sendnn-inference"
 source = { editable = "." }
 dependencies = [
-    { name = "fms-model-optimizer", extra = ["fp8"] },
+    { name = "fms-model-optimizer", extra = ["fp8-infer"] },
     { name = "ibm-fms" },
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'aarch64' and sys_platform == 'darwin'" },
     { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
@@ -3926,7 +3870,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fms-model-optimizer", extras = ["fp8"], specifier = ">=0.8.2,<0.9" },
+    { name = "fms-model-optimizer", extras = ["fp8-infer"], specifier = ">=0.8.3,<0.9" },
     { name = "ibm-fms", specifier = ">=1.9.0,<2" },
     { name = "torch", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torchvision", index = "https://download.pytorch.org/whl/cpu" },
@@ -3935,7 +3879,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "aiu-fms-testing-utils", specifier = ">=0.5.0" },
+    { name = "aiu-fms-testing-utils", specifier = ">=0.8.2" },
     { name = "pytest", specifier = "==8.3.4" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "pytest-forked", specifier = ">=1.6.0" },


### PR DESCRIPTION
llmcompressor is a transitive dependency and it's not required for infrence. It is however causing problems because it has a dependency to an older compressed-tensors library than vllm, causing dependency conflicts. It also is not compatible with transformers 5 yet.
