### PR TITLE
Add ' Louis' to bad_words in test_spyre_bad_words

### DIFF
--- a/tests/e2e/test_sampling_params.py
+++ b/tests/e2e/test_sampling_params.py
@@ -438,7 +438,7 @@ def test_spyre_bad_words(
     )
     prompt = "The capital of France is"
     params1 = SamplingParams(
-        max_tokens=5, temperature=0, bad_words=[" Paris", " Parisi", " France"]
+        max_tokens=5, temperature=0, bad_words=[" Paris", " Parisi", " France", " Louis"]
     )
     params2 = SamplingParams(max_tokens=5, temperature=0)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Extends the `bad_words` list in `test_spyre_bad_words` to include `" Louis"`. The model's greedy completion for "The capital of France is" can produce "Louis" (e.g., "Louis XIV…") in addition to the previously-blocked "Paris"/"Parisi"/"France" tokens, causing the test's assertion that the bad-words-constrained output differs from the unconstrained output to fail intermittently on s390x. Adding `"Louis"` to the blocklist ensures the constrained generation diverges from the baseline completion.

## Related Issues

<!-- Link related issues, e.g., `Fixes #` or `Relates to #456` -->

## Test Plan

- Ran `tests/e2e/test_sampling_params.py::test_spyre_bad_words` on s390x; constrained output no longer overlaps with the unconstrained completion.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [x] My code follows the project's code style (run `bash format.sh`)
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
