### PR TITLE
:bug: fix model caches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -264,6 +264,28 @@ jobs:
 
           wait
 
+      - name: "Check HF model cache sizes"
+        if: steps.changed-src-files.outputs.any_changed == 'true'
+        run: |
+          # Guard against accidentally caching multi-GB model artifacts (e.g.
+          # onnx/, openvino/, or duplicate framework weights). The GHA cache
+          # has a 10 GB total limit; keep individual model caches well under
+          # that so multiple matrix entries can coexist.
+          MAX_BYTES=$((2 * 1024 * 1024 * 1024))  # 2 GiB
+          status=0
+          for path in "${{ env.model_path }}" "${{ env.model_2_path }}"; do
+            if [[ -n "$path" && -d "$path" ]]; then
+              size=$(du -sb "$path" | cut -f1)
+              human=$(du -sh "$path" | cut -f1)
+              echo "Model cache $path: $human ($size bytes)"
+              if (( size > MAX_BYTES )); then
+                echo "::error::Model cache at $path is $human, exceeding the 2 GiB limit. Update tools/download_model.py to exclude unused artifacts (onnx/, openvino/, duplicate framework weights, etc)."
+                status=1
+              fi
+            fi
+          done
+          exit $status
+
       - name: "Save HF models cache"
         if: ( steps.changed-src-files.outputs.any_changed == 'true' && github.event_name != 'pull_request' && steps.cache_restore.outputs.cache-hit != 'true' )
         uses: actions/cache/save@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -271,7 +271,7 @@ jobs:
           # onnx/, openvino/, or duplicate framework weights). The GHA cache
           # has a 10 GB total limit; keep individual model caches well under
           # that so multiple matrix entries can coexist.
-          MAX_BYTES=$((2 * 1024 * 1024 * 1024))  # 2 GiB
+          MAX_BYTES=$((3 * 1024 * 1024 * 1024))  # 3 GiB (uncompressed; caches are compressed before upload)
           status=0
           for path in "${{ env.model_path }}" "${{ env.model_2_path }}"; do
             if [[ -n "$path" && -d "$path" ]]; then
@@ -279,7 +279,7 @@ jobs:
               human=$(du -sh "$path" | cut -f1)
               echo "Model cache $path: $human ($size bytes)"
               if (( size > MAX_BYTES )); then
-                echo "::error::Model cache at $path is $human, exceeding the 2 GiB limit. Update tools/download_model.py to exclude unused artifacts (onnx/, openvino/, duplicate framework weights, etc)."
+                echo "::error::Model cache at $path is $human, exceeding the 3 GiB limit. Update tools/download_model.py to exclude unused artifacts (onnx/, openvino/, duplicate framework weights, etc)."
                 status=1
               fi
             fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,11 @@ ignore = [
     "B905",
 ]
 
+[tool.typos.default.extend-words]
+# `*.ot` is the file extension for HuggingFace Rust framework model weights
+# (rust_model.ot), referenced in tools/download_model.py.
+ot = "ot"
+
 [tool.codespell]
 ignore-words-list = "dout, te, indicies, subtile, ElementE"
 skip = "*.svg,./tests/hf_cache.json"

--- a/tools/download_model.py
+++ b/tools/download_model.py
@@ -23,6 +23,15 @@ def main():
         snapshot_download(
             repo_id=args.model,
             revision=args.revision,
+            ignore_patterns=[
+                "onnx/*",
+                "openvino/*",
+                "*.msgpack",
+                "*.h5",
+                "*.ot",
+                "pytorch_model.bin",
+                "pytorch_model.bin.index.json",
+            ],
         )
     else:
         logging.error("Need to provide a HuggingFace model ID.")


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This updates the model caching script to ignore unused artifacts, and adds a check that we don't blow up the cache with a single model. The pooling models are currently >10GB each because we starting pulling in all of the alternative weight formats and tried to cache them.

## Related Issues


## Test Plan

the usual GHA CI

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
