### PR TITLE
[WIP] Pre-allocate all blocks in spyre scheduler

### DIFF
--- a/sendnn_inference/v1/core/scheduler.py
+++ b/sendnn_inference/v1/core/scheduler.py
@@ -5,6 +5,7 @@ from collections import deque
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterable, Union
 
+
 from vllm.logger import init_logger
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.metrics.stats import SchedulerStats
@@ -151,10 +152,6 @@ class BlockAllocationParams:
     num_new_tokens: int
     num_new_computed_tokens: int
     new_computed_blocks: KVCacheBlocks | None
-    num_lookahead_tokens: int
-    num_external_computed_tokens: int
-    delay_cache_blocks: bool
-    num_encoder_tokens: int
 
 
 class ChunkedPrefillSpyreScheduler(SpyreScheduler):
@@ -278,12 +275,15 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         # This basically replicates what the scheduler already does, but
         # scattered all over the place in `schedule()`
         if request.num_computed_tokens == 0:
+            old_log_stats = self.kv_cache_manager.log_stats
+            self.kv_cache_manager.log_stats = False
             new_computed_blocks, num_new_local_computed_tokens = (
                 self.kv_cache_manager.get_computed_blocks(request)
             )
+            self.kv_cache_manager.log_stats = old_log_stats
             num_computed_tokens = num_new_local_computed_tokens
         else:
-            new_computed_blocks = self.kv_cache_manager.empty_kv_cache_blocks
+            new_computed_blocks = self.kv_cache_manager.create_kv_cache_blocks(blocks=tuple())
             num_new_local_computed_tokens = 0
             num_computed_tokens = request.num_computed_tokens
 
@@ -297,44 +297,11 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
 
         num_new_tokens = num_tokens - num_computed_tokens
 
-        num_encoder_tokens = 0
-        if self.is_encoder_decoder and request.has_encoder_inputs:
-            # Max: for now I think each request gets the full encoder budget
-            # since we don't prefill more than request at a time
-            encoder_compute_budget = self.max_num_encoder_input_tokens
-            token_budget = self.max_num_scheduled_tokens
-            num_new_prompt_tokens = request.num_tokens - num_computed_tokens
-            num_new_prompt_tokens = min(num_new_prompt_tokens, token_budget)
-            (
-                encoder_inputs_to_schedule,
-                updated_new_prompt_tokens,
-                new_encoder_compute_budget,
-                external_load_encoder_input,
-            ) = self._try_schedule_encoder_inputs(
-                request,
-                num_computed_tokens,
-                num_new_prompt_tokens,
-                encoder_compute_budget,
-                shift_computed_tokens=1 if self.use_eagle else 0,
-            )
-            if updated_new_prompt_tokens != num_new_prompt_tokens:
-                # TODO: improve handling of this case
-                raise ValueError("Encoder request cannot be scheduled")
-
-            if encoder_inputs_to_schedule:
-                num_encoder_tokens = sum(
-                    request.get_num_encoder_embeds(i) for i in encoder_inputs_to_schedule
-                )
-
         return BlockAllocationParams(
             original_request_computed_tokens=request.num_computed_tokens,
             num_new_tokens=num_new_tokens,
             num_new_computed_tokens=num_new_local_computed_tokens,
             new_computed_blocks=new_computed_blocks,
-            num_lookahead_tokens=0,  # we don't support spec decoding
-            num_external_computed_tokens=0,  # we don't support KV cache transfers
-            delay_cache_blocks=False,  # we don't support KV cache loading
-            num_encoder_tokens=num_encoder_tokens,
         )
 
     def _are_blocks_available(self, request: Request, block_params: BlockAllocationParams) -> bool:
@@ -351,10 +318,9 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
             request_id=request.request_id,
             num_tokens=full_num_tokens,
             new_computed_blocks=block_params.new_computed_blocks.blocks,
-            num_encoder_tokens=block_params.num_encoder_tokens,
+            num_encoder_tokens=0,
             total_computed_tokens=total_computed_tokens,
             num_tokens_main_model=full_num_tokens,
-            apply_admission_cap=True,
         )
         return num_blocks_to_allocate <= self.kv_cache_manager.block_pool.get_num_free_blocks()
 
@@ -369,6 +335,7 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
             request,
             # Total number of tokens excluding the already computed tokens
             num_new_tokens=block_params.num_new_tokens,
+            delay_cache_blocks=True,  # no need to cache blocks here
             # no other parameters are required here because we're
             # not touching the pre-computed blocks
         )

--- a/sendnn_inference/v1/core/scheduler.py
+++ b/sendnn_inference/v1/core/scheduler.py
@@ -378,7 +378,7 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
             request = holdback_queue[0]
 
             if self.can_schedule_prefill(request):
-                block_params = self._get_block_params_for_request(request)
+                block_params = self._get_block_params_for_request(request, True)
                 block_alloc_params[request.request_id] = block_params
                 if not self._are_blocks_available(request, block_params):
                     # can't schedule the request

--- a/sendnn_inference/v1/core/scheduler.py
+++ b/sendnn_inference/v1/core/scheduler.py
@@ -2,12 +2,14 @@
 
 import math
 from collections import deque
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterable, Union
 
 from vllm.logger import init_logger
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.metrics.stats import SchedulerStats
 from vllm.v1.request import Request, RequestStatus
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 
 import sendnn_inference.envs as envs_spyre
 from sendnn_inference.platform import SpyrePlatform
@@ -141,6 +143,20 @@ class PoolingSpyreScheduler(SpyreScheduler):
         ]
 
 
+@dataclass
+class BlockAllocationParams:
+    """Parameters for block allocation. See KVCacheManager.allocate_slots()"""
+
+    original_request_computed_tokens: int
+    num_new_tokens: int
+    num_new_computed_tokens: int
+    new_computed_blocks: KVCacheBlocks | None
+    num_lookahead_tokens: int
+    num_external_computed_tokens: int
+    delay_cache_blocks: bool
+    num_encoder_tokens: int
+
+
 class ChunkedPrefillSpyreScheduler(SpyreScheduler):
     """
     Chunked-Prefill Scheduling policy
@@ -253,6 +269,121 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         # Otherwise just account for the left padding
         return computed_tokens - left_padding
 
+    def _get_block_params_for_request(
+        self, request: Request, max_output: bool = False
+    ) -> BlockAllocationParams:
+        """
+        Returns the block parameters for the given request.
+        """
+        # This basically replicates what the scheduler already does, but
+        # scattered all over the place in `schedule()`
+        if request.num_computed_tokens == 0:
+            new_computed_blocks, num_new_local_computed_tokens = (
+                self.kv_cache_manager.get_computed_blocks(request)
+            )
+            num_computed_tokens = num_new_local_computed_tokens
+        else:
+            new_computed_blocks = self.kv_cache_manager.empty_kv_cache_blocks
+            num_new_local_computed_tokens = 0
+            num_computed_tokens = request.num_computed_tokens
+
+        num_tokens = request.num_tokens
+        if max_output:
+            assert request.sampling_params is not None
+            assert request.sampling_params.max_tokens is not None
+            prompt_tokens = request.num_prompt_tokens
+            max_tokens = request.sampling_params.max_tokens
+            num_tokens = prompt_tokens + max_tokens
+
+        num_new_tokens = num_tokens - num_computed_tokens
+
+        num_encoder_tokens = 0
+        if self.is_encoder_decoder and request.has_encoder_inputs:
+            # Max: for now I think each request gets the full encoder budget
+            # since we don't prefill more than request at a time
+            encoder_compute_budget = self.max_num_encoder_input_tokens
+            token_budget = self.max_num_scheduled_tokens
+            num_new_prompt_tokens = request.num_tokens - num_computed_tokens
+            num_new_prompt_tokens = min(num_new_prompt_tokens, token_budget)
+            (
+                encoder_inputs_to_schedule,
+                updated_new_prompt_tokens,
+                new_encoder_compute_budget,
+                external_load_encoder_input,
+            ) = self._try_schedule_encoder_inputs(
+                request,
+                num_computed_tokens,
+                num_new_prompt_tokens,
+                encoder_compute_budget,
+                shift_computed_tokens=1 if self.use_eagle else 0,
+            )
+            if updated_new_prompt_tokens != num_new_prompt_tokens:
+                # TODO: improve handling of this case
+                raise ValueError("Encoder request cannot be scheduled")
+
+            if encoder_inputs_to_schedule:
+                num_encoder_tokens = sum(
+                    request.get_num_encoder_embeds(i) for i in encoder_inputs_to_schedule
+                )
+
+        return BlockAllocationParams(
+            original_request_computed_tokens=request.num_computed_tokens,
+            num_new_tokens=num_new_tokens,
+            num_new_computed_tokens=num_new_local_computed_tokens,
+            new_computed_blocks=new_computed_blocks,
+            num_lookahead_tokens=0,  # we don't support spec decoding
+            num_external_computed_tokens=0,  # we don't support KV cache transfers
+            delay_cache_blocks=False,  # we don't support KV cache loading
+            num_encoder_tokens=num_encoder_tokens,
+        )
+
+    def _are_blocks_available(self, request: Request, block_params: BlockAllocationParams) -> bool:
+        """
+        Checks if there are enough blocks for this request to run
+        until it's max-tokens are reached.
+        """
+        full_num_tokens = min(block_params.num_new_tokens, self.max_model_len)
+        num_local_computed_tokens = (
+            request.num_computed_tokens + block_params.num_new_computed_tokens
+        )
+        total_computed_tokens = min(num_local_computed_tokens, self.max_model_len)
+        num_blocks_to_allocate = self.kv_cache_manager.coordinator.get_num_blocks_to_allocate(
+            request_id=request.request_id,
+            num_tokens=full_num_tokens,
+            new_computed_blocks=block_params.new_computed_blocks.blocks,
+            num_encoder_tokens=block_params.num_encoder_tokens,
+            total_computed_tokens=total_computed_tokens,
+            num_tokens_main_model=full_num_tokens,
+            apply_admission_cap=True,
+        )
+        return num_blocks_to_allocate <= self.kv_cache_manager.block_pool.get_num_free_blocks()
+
+    def _preallocate_blocks(
+        self, request: Request, block_params: BlockAllocationParams, outputs: SchedulerOutput
+    ):
+        # here we need to temporarily undo the effect of _update_after_schedule
+        computed_tokens_copy = request.num_computed_tokens
+        request.num_computed_tokens = block_params.original_request_computed_tokens
+
+        new_blocks = self.kv_cache_manager.allocate_slots(
+            request,
+            # Total number of tokens excluding the already computed tokens
+            num_new_tokens=block_params.num_new_tokens,
+            # no other parameters are required here because we're
+            # not touching the pre-computed blocks
+        )
+        request.num_computed_tokens = computed_tokens_copy
+        assert new_blocks is not None
+
+        new_block_ids = tuple(
+            [block.block_id for block in block_list] for block_list in new_blocks.blocks
+        )
+
+        for new_request in outputs.scheduled_new_reqs:
+            if new_request.req_id == request.request_id:
+                for prefix, suffix in zip(new_request.block_ids, new_block_ids):
+                    prefix.extend(suffix)
+
     def schedule(self) -> "SchedulerOutput":
         """
         The chunked prefill scheduling policy is enforced in this method, then
@@ -273,9 +404,19 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         while self.skipped_waiting:
             holdback_queue.append(self.skipped_waiting.pop_request())
 
+        block_alloc_params = dict[str, BlockAllocationParams]()
+
         # Check if new requests can be scheduled for prefill
         while holdback_queue:
-            if self.can_schedule_prefill(holdback_queue[0]):
+            request = holdback_queue[0]
+
+            if self.can_schedule_prefill(request):
+                block_params = self._get_block_params_for_request(request)
+                block_alloc_params[request.request_id] = block_params
+                if not self._are_blocks_available(request, block_params):
+                    # can't schedule the request
+                    break
+
                 new_request = holdback_queue.popleft()
 
                 logger.debug(
@@ -363,7 +504,11 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         # scheduled (i.e., moved from waiting to running by the base
         # scheduler).
         if new_prefill_candidates:
-            self.ongoing_prefills.extend(r for r in new_prefill_candidates if r in self.running)
+            new_prefills = [r for r in new_prefill_candidates if r in self.running]
+            for prefill in new_prefills:
+                block_params = block_alloc_params[prefill.request_id]
+                self._preallocate_blocks(prefill, block_params, outputs)
+            self.ongoing_prefills.extend(new_prefills)
 
         # restore holdbacks after running the base scheduler
         self.running = self.running + running_holdback

--- a/sendnn_inference/v1/worker/spyre_model_runner.py
+++ b/sendnn_inference/v1/worker/spyre_model_runner.py
@@ -1142,7 +1142,9 @@ class ChunkedPrefillModelRunner(
         max_n_blocks = 0
 
         for req_id in req_ids:
-            max_n_blocks = max(max_n_blocks, len(self._get_blocks(req_id)))
+            req_state: SamplingRequestState = self.requests[req_id]
+            actual_blocks = math.ceil((req_state.num_computed_tokens + 1) / self.block_size)
+            max_n_blocks = max(max_n_blocks, actual_blocks)
 
         # We'll calculate tkv on the fly, it is the max num computed tokens
         # of a request since there is no tokens left padding, only for blocks
@@ -1153,8 +1155,16 @@ class ChunkedPrefillModelRunner(
 
             req_state = self.requests[req_id]
 
+            # input token and position of the token generated in the last step
+            generation_token = req_state.output_token_ids[-1]
+            input_tokens.append([generation_token])
+            input_positions.append([req_state.num_computed_tokens])
+            actual_blocks = math.ceil((req_state.num_computed_tokens + 1) / self.block_size)
+
             # filling block table with padding blocks to make it rectangular
             blocks = self._get_blocks(req_id)
+            # since we preallocate the block list can go beyond the current block
+            blocks = blocks[:actual_blocks]
             left_pad_blocks_count = max_n_blocks - len(blocks)
             block_ids = [0] * left_pad_blocks_count + blocks
             block_table.append(block_ids)
@@ -1166,11 +1176,6 @@ class ChunkedPrefillModelRunner(
             offset = req_state.num_computed_tokens % self.block_size
             slot = [start_slot + offset]
             slot_mapping.append(slot)
-
-            # input token and position of the token generated in the last step
-            generation_token = req_state.output_token_ids[-1]
-            input_tokens.append([generation_token])
-            input_positions.append([req_state.num_computed_tokens])
 
             # Calculate left padding on the fly
             left_padding = left_pad_blocks_count * self.block_size

--- a/tests/e2e/test_spyre_cp_scheduler_steps.py
+++ b/tests/e2e/test_spyre_cp_scheduler_steps.py
@@ -63,7 +63,7 @@ def test_prefill_tkv_too_big(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": ["0"],
-            "n_used_blocks": 1,
+            "n_used_blocks": 2,
         },
         # Here we cannot schedule sequence 1. By shifting sequence 0 by
         # 1 block its max tkv would exceed the max model length
@@ -75,7 +75,7 @@ def test_prefill_tkv_too_big(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": ["0"],
-            "n_used_blocks": 1,
+            "n_used_blocks": 2,
         },
         {
             # Prefill sequence 1, tkv large enough to prefill w/o tkv shift
@@ -86,8 +86,7 @@ def test_prefill_tkv_too_big(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": ["1"],
-            # 2 + 2 (prefill (2 block) + 17 decodes in the last block)
-            "n_used_blocks": 3,
+            "n_used_blocks": 4,
         },
         {
             # Decode sequences 0 and 1
@@ -200,7 +199,7 @@ def test_requests_exceed_batch_tkv_limit(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": ["0"],
-            "n_used_blocks": 1,
+            "n_used_blocks": 2,
         },
         # Note: we cannot prefill seq 1 as the volumetric limit
         # max_batch_tkv_limit is exceeded: 129 < 130
@@ -320,7 +319,7 @@ def test_single_cp_prefill(
             "waiting": [],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 8,
+            "n_used_blocks": 9,
         },
         {
             # Prefill sequence 0 chunk 1
@@ -329,7 +328,7 @@ def test_single_cp_prefill(
             "waiting": [],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 8,
+            "n_used_blocks": 9,
         },
         {
             # Prefill sequence 0 chunk 2
@@ -338,7 +337,7 @@ def test_single_cp_prefill(
             "waiting": [],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 8,
+            "n_used_blocks": 9,
         },
         {
             # Prefill sequence 0 chunk 3
@@ -347,7 +346,7 @@ def test_single_cp_prefill(
             "waiting": [],
             "running": ["0"],
             "request_outputs": ["0"],
-            "n_used_blocks": 8,
+            "n_used_blocks": 9,
         },
         {
             # Decode sequence 0
@@ -456,7 +455,7 @@ def test_cp_prefill_interleave1(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 9,
+            "n_used_blocks": 10,
         },
         {
             # Decode 2 of request 0.
@@ -465,7 +464,7 @@ def test_cp_prefill_interleave1(
             "waiting": [],
             "running": ["0", "1"],
             "request_outputs": ["0"],
-            "n_used_blocks": 9,
+            "n_used_blocks": 10,
         },
         {
             # Chunk 1 of request 1 prefill
@@ -475,7 +474,7 @@ def test_cp_prefill_interleave1(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 9,
+            "n_used_blocks": 10,
         },
         {
             # Decode 3 of request 0.
@@ -484,7 +483,7 @@ def test_cp_prefill_interleave1(
             "waiting": [],
             "running": ["0", "1"],
             "request_outputs": ["0"],
-            "n_used_blocks": 9,
+            "n_used_blocks": 10,
         },
         {
             # Chunk 2 of request 1 prefill
@@ -494,7 +493,7 @@ def test_cp_prefill_interleave1(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 9,
+            "n_used_blocks": 10,
         },
         {
             # Decode 4 of request 0.
@@ -503,7 +502,7 @@ def test_cp_prefill_interleave1(
             "waiting": [],
             "running": ["0", "1"],
             "request_outputs": ["0"],
-            "n_used_blocks": 9,
+            "n_used_blocks": 10,
         },
         {
             # Chunk 3 of request 1 prefill.
@@ -514,7 +513,7 @@ def test_cp_prefill_interleave1(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": ["1"],
-            "n_used_blocks": 9,
+            "n_used_blocks": 10,
         },
         {
             # Decode 5 of request 0.
@@ -634,7 +633,7 @@ def test_cp_prefill_no_interleave(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 9,
+            "n_used_blocks": 10,
         },
         {
             # Chunk 1 of request 1 prefill
@@ -644,7 +643,7 @@ def test_cp_prefill_no_interleave(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 9,
+            "n_used_blocks": 10,
         },
         {
             # Chunk 2 of request 1 prefill
@@ -654,7 +653,7 @@ def test_cp_prefill_no_interleave(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 9,
+            "n_used_blocks": 10,
         },
         {
             # Chunk 3 of request 1 prefill.
@@ -665,7 +664,7 @@ def test_cp_prefill_no_interleave(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": ["1"],
-            "n_used_blocks": 9,
+            "n_used_blocks": 10,
         },
         {
             # Both requests start decoding.
@@ -835,7 +834,7 @@ def test_cp_prefill_interleave2(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 9,
+            "n_used_blocks": 10,
         },
         {
             # Decode 3 of request 0.
@@ -844,7 +843,7 @@ def test_cp_prefill_interleave2(
             "waiting": [],
             "running": ["0", "1"],
             "request_outputs": ["0"],
-            "n_used_blocks": 9,
+            "n_used_blocks": 10,
         },
         {
             # Chunk 1 of request 1 prefill
@@ -854,7 +853,7 @@ def test_cp_prefill_interleave2(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 9,
+            "n_used_blocks": 10,
         },
         {
             # Decode 4 of request 0.
@@ -863,7 +862,7 @@ def test_cp_prefill_interleave2(
             "waiting": [],
             "running": ["0", "1"],
             "request_outputs": ["0"],
-            "n_used_blocks": 9,
+            "n_used_blocks": 10,
         },
         {
             # Chunk 2 of request 1 prefill
@@ -873,7 +872,7 @@ def test_cp_prefill_interleave2(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 9,
+            "n_used_blocks": 10,
         },
         {
             # Decode 5 of request 0.
@@ -882,7 +881,7 @@ def test_cp_prefill_interleave2(
             "waiting": [],
             "running": ["0", "1"],
             "request_outputs": ["0"],
-            "n_used_blocks": 9,
+            "n_used_blocks": 10,
         },
         {
             # Chunk 3 of request 1 prefill.
@@ -893,7 +892,7 @@ def test_cp_prefill_interleave2(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": ["1"],
-            "n_used_blocks": 9,
+            "n_used_blocks": 10,
         },
         {
             # Decode 6 of request 0.
@@ -1070,8 +1069,7 @@ def test_prefill_tkv_too_big2(
             "waiting": [],
             "running": ["2", "0"],
             "request_outputs": ["2"],
-            # 3 - 2 (finished seq 1) + 2 (prefill + 50 decodes in new block)
-            "n_used_blocks": 2,
+            "n_used_blocks": 3,
         },
         {
             # Decode 4 of sequence 0
@@ -1083,7 +1081,7 @@ def test_prefill_tkv_too_big2(
             "running": ["2"],
             "request_outputs": ["2", "0"],
             "finished_requests": ["0"],
-            "n_used_blocks": 1,
+            "n_used_blocks": 2,
         },
         {
             # Decode 2 of sequence 2
@@ -1092,7 +1090,7 @@ def test_prefill_tkv_too_big2(
             "waiting": [],
             "running": ["2"],
             "request_outputs": ["2"],
-            "n_used_blocks": 1,
+            "n_used_blocks": 2,
         },
         {
             # Decode 49 of sequence 2

--- a/tests/e2e/test_spyre_cp_scheduler_steps.py
+++ b/tests/e2e/test_spyre_cp_scheduler_steps.py
@@ -314,12 +314,13 @@ def test_single_cp_prefill(
         },
         {
             # Prefill sequence 0 chunk 0
+            # all 8 blocks are preallocated
             "step": 1,
             "tkv": 512,
             "waiting": [],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 2,
+            "n_used_blocks": 8,
         },
         {
             # Prefill sequence 0 chunk 1
@@ -328,21 +329,19 @@ def test_single_cp_prefill(
             "waiting": [],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 4,
+            "n_used_blocks": 8,
         },
         {
             # Prefill sequence 0 chunk 2
-            # total blocks in use: 6
             "step": 3,
             "tkv": 512,
             "waiting": [],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 6,
+            "n_used_blocks": 8,
         },
         {
             # Prefill sequence 0 chunk 3
-            # total blocks in use: 8
             "step": 4,
             "tkv": 512,
             "waiting": [],
@@ -441,7 +440,7 @@ def test_cp_prefill_interleave1(
         },
         {
             # Request 0 starts decoding.
-            # Request 1 can't be scheduled do to a restriction on
+            # Request 1 can't be scheduled due to a restriction on
             # consecutive prefills. Token 1 is generated
             "step": 2,
             "tkv": 11,
@@ -457,7 +456,7 @@ def test_cp_prefill_interleave1(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 3,
+            "n_used_blocks": 9,
         },
         {
             # Decode 2 of request 0.
@@ -466,7 +465,7 @@ def test_cp_prefill_interleave1(
             "waiting": [],
             "running": ["0", "1"],
             "request_outputs": ["0"],
-            "n_used_blocks": 3,
+            "n_used_blocks": 9,
         },
         {
             # Chunk 1 of request 1 prefill
@@ -476,7 +475,7 @@ def test_cp_prefill_interleave1(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 5,
+            "n_used_blocks": 9,
         },
         {
             # Decode 3 of request 0.
@@ -485,7 +484,7 @@ def test_cp_prefill_interleave1(
             "waiting": [],
             "running": ["0", "1"],
             "request_outputs": ["0"],
-            "n_used_blocks": 5,
+            "n_used_blocks": 9,
         },
         {
             # Chunk 2 of request 1 prefill
@@ -495,7 +494,7 @@ def test_cp_prefill_interleave1(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 7,
+            "n_used_blocks": 9,
         },
         {
             # Decode 4 of request 0.
@@ -504,7 +503,7 @@ def test_cp_prefill_interleave1(
             "waiting": [],
             "running": ["0", "1"],
             "request_outputs": ["0"],
-            "n_used_blocks": 7,
+            "n_used_blocks": 9,
         },
         {
             # Chunk 3 of request 1 prefill.
@@ -635,7 +634,7 @@ def test_cp_prefill_no_interleave(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 3,
+            "n_used_blocks": 9,
         },
         {
             # Chunk 1 of request 1 prefill
@@ -645,7 +644,7 @@ def test_cp_prefill_no_interleave(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 5,
+            "n_used_blocks": 9,
         },
         {
             # Chunk 2 of request 1 prefill
@@ -655,7 +654,7 @@ def test_cp_prefill_no_interleave(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 7,
+            "n_used_blocks": 9,
         },
         {
             # Chunk 3 of request 1 prefill.
@@ -836,7 +835,7 @@ def test_cp_prefill_interleave2(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 3,
+            "n_used_blocks": 9,
         },
         {
             # Decode 3 of request 0.
@@ -845,7 +844,7 @@ def test_cp_prefill_interleave2(
             "waiting": [],
             "running": ["0", "1"],
             "request_outputs": ["0"],
-            "n_used_blocks": 3,
+            "n_used_blocks": 9,
         },
         {
             # Chunk 1 of request 1 prefill
@@ -855,7 +854,7 @@ def test_cp_prefill_interleave2(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 5,
+            "n_used_blocks": 9,
         },
         {
             # Decode 4 of request 0.
@@ -864,7 +863,7 @@ def test_cp_prefill_interleave2(
             "waiting": [],
             "running": ["0", "1"],
             "request_outputs": ["0"],
-            "n_used_blocks": 5,
+            "n_used_blocks": 9,
         },
         {
             # Chunk 2 of request 1 prefill
@@ -874,7 +873,7 @@ def test_cp_prefill_interleave2(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 7,
+            "n_used_blocks": 9,
         },
         {
             # Decode 5 of request 0.
@@ -883,7 +882,7 @@ def test_cp_prefill_interleave2(
             "waiting": [],
             "running": ["0", "1"],
             "request_outputs": ["0"],
-            "n_used_blocks": 7,
+            "n_used_blocks": 9,
         },
         {
             # Chunk 3 of request 1 prefill.

--- a/tests/e2e/test_spyre_pc_scheduler_steps.py
+++ b/tests/e2e/test_spyre_pc_scheduler_steps.py
@@ -81,10 +81,10 @@ def test_prefix_hit_within_batch(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 3,
+            "n_used_blocks": 4,
             "n_prefix_hits": 0,
-            "block_tables": {"0": [1, 2, 3]},
-            "block_ref_count": {1: 1, 2: 1, 3: 1},
+            "block_tables": {"0": [1, 2, 3, 4]},
+            "block_ref_count": {1: 1, 2: 1, 3: 1, 4: 1},
         },
         {  # prefill chunk 2 seq 0
             "step": 2,
@@ -92,10 +92,10 @@ def test_prefix_hit_within_batch(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": ["0"],
-            "n_used_blocks": 3,
+            "n_used_blocks": 4,
             "n_prefix_hits": 0,
-            "block_tables": {"0": [1, 2, 3]},
-            "block_ref_count": {1: 1, 2: 1, 3: 1},
+            "block_tables": {"0": [1, 2, 3, 4]},
+            "block_ref_count": {1: 1, 2: 1, 3: 1, 4: 1},
         },
         {  # prefill chunk 2 seq 1
             # prefix hit!
@@ -104,13 +104,13 @@ def test_prefix_hit_within_batch(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": ["1"],
-            "n_used_blocks": 4,
+            "n_used_blocks": 5,
             "n_prefix_hits": 0,
             # each chunk has two blocks. Due to padding, the first chunk has
             # only one usable block
             "n_cached_blocks": 1,
-            "block_tables": {"0": [1, 2, 3], "1": [1, 2, 4]},
-            "block_ref_count": {1: 2, 2: 2, 3: 1, 4: 1},
+            "block_tables": {"0": [1, 2, 3, 4], "1": [1, 2, 5]},
+            "block_ref_count": {1: 2, 2: 2, 3: 1, 4: 1, 5: 1},
         },
         {
             # Decode 1 of request 0.
@@ -361,7 +361,7 @@ def test_prefix_hit_decoded_block_within_batch(
             "waiting": [],
             "running": ["0"],
             "request_outputs": ["0"],
-            "n_used_blocks": 2,
+            "n_used_blocks": 4,
             "n_prefix_hits": 0,
         },
         {
@@ -371,7 +371,7 @@ def test_prefix_hit_decoded_block_within_batch(
             "waiting": [],
             "running": ["0"],
             "request_outputs": ["0"],
-            "n_used_blocks": 2,
+            "n_used_blocks": 4,
         },
         {
             # Decode 3 of request 0.
@@ -381,7 +381,7 @@ def test_prefix_hit_decoded_block_within_batch(
             "waiting": [],
             "running": ["0"],
             "request_outputs": ["0"],
-            "n_used_blocks": 3,
+            "n_used_blocks": 4,
         },
         {
             # Decode 66 of request 0.
@@ -390,7 +390,7 @@ def test_prefix_hit_decoded_block_within_batch(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": ["0"],
-            "n_used_blocks": 3,
+            "n_used_blocks": 4,
         },
         {  # prefill chunk 2 seq 1
             # no prefix hit, always recompute last chunk
@@ -401,12 +401,12 @@ def test_prefix_hit_decoded_block_within_batch(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": ["1"],
-            "n_used_blocks": 5,
+            "n_used_blocks": 6,
             "n_prefix_hits": 0,
             "n_cached_blocks": 2,
             "block_tables": {
-                "0": [1, 2, 3],
-                "1": [1, 2, 4, 5],
+                "0": [1, 2, 3, 4],
+                "1": [1, 2, 5, 6],
                 # Note: new block id 4 instead of 3 here as vLLM does not
                 # currently deduplicate decoded blocks and so do we:
                 # https://github.com/vllm-project/vllm/blob/1166c31cc78073378a16509fbbbed4cb4f040a4d/vllm/v1/core/block_pool.py#L46
@@ -518,7 +518,7 @@ def test_prefix_hit_not_in_batch(
             "waiting": [],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 3,
+            "n_used_blocks": 4,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 2 seq 0
@@ -527,10 +527,10 @@ def test_prefix_hit_not_in_batch(
             "waiting": [],
             "running": ["0"],
             "request_outputs": ["0"],
-            "n_used_blocks": 3,
+            "n_used_blocks": 4,
             "n_prefix_hits": 0,
             "block_tables": {
-                "0": [1, 2, 3],
+                "0": [1, 2, 3, 4],
             },
         },
         {
@@ -673,7 +673,7 @@ def test_limit_blocks_no_prefix_hit(
             "waiting": [],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 3,
+            "n_used_blocks": 4,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 2 seq 0
@@ -682,7 +682,7 @@ def test_limit_blocks_no_prefix_hit(
             "waiting": [],
             "running": ["0"],
             "request_outputs": ["0"],
-            "n_used_blocks": 3,
+            "n_used_blocks": 4,
             "n_prefix_hits": 0,
         },
         {
@@ -702,7 +702,7 @@ def test_limit_blocks_no_prefix_hit(
             "waiting": [],
             "running": ["1"],
             "request_outputs": [],
-            "n_used_blocks": 3,
+            "n_used_blocks": 4,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 2 seq 1
@@ -711,7 +711,7 @@ def test_limit_blocks_no_prefix_hit(
             "waiting": [],
             "running": ["1"],
             "request_outputs": ["1"],
-            "n_used_blocks": 3,
+            "n_used_blocks": 4,
             "n_prefix_hits": 0,
         },
         {
@@ -732,7 +732,7 @@ def test_limit_blocks_no_prefix_hit(
             "waiting": [],
             "running": ["2"],
             "request_outputs": [],
-            "n_used_blocks": 3,
+            "n_used_blocks": 4,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 2 seq 2
@@ -741,7 +741,7 @@ def test_limit_blocks_no_prefix_hit(
             "waiting": [],
             "running": ["2"],
             "request_outputs": ["2"],
-            "n_used_blocks": 3,
+            "n_used_blocks": 4,
             "n_prefix_hits": 0,
         },
         {
@@ -867,10 +867,10 @@ def test_double_prefix_hit_within_batch(
             "waiting": ["1", "2", "3"],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 3,
+            "n_used_blocks": 4,
             "n_prefix_hits": 0,
-            "block_tables": {"0": [1, 2, 3]},
-            "block_ref_count": {1: 1, 2: 1, 3: 1},
+            "block_tables": {"0": [1, 2, 3, 4]},
+            "block_ref_count": {1: 1, 2: 1, 3: 1, 4: 1},
         },
         {  # prefill chunk 2 seq 0
             "step": 2,
@@ -878,10 +878,10 @@ def test_double_prefix_hit_within_batch(
             "waiting": ["1", "2", "3"],
             "running": ["0"],
             "request_outputs": ["0"],
-            "n_used_blocks": 3,
+            "n_used_blocks": 4,
             "n_prefix_hits": 0,
-            "block_tables": {"0": [1, 2, 3]},
-            "block_ref_count": {1: 1, 2: 1, 3: 1},
+            "block_tables": {"0": [1, 2, 3, 4]},
+            "block_ref_count": {1: 1, 2: 1, 3: 1, 4: 1},
         },
         {  # prefill chunk 2 seq 1
             # prefix hit!
@@ -891,11 +891,11 @@ def test_double_prefix_hit_within_batch(
             "waiting": ["2", "3"],
             "running": ["1", "0"],
             "request_outputs": ["1"],
-            "n_used_blocks": 4,
+            "n_used_blocks": 5,
             "n_prefix_hits": 0,
-            "block_tables": {"0": [1, 2, 3], "1": [1, 2, 4]},
-            "block_ref_count": {1: 2, 2: 2, 3: 1, 4: 1},
-            "prefill_slot_mappings": {"1": [0, 4]},  # Fully masked prefill
+            "block_tables": {"0": [1, 2, 3, 4], "1": [1, 2, 5]},
+            "block_ref_count": {1: 2, 2: 2, 3: 1, 4: 1, 5: 1},
+            "prefill_slot_mappings": {"1": [0, 5]},  # Fully masked prefill
         },
         {  # prefill chunk 1 seq 2
             "step": 4,
@@ -903,10 +903,10 @@ def test_double_prefix_hit_within_batch(
             "waiting": ["3"],
             "running": ["2", "1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 7,
+            "n_used_blocks": 9,
             "n_prefix_hits": 0,
-            "block_tables": {"0": [1, 2, 3], "1": [1, 2, 4], "2": [5, 6, 7]},
-            "block_ref_count": {1: 2, 2: 2, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1},
+            "block_tables": {"0": [1, 2, 3, 4], "1": [1, 2, 5], "2": [6, 7, 8, 9]},
+            "block_ref_count": {1: 2, 2: 2, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1},
         },
         {  # prefill chunk 2 seq 2
             "step": 5,
@@ -914,10 +914,10 @@ def test_double_prefix_hit_within_batch(
             "waiting": ["3"],
             "running": ["2", "1", "0"],
             "request_outputs": ["2"],
-            "n_used_blocks": 7,
+            "n_used_blocks": 9,
             "n_prefix_hits": 0,
-            "block_tables": {"0": [1, 2, 3], "1": [1, 2, 4], "2": [5, 6, 7]},
-            "block_ref_count": {1: 2, 2: 2, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1},
+            "block_tables": {"0": [1, 2, 3, 4], "1": [1, 2, 5], "2": [6, 7, 8, 9]},
+            "block_ref_count": {1: 2, 2: 2, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1},
         },
         {  # prefill chunk 2 seq 3
             # prefix hit!
@@ -927,10 +927,10 @@ def test_double_prefix_hit_within_batch(
             "waiting": [],
             "running": ["3", "2", "1", "0"],
             "request_outputs": ["3"],
-            "n_used_blocks": 8,
+            "n_used_blocks": 10,
             "n_prefix_hits": 0,
-            "block_tables": {"0": [1, 2, 3], "1": [1, 2, 4], "2": [5, 6, 7], "3": [1, 2, 8]},
-            "block_ref_count": {1: 3, 2: 3, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1},
+            "block_tables": {"0": [1, 2, 3, 4], "1": [1, 2, 5], "2": [6, 7, 8, 9], "3": [1, 2, 10]},
+            "block_ref_count": {1: 3, 2: 3, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1},
         },
         {
             # Decode 1 of request 0, 1, 2, 3
@@ -1048,7 +1048,7 @@ def test_limit_blocks_prefix_hit(
             "waiting": [],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 3,
+            "n_used_blocks": 4,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 2 seq 0
@@ -1057,7 +1057,7 @@ def test_limit_blocks_prefix_hit(
             "waiting": [],
             "running": ["0"],
             "request_outputs": ["0"],
-            "n_used_blocks": 3,
+            "n_used_blocks": 4,
             "n_prefix_hits": 0,
         },
         {
@@ -1077,7 +1077,7 @@ def test_limit_blocks_prefix_hit(
             "waiting": [],
             "running": ["1"],
             "request_outputs": [],
-            "n_used_blocks": 3,
+            "n_used_blocks": 4,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 2 seq 1
@@ -1086,7 +1086,7 @@ def test_limit_blocks_prefix_hit(
             "waiting": [],
             "running": ["1"],
             "request_outputs": ["1"],
-            "n_used_blocks": 3,
+            "n_used_blocks": 4,
             "n_prefix_hits": 0,
         },
         {
@@ -1212,7 +1212,7 @@ def test_multi_chunk_full_match(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 6,
+            "n_used_blocks": 7,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 2 seq 0
@@ -1221,7 +1221,7 @@ def test_multi_chunk_full_match(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 6,
+            "n_used_blocks": 7,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 3 seq 0
@@ -1230,12 +1230,12 @@ def test_multi_chunk_full_match(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": ["0"],
-            "n_used_blocks": 6,
+            "n_used_blocks": 7,
             "n_prefix_hits": 0,
             # up until this point nothing interesting happened
             # with the block table
-            "block_tables": {"0": [1, 2, 3, 4, 5, 6]},
-            "block_ref_count": {1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1},
+            "block_tables": {"0": [1, 2, 3, 4, 5, 6, 7]},
+            "block_ref_count": {1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1},
         },
         {  # prefill chunk 3 seq 1
             # prefix hit!
@@ -1245,14 +1245,14 @@ def test_multi_chunk_full_match(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": ["1"],
-            "n_used_blocks": 7,
+            "n_used_blocks": 8,
             "n_prefix_hits": 0,
             # The number of cached blocks is determined up front
             "n_cached_blocks": 4,  # can reuse the first two chunk (4 blocks)
             # Now, although the last chunk has to be recomputed,
             # the blocks are still shared.
-            "block_tables": {"0": [1, 2, 3, 4, 5, 6], "1": [1, 2, 3, 4, 5, 7]},
-            "block_ref_count": {1: 2, 2: 2, 3: 2, 4: 2, 5: 2, 6: 1, 7: 1},
+            "block_tables": {"0": [1, 2, 3, 4, 5, 6, 7], "1": [1, 2, 3, 4, 5, 8]},
+            "block_ref_count": {1: 2, 2: 2, 3: 2, 4: 2, 5: 2, 6: 1, 7: 1, 8: 1},
         },
         {
             # Decode 1 of request 0.
@@ -1370,7 +1370,7 @@ def test_multi_chunk_partial_match_misaligned(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 6,
+            "n_used_blocks": 7,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 2 seq 0
@@ -1379,7 +1379,7 @@ def test_multi_chunk_partial_match_misaligned(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 6,
+            "n_used_blocks": 7,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 3 seq 0
@@ -1388,7 +1388,7 @@ def test_multi_chunk_partial_match_misaligned(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": ["0"],
-            "n_used_blocks": 6,
+            "n_used_blocks": 7,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 2 seq 1
@@ -1399,7 +1399,7 @@ def test_multi_chunk_partial_match_misaligned(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 8,
+            "n_used_blocks": 9,
             "n_prefix_hits": 0,
             "n_cached_blocks": 2,
             "prefill_slot_mappings": {"1": [0, 4]},  # Block 3 (prefix hit) is masked out
@@ -1410,14 +1410,14 @@ def test_multi_chunk_partial_match_misaligned(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": ["1"],
-            "n_used_blocks": 9,
+            "n_used_blocks": 10,
             "n_prefix_hits": 0,
             "n_cached_blocks": 2,
             "block_tables": {
-                "0": [1, 2, 3, 4, 5, 6],
-                "1": [1, 2, 3, 7, 8, 9],
+                "0": [1, 2, 3, 4, 5, 6, 7],
+                "1": [1, 2, 3, 8, 9, 10],
             },
-            "prefill_slot_mappings": {"1": [8, 9]},
+            "prefill_slot_mappings": {"1": [9, 10]},
         },
         {
             # Decode 1 of request 0.
@@ -1526,7 +1526,7 @@ def test_multi_chunk_partial_match_aligned(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 6,
+            "n_used_blocks": 7,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 2 seq 0
@@ -1535,7 +1535,7 @@ def test_multi_chunk_partial_match_aligned(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 6,
+            "n_used_blocks": 7,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 3 seq 0
@@ -1544,7 +1544,7 @@ def test_multi_chunk_partial_match_aligned(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": ["0"],
-            "n_used_blocks": 6,
+            "n_used_blocks": 7,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 3 seq 1
@@ -1554,12 +1554,12 @@ def test_multi_chunk_partial_match_aligned(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": ["1"],
-            "n_used_blocks": 8,
+            "n_used_blocks": 9,
             "n_prefix_hits": 0,
             "n_cached_blocks": 4,
             "block_tables": {
-                "0": [1, 2, 3, 4, 5, 6],
-                "1": [1, 2, 3, 4, 7, 8],
+                "0": [1, 2, 3, 4, 5, 6, 7],
+                "1": [1, 2, 3, 4, 8, 9],
             },
         },
         {
@@ -1669,9 +1669,9 @@ def test_first_chunk_partial_match(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": ["0"],
-            "n_used_blocks": 1,
+            "n_used_blocks": 2,
             "n_prefix_hits": 0,
-            "block_tables": {"0": [1]},
+            "block_tables": {"0": [1, 2]},
         },
         {  # prefill seq 1. This step was crashing before
             "step": 2,
@@ -1679,11 +1679,11 @@ def test_first_chunk_partial_match(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 4,
+            "n_used_blocks": 6,
             "n_prefix_hits": 0,
-            "block_tables": {"0": [1], "1": [1, 2, 3, 4]},
+            "block_tables": {"0": [1, 2], "1": [1, 3, 4, 5, 6]},
             "prefill_slot_mappings": {
-                "1": [0, 0, 2]  # One mask for left padding, one mask for block `1` to not be
+                "1": [0, 0, 3]  # One mask for left padding, one mask for block `1` to not be
                 # overwritten since it hit cache
             },
         },
@@ -1693,10 +1693,10 @@ def test_first_chunk_partial_match(
             "waiting": [],
             "running": ["1", "0"],
             "request_outputs": ["1"],
-            "n_used_blocks": 5,
+            "n_used_blocks": 6,
             "n_prefix_hits": 0,
-            "block_tables": {"0": [1], "1": [1, 2, 3, 4, 5]},
-            "prefill_slot_mappings": {"1": [3, 4, 5]},
+            "block_tables": {"0": [1, 2], "1": [1, 3, 4, 5, 6]},
+            "prefill_slot_mappings": {"1": [4, 5, 6]},
         },
         {  # decode
             "step": 4,

--- a/tests/e2e/test_spyre_pc_scheduler_steps.py
+++ b/tests/e2e/test_spyre_pc_scheduler_steps.py
@@ -81,10 +81,10 @@ def test_prefix_hit_within_batch(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 2,
+            "n_used_blocks": 3,
             "n_prefix_hits": 0,
-            "block_tables": {"0": [1, 2]},
-            "block_ref_count": {1: 1, 2: 1},
+            "block_tables": {"0": [1, 2, 3]},
+            "block_ref_count": {1: 1, 2: 1, 3: 1},
         },
         {  # prefill chunk 2 seq 0
             "step": 2,
@@ -518,7 +518,7 @@ def test_prefix_hit_not_in_batch(
             "waiting": [],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 2,
+            "n_used_blocks": 3,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 2 seq 0
@@ -673,7 +673,7 @@ def test_limit_blocks_no_prefix_hit(
             "waiting": [],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 2,
+            "n_used_blocks": 3,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 2 seq 0
@@ -702,7 +702,7 @@ def test_limit_blocks_no_prefix_hit(
             "waiting": [],
             "running": ["1"],
             "request_outputs": [],
-            "n_used_blocks": 2,
+            "n_used_blocks": 3,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 2 seq 1
@@ -732,7 +732,7 @@ def test_limit_blocks_no_prefix_hit(
             "waiting": [],
             "running": ["2"],
             "request_outputs": [],
-            "n_used_blocks": 2,
+            "n_used_blocks": 3,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 2 seq 2
@@ -867,10 +867,10 @@ def test_double_prefix_hit_within_batch(
             "waiting": ["1", "2", "3"],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 2,
+            "n_used_blocks": 3,
             "n_prefix_hits": 0,
-            "block_tables": {"0": [1, 2]},
-            "block_ref_count": {1: 1, 2: 1},
+            "block_tables": {"0": [1, 2, 3]},
+            "block_ref_count": {1: 1, 2: 1, 3: 1},
         },
         {  # prefill chunk 2 seq 0
             "step": 2,
@@ -903,10 +903,10 @@ def test_double_prefix_hit_within_batch(
             "waiting": ["3"],
             "running": ["2", "1", "0"],
             "request_outputs": [],
-            "n_used_blocks": 6,
+            "n_used_blocks": 7,
             "n_prefix_hits": 0,
-            "block_tables": {"0": [1, 2, 3], "1": [1, 2, 4], "2": [5, 6]},
-            "block_ref_count": {1: 2, 2: 2, 3: 1, 4: 1, 5: 1, 6: 1},
+            "block_tables": {"0": [1, 2, 3], "1": [1, 2, 4], "2": [5, 6, 7]},
+            "block_ref_count": {1: 2, 2: 2, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1},
         },
         {  # prefill chunk 2 seq 2
             "step": 5,
@@ -1048,7 +1048,7 @@ def test_limit_blocks_prefix_hit(
             "waiting": [],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 2,
+            "n_used_blocks": 3,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 2 seq 0
@@ -1077,7 +1077,7 @@ def test_limit_blocks_prefix_hit(
             "waiting": [],
             "running": ["1"],
             "request_outputs": [],
-            "n_used_blocks": 2,
+            "n_used_blocks": 3,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 2 seq 1
@@ -1212,7 +1212,7 @@ def test_multi_chunk_full_match(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 2,
+            "n_used_blocks": 6,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 2 seq 0
@@ -1221,7 +1221,7 @@ def test_multi_chunk_full_match(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 4,
+            "n_used_blocks": 6,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 3 seq 0
@@ -1370,7 +1370,7 @@ def test_multi_chunk_partial_match_misaligned(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 2,
+            "n_used_blocks": 6,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 2 seq 0
@@ -1379,7 +1379,7 @@ def test_multi_chunk_partial_match_misaligned(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 4,
+            "n_used_blocks": 6,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 3 seq 0
@@ -1526,7 +1526,7 @@ def test_multi_chunk_partial_match_aligned(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 2,
+            "n_used_blocks": 6,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 2 seq 0
@@ -1535,7 +1535,7 @@ def test_multi_chunk_partial_match_aligned(
             "waiting": ["1"],
             "running": ["0"],
             "request_outputs": [],
-            "n_used_blocks": 4,
+            "n_used_blocks": 6,
             "n_prefix_hits": 0,
         },
         {  # prefill chunk 3 seq 0

--- a/tests/multimodal/test_llava_next.py
+++ b/tests/multimodal/test_llava_next.py
@@ -15,7 +15,7 @@ from transformers import AutoConfig, AutoProcessor
 from vllm.multimodal.inputs import MultiModalFeatureSpec
 
 import sendnn_inference.multimodal as spyre_mm
-from tests.spyre_util import REFERENCE_MODELS
+from spyre_util import REFERENCE_MODELS
 
 GVISION_MODEL = REFERENCE_MODELS["ibm-granite/granite-vision-3.2-2b"]
 # Marks all tests in this file as multimodal and CPU to match

--- a/tests/multimodal/test_mistral3.py
+++ b/tests/multimodal/test_mistral3.py
@@ -15,7 +15,7 @@ from transformers import AutoConfig, AutoProcessor
 from vllm.multimodal.inputs import MultiModalFeatureSpec
 
 import sendnn_inference.multimodal as spyre_mm
-from tests.spyre_util import REFERENCE_MODELS
+from spyre_util import REFERENCE_MODELS
 
 # MISTRAL3_MODEL = REFERENCE_MODELS["mistralai/Mistral-Small-3.2-24B-Instruct-2506"]
 MISTRAL3_MODEL = REFERENCE_MODELS["mistralai/Mistral-Small-3.1-24B-Instruct-2503"]

--- a/tests/v1/core/test_scheduler_structured_outputs.py
+++ b/tests/v1/core/test_scheduler_structured_outputs.py
@@ -48,6 +48,10 @@ def mocked_scheduler():
     scheduler.n_free_blocks = 100
     scheduler.max_batch_tkv_limit = "8192"
 
+    scheduler._get_block_params_for_request = lambda x, *args, **kwargs: None
+    scheduler._are_blocks_available = lambda x, *args, **kwargs: None
+    scheduler._preallocate_blocks = lambda x, *args, **kwargs: True
+
     # Mock the base scheduler's schedule method and can_schedule_prefill,
     # but ChunkedPrefillSpyreScheduler.schedule uses the code implementation
     mock_output = Mock()

--- a/tests/v1/worker/test_prefix_caching_worker.py
+++ b/tests/v1/worker/test_prefix_caching_worker.py
@@ -131,7 +131,7 @@ def test_multi_chunk_partial_match_misaligned(
         num_sampled_token_ids=0,
         tkv=384,
         # actual number of available blocks: 18 - 1 (padding block) = 17
-        n_free_blocks=15,  # 17 - 2 = 15
+        n_free_blocks=11,
         left_padding={"0": 0},
         prefix_cache_hit_len={"0": 0},
     )
@@ -147,7 +147,7 @@ def test_multi_chunk_partial_match_misaligned(
         req_ids=["0"],
         num_sampled_token_ids=0,
         tkv=384,
-        n_free_blocks=13,
+        n_free_blocks=11,
         left_padding={"0": 0},
         prefix_cache_hit_len={"0": 0},
     )
@@ -404,7 +404,7 @@ def test_middle_chunk_recomputation_with_padding(
         num_sampled_token_ids=0,
         tkv=512,
         # actual number of available blocks: 34 - 1 (padding block) = 33
-        n_free_blocks=29,
+        n_free_blocks=25,
         left_padding={"0": 0},
         prefix_cache_hit_len={"0": 0},
     )

--- a/tests/v1/worker/test_prefix_caching_worker.py
+++ b/tests/v1/worker/test_prefix_caching_worker.py
@@ -131,7 +131,7 @@ def test_multi_chunk_partial_match_misaligned(
         num_sampled_token_ids=0,
         tkv=384,
         # actual number of available blocks: 18 - 1 (padding block) = 17
-        n_free_blocks=11,
+        n_free_blocks=10,
         left_padding={"0": 0},
         prefix_cache_hit_len={"0": 0},
     )
@@ -147,7 +147,7 @@ def test_multi_chunk_partial_match_misaligned(
         req_ids=["0"],
         num_sampled_token_ids=0,
         tkv=384,
-        n_free_blocks=11,
+        n_free_blocks=10,
         left_padding={"0": 0},
         prefix_cache_hit_len={"0": 0},
     )
@@ -163,7 +163,7 @@ def test_multi_chunk_partial_match_misaligned(
         req_ids=["0"],
         num_sampled_token_ids=1,
         tkv=384,
-        n_free_blocks=11,
+        n_free_blocks=10,
         left_padding={"0": 0},
     )
 
@@ -175,35 +175,35 @@ def test_multi_chunk_partial_match_misaligned(
         req_ids=["1"],
         num_sampled_token_ids=0,
         tkv=384,
-        n_free_blocks=9,
+        n_free_blocks=8,
         left_padding={"1": 0},
         prefix_cache_hit_len={"1": 128},
     )
     pc_model_runner.assert_block_tables_and_slot_mappings(
-        block_tables=[[1, 2, 3, 7]],
-        slot_mappings=[[0, 7]],
+        block_tables=[[1, 2, 3, 8]],
+        slot_mappings=[[0, 8]],
     )
 
     # Schedule chunk 2 of request 1
     model_runner_output_5 = pc_model_runner.execute_running_requests()
     pc_model_runner.assert_block_tables_and_slot_mappings(
-        block_tables=[[1, 2, 3, 7, 8, 9]],
-        slot_mappings=[[8, 9]],
+        block_tables=[[1, 2, 3, 8, 9, 10]],
+        slot_mappings=[[9, 10]],
     )
     pc_model_runner.verify_model_runner_output(
         model_runner_output_5,
         req_ids=["1"],
         num_sampled_token_ids=1,
         tkv=384,
-        n_free_blocks=8,
+        n_free_blocks=7,
         left_padding={"1": 0},
     )
 
     # Schedule decodes of requests 0 and 1
     model_runner_output_6 = pc_model_runner.execute_running_requests()
     pc_model_runner.assert_block_tables_and_slot_mappings(
-        block_tables=[[1, 2, 3, 4, 5, 6, 11], [1, 2, 3, 7, 8, 9, 10]],
-        slot_mappings=[[11], [10]],
+        block_tables=[[1, 2, 3, 4, 5, 6, 7], [1, 2, 3, 8, 9, 10, 11]],
+        slot_mappings=[[7], [11]],
         slot_slice=slice(0, 1),
     )
     pc_model_runner.verify_model_runner_output(
@@ -284,15 +284,15 @@ def test_first_chunk_recomputation(
         num_sampled_token_ids=1,
         tkv=128,
         # actual number of available blocks: 18 - 1 (padding block) = 17
-        n_free_blocks=15,  # 17 - (4 - 2 (pads)) = 15
+        n_free_blocks=14,
         left_padding={"0": 128},
     )
 
     # Schedule chunk 0 of request 1
     model_runner_output_2 = pc_model_runner.execute_new_request(request=request2.request)
     pc_model_runner.assert_block_tables_and_slot_mappings(
-        block_tables=[[0, 0, 1, 3]],
-        slot_mappings=[[0, 0, 0, 3]],
+        block_tables=[[0, 0, 1, 4]],
+        slot_mappings=[[0, 0, 0, 4]],
     )
     # ^This block table and slot mapping is the crux of this test.
     # The padding blocks align with the slot mapping pointing to block
@@ -306,15 +306,15 @@ def test_first_chunk_recomputation(
         req_ids=["1"],
         num_sampled_token_ids=1,
         tkv=128,
-        n_free_blocks=14,  # 15 - (4 - 2 (pads) - 1 (prefix)) = 14
+        n_free_blocks=13,
         left_padding={"1": 128},
     )
 
     # Schedule decodes of requests 0 and 1
     model_runner_output_3 = pc_model_runner.execute_running_requests()
     pc_model_runner.assert_block_tables_and_slot_mappings(
-        block_tables=[[1, 2, 5], [1, 3, 4]],
-        slot_mappings=[[5], [4]],
+        block_tables=[[1, 2, 3], [1, 4, 5]],
+        slot_mappings=[[3], [5]],
         slot_slice=slice(0, 1),
     )
     pc_model_runner.verify_model_runner_output(
@@ -404,7 +404,7 @@ def test_middle_chunk_recomputation_with_padding(
         num_sampled_token_ids=0,
         tkv=512,
         # actual number of available blocks: 34 - 1 (padding block) = 33
-        n_free_blocks=25,
+        n_free_blocks=24,
         left_padding={"0": 0},
         prefix_cache_hit_len={"0": 0},
     )
@@ -420,30 +420,30 @@ def test_middle_chunk_recomputation_with_padding(
         req_ids=["0"],
         num_sampled_token_ids=1,
         tkv=512,
-        n_free_blocks=25,
+        n_free_blocks=24,
         left_padding={"0": 0},
     )
 
     # Skip chunk 0 and run chunk 1 of request 1
     model_runner_output_3 = pc_model_runner.execute_new_request(request=request2.request)
     pc_model_runner.assert_block_tables_and_slot_mappings(
-        block_tables=[[0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]],
-        slot_mappings=[[0, 0, 9, 10]],
+        block_tables=[[0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11]],
+        slot_mappings=[[0, 0, 10, 11]],
     )
     pc_model_runner.verify_model_runner_output(
         model_runner_output_3,
         req_ids=["1"],
         num_sampled_token_ids=1,
         tkv=640,
-        n_free_blocks=23,
+        n_free_blocks=22,
         left_padding={"1": 128},
     )
 
     # Schedule decodes of requests 0 and 1
     model_runner_output_4 = pc_model_runner.execute_running_requests()
     pc_model_runner.assert_block_tables_and_slot_mappings(
-        block_tables=[[0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 12], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]],
-        slot_mappings=[[12], [11]],
+        block_tables=[[0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12]],
+        slot_mappings=[[9], [12]],
         slot_slice=slice(0, 1),
     )
 


### PR DESCRIPTION
## Description

To improve device utilization, we want to allow a form of request preemption where the scheduler can remove requests from the current decoding batch but without freeing the associated KV-Cache blocks, essentially pausing the execution of the request. For that we need to be able to track how much KV cache blocks are available and reserve them to prevent overcommiting resources.

I see two design choices for this:
1) Replicate block accounting in the SpyreScheduler
2) Add behavior in the SpyreScheduler to verify block availability and pre-allocate all blocks.

With option 1) we need to be careful to track how many blocks the scheduler has assigned to each request, especially considering that some might be cached. This option is a bit simpler, but the vllm scheduler has no visibility of the blocks that are reserved.

With option 2) before callig the vllm Schedule.schedule(), we verify the availabity of all the blocks required to generate the requests max-tokens and afterwards we pre-allocate these blocks. 

This PR explores option 2.