### PR TITLE
[DO NOT MERGE] Experimental, ensure preemption is possible

### DIFF
--- a/examples/offline_inference/countdown_inference.py
+++ b/examples/offline_inference/countdown_inference.py
@@ -1,0 +1,185 @@
+"""
+This example shows how to run offline inference with countdown prompts.
+All parameters are hardcoded for the granite-3.3-8b-instruct model.
+"""
+
+import os
+import platform
+import time
+
+import re
+
+os.environ["VLLM_LOGGING_LEVEL"] = "DEBUG"
+
+from vllm import LLM, SamplingParams
+
+
+def validate_countdown(generated_text: str, prompt: str) -> dict:
+    """
+    Validate that the generated text contains properly decremented integers.
+    
+    Returns a dict with validation results:
+    - is_valid: bool
+    - expected_start: int (next number after prompt)
+    - actual_numbers: list of extracted integers
+    - issues: list of validation issues found
+    """
+    # Extract numbers from prompt to determine expected starting point
+    prompt_numbers = [int(x) for x in re.findall(r'\d+', prompt)]
+    if not prompt_numbers:
+        return {
+            "is_valid": False,
+            "expected_start": None,
+            "actual_numbers": [],
+            "issues": ["No numbers found in prompt"]
+        }
+    
+    expected_start = prompt_numbers[-1] - 1
+    
+    # Extract numbers from generated text
+    generated_numbers = [int(x) for x in re.findall(r'\d+', generated_text)]
+    
+    issues = []
+    is_valid = True
+    
+    if not generated_numbers:
+        issues.append("No numbers found in generated text")
+        is_valid = False
+    else:
+        # Check if first number matches expected
+        if generated_numbers[0] != expected_start:
+            issues.append(f"Expected first number to be {expected_start}, got {generated_numbers[0]}")
+            is_valid = False
+        
+        # Check if sequence is properly decremented
+        for i in range(len(generated_numbers) - 1):
+            if generated_numbers[i] - generated_numbers[i + 1] != 1:
+                issues.append(
+                    f"Non-consecutive numbers at position {i}: "
+                    f"{generated_numbers[i]} -> {generated_numbers[i + 1]}"
+                )
+                is_valid = False
+    
+    return {
+        "is_valid": is_valid,
+        "expected_start": expected_start,
+        "actual_numbers": generated_numbers,
+        "issues": issues
+    }
+
+if __name__ == "__main__":
+    # Hardcoded configuration
+    MODEL = "ibm-granite/granite-3.3-8b-instruct"
+    MAX_MODEL_LEN = 4096
+    MAX_NUM_SEQS = 4
+    TENSOR_PARALLEL_SIZE = 4
+    MAX_TOKENS = 300
+    ENABLE_PREFIX_CACHING = True
+    MAX_NUM_BATCHED_TOKENS = 512
+    BACKEND = "sendnn"
+
+    if platform.machine() == "arm64":
+        print(
+            "Detected arm64 running environment. "
+            "Setting HF_HUB_OFFLINE=1 otherwise vllm tries to download a "
+            "different version of the model using HF API which might not work "
+            "locally on arm64."
+        )
+        os.environ["HF_HUB_OFFLINE"] = "1"
+
+    if platform.system() == "Darwin":
+        print("Setting VLLM_WORKER_MULTIPROC_METHOD=spawn to avoid forking problems on Mac OS")
+        os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+    os.environ["SENDNN_INFERENCE_DYNAMO_BACKEND"] = BACKEND
+    os.environ["SENDNN_INFERENCE_CP_INTERLEAVE_STEPS"] = "0"
+
+    # Create countdown prompts with actual countdown values
+    prompts = [
+        " ".join(str(i) for i in range(200, 180, -1)) + " ",
+        " ".join(str(i) for i in range(150, 130, -1)) + " ",
+        " ".join(str(i) for i in range(1000, 980, -1)) + " ",
+        " ".join(str(i) for i in range(500, 480, -1)) + " ",
+    ]
+
+    print(f"Model: {MODEL}")
+    print(f"Max Model Length: {MAX_MODEL_LEN}")
+    print(f"Max Num Seqs: {MAX_NUM_SEQS}")
+    print(f"Tensor Parallel Size: {TENSOR_PARALLEL_SIZE}")
+    print(f"Number of prompts: {len(prompts)}")
+    print("=" * 80)
+    
+    # Print the prompts
+    print("\nPROMPTS:")
+    for i, prompt in enumerate(prompts, 1):
+        print(f"\nPrompt {i}:")
+        print(prompt)
+    print("\n" + "=" * 80)
+
+    # Create sampling parameters
+    sampling_params = [
+        SamplingParams(max_tokens=MAX_TOKENS, temperature=0.0, ignore_eos=True)
+        for _ in prompts
+    ]
+
+    # Create an LLM
+    print("Initializing LLM...")
+    llm = LLM(
+        model=MODEL,
+        tokenizer=MODEL,
+        max_model_len=MAX_MODEL_LEN,
+        max_num_seqs=MAX_NUM_SEQS,
+        tensor_parallel_size=TENSOR_PARALLEL_SIZE,
+        enable_prefix_caching=ENABLE_PREFIX_CACHING,
+        max_num_batched_tokens=MAX_NUM_BATCHED_TOKENS,
+    )
+
+    # Generate texts from the prompts
+    print("\n" + "=" * 80)
+    print("GENERATING OUTPUTS")
+    print("=" * 80)
+    t0 = time.time()
+    outputs = llm.generate(prompts, sampling_params)
+    elapsed_time = time.time() - t0
+    
+    total_tokens = sum(len(output.outputs[0].token_ids) for output in outputs)
+    print(f"\nTime elapsed for {total_tokens} tokens is {elapsed_time:.2f} sec")
+    print(f"Tokens per second: {total_tokens / elapsed_time:.2f}")
+    
+    print("\n" + "=" * 80)
+    print("RESULTS")
+    print("=" * 80)
+    
+    all_valid = True
+    for i, output in enumerate(outputs, 1):
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        num_tokens = len(output.outputs[0].token_ids)
+        
+        # Validate countdown
+        validation = validate_countdown(generated_text, prompt)
+        
+        print(f"\n[Prompt {i}]")
+        print(f"Prompt: {prompt!r}")
+        print(f"Generated text: {generated_text!r}")
+        print(f"Tokens generated: {num_tokens}")
+        print(f"\nValidation:")
+        print(f"  Status: {'✓ PASS' if validation['is_valid'] else '✗ FAIL'}")
+        print(f"  Expected start: {validation['expected_start']}")
+        print(f"  Numbers found: {len(validation['actual_numbers'])}")
+        if validation['actual_numbers']:
+            print(f"  First few numbers: {validation['actual_numbers'][:10]}")
+            print(f"  Last few numbers: {validation['actual_numbers'][-10:]}")
+        if validation['issues']:
+            print(f"  Issues:")
+            for issue in validation['issues']:
+                print(f"    - {issue}")
+        
+        if not validation['is_valid']:
+            all_valid = False
+        
+        print("-" * 80)
+    
+    print("\n" + "=" * 80)
+    print(f"OVERALL VALIDATION: {'✓ ALL PASSED' if all_valid else '✗ SOME FAILED'}")
+    print("=" * 80)

--- a/examples/offline_inference/countdown_inference.py
+++ b/examples/offline_inference/countdown_inference.py
@@ -1,6 +1,13 @@
 """
-This example shows how to run offline inference with countdown prompts.
-All parameters are hardcoded for the granite-3.3-8b-instruct model.
+This is a small script that runs inference with four prompts of decremented integers:
+
+1. "200 199 198 197 196... 181"
+2. "150 149 148 147 146... 130"
+3. "1000 1999 1998 1997... 980"
+4. "500 499 498 497 ... 480"
+
+because it is basically counting, this makes sure the output tokens are deterministic
+we check model correctness by checking if the counting (decrementation) is correct
 """
 
 import argparse

--- a/examples/offline_inference/countdown_inference.py
+++ b/examples/offline_inference/countdown_inference.py
@@ -3,13 +3,13 @@ This example shows how to run offline inference with countdown prompts.
 All parameters are hardcoded for the granite-3.3-8b-instruct model.
 """
 
+import argparse
 import os
 import platform
 import time
 
 import re
 
-os.environ["VLLM_LOGGING_LEVEL"] = "DEBUG"
 
 from vllm import LLM, SamplingParams
 
@@ -68,6 +68,19 @@ def validate_countdown(generated_text: str, prompt: str) -> dict:
     }
 
 if __name__ == "__main__":
+    # Parse command-line arguments
+    parser = argparse.ArgumentParser(
+        description="Run offline inference with countdown prompts"
+    )
+    parser.add_argument(
+        "--backend",
+        type=str,
+        choices=["eager", "sendnn"],
+        default="sendnn",
+        help="Backend to use for inference (default: sendnn)"
+    )
+    args = parser.parse_args()
+    
     # Hardcoded configuration
     MODEL = "ibm-granite/granite-3.3-8b-instruct"
     MAX_MODEL_LEN = 4096
@@ -76,7 +89,7 @@ if __name__ == "__main__":
     MAX_TOKENS = 300
     ENABLE_PREFIX_CACHING = True
     MAX_NUM_BATCHED_TOKENS = 512
-    BACKEND = "sendnn"
+    BACKEND = args.backend
 
     if platform.machine() == "arm64":
         print(
@@ -94,6 +107,8 @@ if __name__ == "__main__":
     os.environ["SENDNN_INFERENCE_DYNAMO_BACKEND"] = BACKEND
     os.environ["SENDNN_INFERENCE_CP_INTERLEAVE_STEPS"] = "0"
 
+    print(f"Backend: {BACKEND}")
+    
     # Create countdown prompts with actual countdown values
     prompts = [
         " ".join(str(i) for i in range(200, 180, -1)) + " ",

--- a/sendnn_inference/v1/core/scheduler.py
+++ b/sendnn_inference/v1/core/scheduler.py
@@ -267,7 +267,8 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         - Increments the decode step counter
         - Validates state at the first decode step
         - Preempts 2nd and last request at decode step 100
-        - Restores preempted requests at decode step 200
+        - Restores first preempted request at decode step 200
+        - Restores second preempted request at decode step 230
         """
         self.total_decode_steps += 1
         logger.info("Total decode steps executed: %d", self.total_decode_steps)
@@ -288,8 +289,8 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
             )
         
         # Preempt 2nd and last request at decode step 100
-        if self.total_decode_steps == 100 and len(self.running) >= 2:
-            assert len(self.running) == 4, f"Expecting four decoding requests at step 100"
+        if self.total_decode_steps == 100:
+            assert len(self.running) == 4, f"Expecting four decoding requests at step 100, got {len(self.running)}"
             
             # Store the 2nd request (index 1) and last request (index -1)
             second_request = self.running[1]
@@ -300,12 +301,23 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
             logger.info("Decode step 100: Preempted 2nd and last request from running queue. "
                         f"Preempted request IDs: {[r.request_id for r in self.preempted_requests]}")
         
-        # Restore preempted requests at decode step 200
-        if self.total_decode_steps == 200 and self.preempted_requests:
-            self.running.extend(self.preempted_requests)
-            logger.info("Decode step 200: Restored preempted requests to running queue. "
-                      f"Restored request IDs: {[r.request_id for r in self.preempted_requests]}")
-            self.preempted_requests = []
+        # Restore first preempted request at decode step 200
+        if self.total_decode_steps == 200:
+            assert len(self.preempted_requests) == 2, f"Expecting two preempted requests at step 200, got {len(self.preempted_requests)}"
+            first_request = self.preempted_requests[0]
+            self.running.append(first_request)
+            logger.info("Decode step 200: Restored first preempted request to running queue. "
+                      f"Restored request ID: {first_request.request_id}")
+            self.preempted_requests = self.preempted_requests[1:]
+        
+        # Restore second preempted request at decode step 230
+        if self.total_decode_steps == 230:
+            assert len(self.preempted_requests) == 1, f"Expecting one preempted request at step 230, got {len(self.preempted_requests)}"
+            second_request = self.preempted_requests[0]
+            self.running.append(second_request)
+            logger.info("Decode step 230: Restored second preempted request to running queue. "
+                      f"Restored request ID: {second_request.request_id}")
+            self.preempted_requests = self.preempted_requests[1:]
 
     def schedule(self) -> "SchedulerOutput":
         """

--- a/sendnn_inference/v1/core/scheduler.py
+++ b/sendnn_inference/v1/core/scheduler.py
@@ -259,6 +259,54 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         # Otherwise just account for the left padding
         return computed_tokens - left_padding
 
+    def _handle_decode_step_preemption(self) -> None:
+        """
+        Handle decode step tracking and preemption logic.
+        
+        This method:
+        - Increments the decode step counter
+        - Validates state at the first decode step
+        - Preempts 2nd and last request at decode step 100
+        - Restores preempted requests at decode step 200
+        """
+        self.total_decode_steps += 1
+        logger.info("Total decode steps executed: %d", self.total_decode_steps)
+        
+        # Assert conditions at the first decode step
+        if self.total_decode_steps == 1:
+            assert len(self.running) == 4, (
+                f"Expected exactly 4 decoding requests in running queue at first decode step, "
+                f"but got {len(self.running)}"
+            )
+            assert len(self.ongoing_prefills) == 0, (
+                f"Expected no requests in prefill queue at first decode step, "
+                f"but got {len(self.ongoing_prefills)}"
+            )
+            assert len(self.waiting) == 0, (
+                f"Expected no requests in waiting queue at first decode step, "
+                f"but got {len(self.waiting)}"
+            )
+        
+        # Preempt 2nd and last request at decode step 100
+        if self.total_decode_steps == 100 and len(self.running) >= 2:
+            assert len(self.running) == 4, f"Expecting four decoding requests at step 100"
+            
+            # Store the 2nd request (index 1) and last request (index -1)
+            second_request = self.running[1]
+            last_request = self.running[-1]
+            
+            self.preempted_requests = [second_request, last_request]
+            self.running = [r for r in self.running if r not in self.preempted_requests]
+            logger.info("Decode step 100: Preempted 2nd and last request from running queue. "
+                        f"Preempted request IDs: {[r.request_id for r in self.preempted_requests]}")
+        
+        # Restore preempted requests at decode step 200
+        if self.total_decode_steps == 200 and self.preempted_requests:
+            self.running.extend(self.preempted_requests)
+            logger.info("Decode step 200: Restored preempted requests to running queue. "
+                      f"Restored request IDs: {[r.request_id for r in self.preempted_requests]}")
+            self.preempted_requests = []
+
     def schedule(self) -> "SchedulerOutput":
         """
         The chunked prefill scheduling policy is enforced in this method, then
@@ -328,43 +376,7 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
                 self.running = [r for r in self.running if r not in self.ongoing_prefills]
                 running_holdback = self.ongoing_prefills
                 self.previous_step_was_prefill = False
-                self.total_decode_steps += 1
-                logger.info("Total decode steps executed: %d", self.total_decode_steps)
-                
-                # Just verify that the four hardcoded prompts are all decoding now
-                if self.total_decode_steps == 1:
-                    assert len(self.running) == 4, (
-                        f"Expected exactly 4 decoding requests in running queue at first decode step, "
-                        f"but got {len(self.running)}"
-                    )
-                    assert len(self.ongoing_prefills) == 0, (
-                        f"Expected no requests in prefill queue at first decode step, "
-                        f"but got {len(self.ongoing_prefills)}"
-                    )
-                    assert len(self.waiting) == 0, (
-                        f"Expected no requests in waiting queue at first decode step, "
-                        f"but got {len(self.waiting)}"
-                    )
-                
-                # Preempt 2nd and last request at decode step 100
-                if self.total_decode_steps == 100:
-                    assert len(self.running) == 4, f"Expecting four decoding requests at step 100"
-                    # Store the 2nd request (index 1) and last request (index -1)
-                    second_request = self.running[1]
-                    last_request = self.running[-1]
-                    
-                    self.preempted_requests = [second_request, last_request]
-                    self.running = [r for r in self.running if r not in self.preempted_requests]
-                    logger.info("Decode step 100: Preempted 2nd and last request from running queue. "
-                                f"Preempted request IDs: {[r.request_id for r in self.preempted_requests]}")
-                
-                # Restore preempted requests at decode step 200
-                if self.total_decode_steps == 200:
-                    assert len(self.preempted_requests) == 2, f"We should have two preempted requests at step 200"
-                    self.running.extend(self.preempted_requests)
-                    logger.info("Decode step 200: Restored preempted requests to running queue. "
-                              f"Restored request IDs: {[r.request_id for r in self.preempted_requests]}")
-                    self.preempted_requests = []
+                self._handle_decode_step_preemption()
 
         # Check new requests to prefill
         elif len(self.waiting) > 0:
@@ -395,83 +407,10 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
                     holdback_queue.appendleft(self.waiting.pop())
                 running_holdback = []
                 self.previous_step_was_prefill = False
-                self.total_decode_steps += 1
-                logger.info("Total decode steps executed: %d", self.total_decode_steps)
-                
-                # Assert conditions at the first decode step
-                if self.total_decode_steps == 1:
-                    assert len(self.running) == 4, (
-                        f"Expected exactly 4 decoding requests in running queue at first decode step, "
-                        f"but got {len(self.running)}"
-                    )
-                    assert len(self.ongoing_prefills) == 0, (
-                        f"Expected no requests in prefill queue at first decode step, "
-                        f"but got {len(self.ongoing_prefills)}"
-                    )
-                    assert len(self.waiting) == 0, (
-                        f"Expected no requests in waiting queue at first decode step, "
-                        f"but got {len(self.waiting)}"
-                    )
-                
-                # Preempt 2nd and last request at decode step 100
-                if self.total_decode_steps == 100 and len(self.running) >= 2:
-                    assert len(self.running) == 4, f"Expecting four decoding requests at step 100"
-
-                    # Store the 2nd request (index 1) and last request (index -1)
-                    second_request = self.running[1]
-                    last_request = self.running[-1]
-                    
-                    self.preempted_requests = [second_request, last_request]
-                    self.running = [r for r in self.running if r not in self.preempted_requests]
-                    logger.info("Decode step 100: Preempted 2nd and last request from running queue. "
-                                f"Preempted request IDs: {[r.request_id for r in self.preempted_requests]}")
-                
-                # Restore preempted requests at decode step 200
-                if self.total_decode_steps == 200 and self.preempted_requests:
-                    self.running.extend(self.preempted_requests)
-                    logger.info("Decode step 200: Restored preempted requests to running queue. "
-                              f"Restored request IDs: {[r.request_id for r in self.preempted_requests]}")
-                    self.preempted_requests = []
+                self._handle_decode_step_preemption()
         else:
             self.previous_step_was_prefill = False
-            self.total_decode_steps += 1
-            logger.info("Total decode steps executed: %d", self.total_decode_steps)
-            
-            # Assert conditions at the first decode step
-            if self.total_decode_steps == 1:
-                assert len(self.running) == 4, (
-                    f"Expected exactly 4 decoding requests in running queue at first decode step, "
-                    f"but got {len(self.running)}"
-                )
-                assert len(self.ongoing_prefills) == 0, (
-                    f"Expected no requests in prefill queue at first decode step, "
-                    f"but got {len(self.ongoing_prefills)}"
-                )
-                assert len(self.waiting) == 0, (
-                    f"Expected no requests in waiting queue at first decode step, "
-                    f"but got {len(self.waiting)}"
-                )
-            
-            # Preempt 2nd and last request at decode step 100
-            if self.total_decode_steps == 100 and len(self.running) >= 2:
-                assert len(self.running) == 4, f"Expecting four decoding requests at step 100"
-
-                # Store the 2nd request (index 1) and last request (index -1)
-                second_request = self.running[1]
-                last_request = self.running[-1]
-                
-                self.preempted_requests = [second_request, last_request]
-                self.running = [r for r in self.running if r not in self.preempted_requests]
-                logger.info("Decode step 100: Preempted 2nd and last request from running queue. "
-                            f"Preempted request IDs: {[r.request_id for r in self.preempted_requests]}")
-            
-            # Restore preempted requests at decode step 200
-            if self.total_decode_steps == 200 and self.preempted_requests:
-                self.running.extend(self.preempted_requests)
-                logger.info("Decode step 200: Restored preempted requests to running queue. "
-                          f"Restored request IDs: {[r.request_id for r in self.preempted_requests]}")
-                self.preempted_requests = []
-            
+            self._handle_decode_step_preemption()
             running_holdback = []
 
         # delegate to super of SpyreScheduler: base V1 Scheduler

--- a/sendnn_inference/v1/core/scheduler.py
+++ b/sendnn_inference/v1/core/scheduler.py
@@ -203,6 +203,12 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         self.block_size = SpyrePlatform.get_block_size()
         self.max_batch_tkv_limit = SpyrePlatform.get_max_batch_tkv_limit()
 
+        # Track total number of decode steps executed
+        self.total_decode_steps = 0
+        
+        # Store removed requests temporarily (for decode step 100-200 experiment)
+        self.removed_requests: list[Request] = []
+
         assert self.max_batch_tkv_limit != -1, (
             "Expecting the env var VLLM_DT_MAX_BATCH_TKV_LIMIT to be set in platform.py"
         )
@@ -322,6 +328,43 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
                 self.running = [r for r in self.running if r not in self.ongoing_prefills]
                 running_holdback = self.ongoing_prefills
                 self.previous_step_was_prefill = False
+                self.total_decode_steps += 1
+                logger.info("Total decode steps executed: %d", self.total_decode_steps)
+                
+                # Just verify that the four hardcoded prompts are all decoding now
+                if self.total_decode_steps == 1:
+                    assert len(self.running) == 4, (
+                        f"Expected exactly 4 decoding requests in running queue at first decode step, "
+                        f"but got {len(self.running)}"
+                    )
+                    assert len(self.ongoing_prefills) == 0, (
+                        f"Expected no requests in prefill queue at first decode step, "
+                        f"but got {len(self.ongoing_prefills)}"
+                    )
+                    assert len(self.waiting) == 0, (
+                        f"Expected no requests in waiting queue at first decode step, "
+                        f"but got {len(self.waiting)}"
+                    )
+                
+                # Preempt 2nd and last request at decode step 100
+                if self.total_decode_steps == 100:
+                    assert len(self.running) == 4, f"Expecting four decoding requests at step 100"
+                    # Store the 2nd request (index 1) and last request (index -1)
+                    second_request = self.running[1]
+                    last_request = self.running[-1]
+                    
+                    self.removed_requests = [second_request, last_request]
+                    self.running = [r for r in self.running if r not in self.removed_requests]
+                    logger.info("Decode step 100: Removed 2nd and last request from running queue. "
+                                f"Removed request IDs: {[r.request_id for r in self.removed_requests]}")
+                
+                # Restore preemptd requests at decode step 200
+                if self.total_decode_steps == 200:
+                    assert len(self.removed_requests) == 2, f"We should have two preempted requests at step 200"
+                    self.running.extend(self.removed_requests)
+                    logger.info("Decode step 200: Restored preempted requests to running queue. "
+                              f"Restored request IDs: {[r.request_id for r in self.removed_requests]}")
+                    self.removed_requests = []
 
         # Check new requests to prefill
         elif len(self.waiting) > 0:
@@ -352,8 +395,95 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
                     holdback_queue.appendleft(self.waiting.pop())
                 running_holdback = []
                 self.previous_step_was_prefill = False
+                self.total_decode_steps += 1
+                logger.info("Total decode steps executed: %d", self.total_decode_steps)
+                
+                # Assert conditions at the first decode step
+                if self.total_decode_steps == 1:
+                    assert len(self.running) == 4, (
+                        f"Expected exactly 4 decoding requests in running queue at first decode step, "
+                        f"but got {len(self.running)}"
+                    )
+                    assert len(self.ongoing_prefills) == 0, (
+                        f"Expected no requests in prefill queue at first decode step, "
+                        f"but got {len(self.ongoing_prefills)}"
+                    )
+                    assert len(self.waiting) == 0, (
+                        f"Expected no requests in waiting queue at first decode step, "
+                        f"but got {len(self.waiting)}"
+                    )
+                
+                # Remove 2nd and last request at decode step 100
+                if self.total_decode_steps == 100 and len(self.running) >= 2:
+                    # Store the 2nd request (index 1) and last request (index -1)
+                    second_request = self.running[1]
+                    last_request = self.running[-1]
+                    
+                    # Only remove if they are different requests
+                    if second_request != last_request:
+                        self.removed_requests = [second_request, last_request]
+                        self.running = [r for r in self.running if r not in self.removed_requests]
+                        logger.info("Decode step 100: Removed 2nd and last request from running queue. "
+                                  f"Removed request IDs: {[r.request_id for r in self.removed_requests]}")
+                    else:
+                        # If there are only 2 requests, remove just the last one
+                        self.removed_requests = [last_request]
+                        self.running = [r for r in self.running if r != last_request]
+                        logger.info("Decode step 100: Removed last request from running queue. "
+                                  f"Removed request ID: {last_request.request_id}")
+                
+                # Restore removed requests at decode step 200
+                if self.total_decode_steps == 200 and self.removed_requests:
+                    self.running.extend(self.removed_requests)
+                    logger.info("Decode step 200: Restored removed requests to running queue. "
+                              f"Restored request IDs: {[r.request_id for r in self.removed_requests]}")
+                    self.removed_requests = []
         else:
             self.previous_step_was_prefill = False
+            self.total_decode_steps += 1
+            logger.info("Total decode steps executed: %d", self.total_decode_steps)
+            
+            # Assert conditions at the first decode step
+            if self.total_decode_steps == 1:
+                assert len(self.running) == 4, (
+                    f"Expected exactly 4 decoding requests in running queue at first decode step, "
+                    f"but got {len(self.running)}"
+                )
+                assert len(self.ongoing_prefills) == 0, (
+                    f"Expected no requests in prefill queue at first decode step, "
+                    f"but got {len(self.ongoing_prefills)}"
+                )
+                assert len(self.waiting) == 0, (
+                    f"Expected no requests in waiting queue at first decode step, "
+                    f"but got {len(self.waiting)}"
+                )
+            
+            # Remove 2nd and last request at decode step 100
+            if self.total_decode_steps == 100 and len(self.running) >= 2:
+                # Store the 2nd request (index 1) and last request (index -1)
+                second_request = self.running[1]
+                last_request = self.running[-1]
+                
+                # Only remove if they are different requests
+                if second_request != last_request:
+                    self.removed_requests = [second_request, last_request]
+                    self.running = [r for r in self.running if r not in self.removed_requests]
+                    logger.info("Decode step 100: Removed 2nd and last request from running queue. "
+                              f"Removed request IDs: {[r.request_id for r in self.removed_requests]}")
+                else:
+                    # If there are only 2 requests, remove just the last one
+                    self.removed_requests = [last_request]
+                    self.running = [r for r in self.running if r != last_request]
+                    logger.info("Decode step 100: Removed last request from running queue. "
+                              f"Removed request ID: {last_request.request_id}")
+            
+            # Restore removed requests at decode step 200
+            if self.total_decode_steps == 200 and self.removed_requests:
+                self.running.extend(self.removed_requests)
+                logger.info("Decode step 200: Restored removed requests to running queue. "
+                          f"Restored request IDs: {[r.request_id for r in self.removed_requests]}")
+                self.removed_requests = []
+            
             running_holdback = []
 
         # delegate to super of SpyreScheduler: base V1 Scheduler

--- a/sendnn_inference/v1/core/scheduler.py
+++ b/sendnn_inference/v1/core/scheduler.py
@@ -206,8 +206,8 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         # Track total number of decode steps executed
         self.total_decode_steps = 0
         
-        # Store removed requests temporarily (for decode step 100-200 experiment)
-        self.removed_requests: list[Request] = []
+        # Store preempted requests temporarily (for decode step 100-200 experiment)
+        self.preempted_requests: list[Request] = []
 
         assert self.max_batch_tkv_limit != -1, (
             "Expecting the env var VLLM_DT_MAX_BATCH_TKV_LIMIT to be set in platform.py"
@@ -353,18 +353,18 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
                     second_request = self.running[1]
                     last_request = self.running[-1]
                     
-                    self.removed_requests = [second_request, last_request]
-                    self.running = [r for r in self.running if r not in self.removed_requests]
-                    logger.info("Decode step 100: Removed 2nd and last request from running queue. "
-                                f"Removed request IDs: {[r.request_id for r in self.removed_requests]}")
+                    self.preempted_requests = [second_request, last_request]
+                    self.running = [r for r in self.running if r not in self.preempted_requests]
+                    logger.info("Decode step 100: Preempted 2nd and last request from running queue. "
+                                f"Preempted request IDs: {[r.request_id for r in self.preempted_requests]}")
                 
-                # Restore preemptd requests at decode step 200
+                # Restore preempted requests at decode step 200
                 if self.total_decode_steps == 200:
-                    assert len(self.removed_requests) == 2, f"We should have two preempted requests at step 200"
-                    self.running.extend(self.removed_requests)
+                    assert len(self.preempted_requests) == 2, f"We should have two preempted requests at step 200"
+                    self.running.extend(self.preempted_requests)
                     logger.info("Decode step 200: Restored preempted requests to running queue. "
-                              f"Restored request IDs: {[r.request_id for r in self.removed_requests]}")
-                    self.removed_requests = []
+                              f"Restored request IDs: {[r.request_id for r in self.preempted_requests]}")
+                    self.preempted_requests = []
 
         # Check new requests to prefill
         elif len(self.waiting) > 0:
@@ -413,31 +413,25 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
                         f"but got {len(self.waiting)}"
                     )
                 
-                # Remove 2nd and last request at decode step 100
+                # Preempt 2nd and last request at decode step 100
                 if self.total_decode_steps == 100 and len(self.running) >= 2:
+                    assert len(self.running) == 4, f"Expecting four decoding requests at step 100"
+
                     # Store the 2nd request (index 1) and last request (index -1)
                     second_request = self.running[1]
                     last_request = self.running[-1]
                     
-                    # Only remove if they are different requests
-                    if second_request != last_request:
-                        self.removed_requests = [second_request, last_request]
-                        self.running = [r for r in self.running if r not in self.removed_requests]
-                        logger.info("Decode step 100: Removed 2nd and last request from running queue. "
-                                  f"Removed request IDs: {[r.request_id for r in self.removed_requests]}")
-                    else:
-                        # If there are only 2 requests, remove just the last one
-                        self.removed_requests = [last_request]
-                        self.running = [r for r in self.running if r != last_request]
-                        logger.info("Decode step 100: Removed last request from running queue. "
-                                  f"Removed request ID: {last_request.request_id}")
+                    self.preempted_requests = [second_request, last_request]
+                    self.running = [r for r in self.running if r not in self.preempted_requests]
+                    logger.info("Decode step 100: Preempted 2nd and last request from running queue. "
+                                f"Preempted request IDs: {[r.request_id for r in self.preempted_requests]}")
                 
-                # Restore removed requests at decode step 200
-                if self.total_decode_steps == 200 and self.removed_requests:
-                    self.running.extend(self.removed_requests)
-                    logger.info("Decode step 200: Restored removed requests to running queue. "
-                              f"Restored request IDs: {[r.request_id for r in self.removed_requests]}")
-                    self.removed_requests = []
+                # Restore preempted requests at decode step 200
+                if self.total_decode_steps == 200 and self.preempted_requests:
+                    self.running.extend(self.preempted_requests)
+                    logger.info("Decode step 200: Restored preempted requests to running queue. "
+                              f"Restored request IDs: {[r.request_id for r in self.preempted_requests]}")
+                    self.preempted_requests = []
         else:
             self.previous_step_was_prefill = False
             self.total_decode_steps += 1
@@ -458,31 +452,25 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
                     f"but got {len(self.waiting)}"
                 )
             
-            # Remove 2nd and last request at decode step 100
+            # Preempt 2nd and last request at decode step 100
             if self.total_decode_steps == 100 and len(self.running) >= 2:
+                assert len(self.running) == 4, f"Expecting four decoding requests at step 100"
+
                 # Store the 2nd request (index 1) and last request (index -1)
                 second_request = self.running[1]
                 last_request = self.running[-1]
                 
-                # Only remove if they are different requests
-                if second_request != last_request:
-                    self.removed_requests = [second_request, last_request]
-                    self.running = [r for r in self.running if r not in self.removed_requests]
-                    logger.info("Decode step 100: Removed 2nd and last request from running queue. "
-                              f"Removed request IDs: {[r.request_id for r in self.removed_requests]}")
-                else:
-                    # If there are only 2 requests, remove just the last one
-                    self.removed_requests = [last_request]
-                    self.running = [r for r in self.running if r != last_request]
-                    logger.info("Decode step 100: Removed last request from running queue. "
-                              f"Removed request ID: {last_request.request_id}")
+                self.preempted_requests = [second_request, last_request]
+                self.running = [r for r in self.running if r not in self.preempted_requests]
+                logger.info("Decode step 100: Preempted 2nd and last request from running queue. "
+                            f"Preempted request IDs: {[r.request_id for r in self.preempted_requests]}")
             
-            # Restore removed requests at decode step 200
-            if self.total_decode_steps == 200 and self.removed_requests:
-                self.running.extend(self.removed_requests)
-                logger.info("Decode step 200: Restored removed requests to running queue. "
-                          f"Restored request IDs: {[r.request_id for r in self.removed_requests]}")
-                self.removed_requests = []
+            # Restore preempted requests at decode step 200
+            if self.total_decode_steps == 200 and self.preempted_requests:
+                self.running.extend(self.preempted_requests)
+                logger.info("Decode step 200: Restored preempted requests to running queue. "
+                          f"Restored request IDs: {[r.request_id for r in self.preempted_requests]}")
+                self.preempted_requests = []
             
             running_holdback = []
 

--- a/sendnn_inference/v1/worker/spyre_model_runner.py
+++ b/sendnn_inference/v1/worker/spyre_model_runner.py
@@ -1447,6 +1447,29 @@ class ChunkedPrefillModelRunner(
         - Refreshes metadata for logits processors
         """
         req_data = scheduler_output.scheduled_cached_reqs
+        
+        # Synchronize input_batch with scheduler output: remove requests that are not in scheduler output
+        # This handles preemption cases where scheduler temporarily removes requests from running queue
+        scheduled_req_ids = set(req_data.req_ids)
+        current_batch_req_ids = set(self.input_batch.req_id_to_index.keys())
+        
+        # Find requests that are in input_batch but not in scheduler output (preempted)
+        preempted_req_ids = current_batch_req_ids - scheduled_req_ids
+        for req_id in preempted_req_ids:
+            # Only remove if it's not a finished request (finished requests are handled separately)
+            if req_id not in (scheduler_output.finished_req_ids or []):
+                logger.info(f"Removing preempted request {req_id} from input_batch")
+                self.input_batch.remove_request(req_id)
+        
+        # Find requests that are in scheduler output but not in input_batch (restored from preemption)
+        restored_req_ids = scheduled_req_ids - current_batch_req_ids
+        for req_id in restored_req_ids:
+            # Add back the request that was preempted
+            if req_id in self.requests:
+                logger.info(f"Restoring preempted request {req_id} to input_batch")
+                req_state = self.requests[req_id]
+                self.input_batch.add_request(req_state)
+        
         for i, req_id in enumerate(req_data.req_ids):
             req_state: SamplingRequestState = self.requests[req_id]
 


### PR DESCRIPTION
A small experiment just to verify that preemption is possible: output is correct if we remove a few requests from the decoding batch, and re-add them later on

* `countdown_inference.py` a small output validation script with four requests running
* `scheduler.py`: preempt two requests at step 100, reintroduce the first at step 200, the second at step 230. It simply removes and readds them to the running queue
* `spyre_model_runner.py`: removes/readds the `input_batch` of each request