### PR TITLE
:bug: Fix structered Output crash when running multpile requests (#995)

### DIFF
--- a/.github/workflows/check_uv_lock.yml
+++ b/.github/workflows/check_uv_lock.yml
@@ -6,7 +6,7 @@ on:
       - 'pyproject.toml'
       - 'uv.lock'
   push:
-    branches: [main]
+    branches: [main, release-2.0.0]
     paths:
       - 'pyproject.toml'
       - 'uv.lock'

--- a/.github/workflows/lint_scripts.yml
+++ b/.github/workflows/lint_scripts.yml
@@ -6,9 +6,11 @@ on:
   pull_request:
     branches:
       - main
+      - release-2.0.0
   push:
     branches:
       - main
+      - release-2.0.0
     paths:
       - '**/*.sh'
       - '.github/workflows/lint_scripts.yml'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, release-2.0.0]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/publish_to_test_pypi.yaml
+++ b/.github/workflows/publish_to_test_pypi.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - release-2.0.0
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,10 @@ on:
   pull_request:
     # add labeled and unlabeled to the default types (runs when label is added)
     types: [opened, synchronize, reopened, labeled, unlabeled, auto_merge_enabled]
-    branches: [main]
+    branches: [main, release-2.0.0]
 
   push:
-    branches: [main]
+    branches: [main, release-2.0.0]
 
   workflow_dispatch:
 

--- a/sendnn_inference/v1/worker/spyre_model_runner.py
+++ b/sendnn_inference/v1/worker/spyre_model_runner.py
@@ -1518,10 +1518,18 @@ class ChunkedPrefillModelRunner(
         if grammar_output is None:
             return
 
+        class _DenseBatchAdapter:
+            def __init__(self, batch: SamplingInputBatch):
+                self._batch = batch
+                self.req_ids = batch.sorted_requests_ids
+
+            def __getattr__(self, name: str):
+                return getattr(self._batch, name)
+
         vllm_apply_grammar_bitmask(
             scheduler_output,
             grammar_output,
-            batch,  # type: ignore[arg-type]
+            _DenseBatchAdapter(batch),  # type: ignore[arg-type]
             logits,
         )
 

--- a/tests/v1/core/test_scheduler_structured_outputs.py
+++ b/tests/v1/core/test_scheduler_structured_outputs.py
@@ -14,6 +14,12 @@ from vllm.sampling_params import StructuredOutputsParams
 from vllm.v1.core.sched.request_queue import FCFSRequestQueue
 from vllm.v1.request import Request, RequestStatus
 from sendnn_inference.v1.core.scheduler import ChunkedPrefillSpyreScheduler
+from scheduling_utils import create_request_for_scheduler_test, random_prompt
+
+from v1.worker.mock_model import InstrumentedModelRunner
+from vllm.v1.structured_output.request import StructuredOutputRequest
+from vllm.tokenizers import get_tokenizer
+from spyre_util import REFERENCE_MODELS
 
 pytestmark = pytest.mark.skip_global_cleanup
 
@@ -200,4 +206,226 @@ class TestSchedulerStructuredOutputHandling:
         assert request.status == RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR
 
 
-# Made with Bob
+class TestSchedulerSimultaneousRequests:
+    """Test that the scheduler handles simultaneous structured and regular requests."""
+
+    def test_simultaneous_structured_and_regular_requests(self, mocked_scheduler):
+        """Simulate a mixed batch: some requests use json_object, others don't.
+        All structured_output_request values should be preserved correctly."""
+
+        structured_params = SamplingParams(
+            max_tokens=20,
+            temperature=0.0,
+            structured_outputs=StructuredOutputsParams(json_object=True),
+        )
+        regular_params = SamplingParams(
+            max_tokens=20,
+            temperature=0.0,
+        )
+
+        structured_req_1 = Request(
+            request_id="struct_1",
+            sampling_params=structured_params,
+            prompt_token_ids=list(range(50)),
+            arrival_time=0,
+            lora_request=None,
+            pooling_params=None,
+        )
+        regular_req = Request(
+            request_id="regular_1",
+            sampling_params=regular_params,
+            prompt_token_ids=list(range(40)),
+            arrival_time=1,
+            lora_request=None,
+            pooling_params=None,
+        )
+        structured_req_2 = Request(
+            request_id="struct_2",
+            sampling_params=structured_params,
+            prompt_token_ids=list(range(60)),
+            arrival_time=2,
+            lora_request=None,
+            pooling_params=None,
+        )
+
+        # Verify initial state
+        assert structured_req_1.structured_output_request is not None
+        assert regular_req.structured_output_request is None
+        assert structured_req_2.structured_output_request is not None
+
+        # Add all three to the waiting queue simultaneously
+        mocked_scheduler.waiting.append(structured_req_1)
+        mocked_scheduler.waiting.append(regular_req)
+        mocked_scheduler.waiting.append(structured_req_2)
+
+        mocked_scheduler.schedule()
+
+        # Structured requests should still have their structured_output_request
+        assert structured_req_1.structured_output_request is not None
+        assert structured_req_2.structured_output_request is not None
+        # Regular request should still have None
+        assert regular_req.structured_output_request is None
+
+    def test_simultaneous_structured_requests_all_preserved(self, mocked_scheduler):
+        """Multiple structured output requests arriving at the same time
+        should all be preserved after scheduling."""
+
+        requests = []
+        for i in range(4):
+            params = SamplingParams(
+                max_tokens=20,
+                temperature=0.0,
+                structured_outputs=StructuredOutputsParams(json_object=True),
+            )
+            req = Request(
+                request_id=f"concurrent_struct_{i}",
+                sampling_params=params,
+                prompt_token_ids=list(range(30 + i * 10)),
+                arrival_time=i * 0.1,
+                lora_request=None,
+                pooling_params=None,
+            )
+            requests.append(req)
+            mocked_scheduler.waiting.append(req)
+
+        mocked_scheduler.schedule()
+
+        for req in requests:
+            assert req.structured_output_request is not None, (
+                f"Request {req.request_id} lost its structured_output_request"
+            )
+
+    def test_grammar_output_attached_for_mixed_batch(self, mocked_scheduler):
+        """Verify _spyre_grammar_output is attached to scheduler output
+        when the batch contains a mix of structured and regular requests."""
+
+        structured_params = SamplingParams(
+            max_tokens=20,
+            temperature=0.0,
+            structured_outputs=StructuredOutputsParams(json_object=True),
+        )
+        regular_params = SamplingParams(
+            max_tokens=20,
+            temperature=0.0,
+        )
+
+        mocked_scheduler.waiting.append(
+            Request(
+                request_id="struct_req",
+                sampling_params=structured_params,
+                prompt_token_ids=list(range(50)),
+                arrival_time=0,
+                lora_request=None,
+                pooling_params=None,
+            )
+        )
+        mocked_scheduler.waiting.append(
+            Request(
+                request_id="regular_req",
+                sampling_params=regular_params,
+                prompt_token_ids=list(range(40)),
+                arrival_time=1,
+                lora_request=None,
+                pooling_params=None,
+            )
+        )
+
+        output = mocked_scheduler.schedule()
+
+        # _spyre_grammar_output should be set on the output
+        assert hasattr(output, "_spyre_grammar_output")
+
+    def test_grammar_output_attached_for_all_regular_batch(self, mocked_scheduler):
+        """When all requests are regular (no structured output),
+        _spyre_grammar_output should still be set (may be None)."""
+
+        regular_params = SamplingParams(
+            max_tokens=20,
+            temperature=0.0,
+        )
+
+        for i in range(3):
+            mocked_scheduler.waiting.append(
+                Request(
+                    request_id=f"regular_{i}",
+                    sampling_params=regular_params,
+                    prompt_token_ids=list(range(50)),
+                    arrival_time=i,
+                    lora_request=None,
+                    pooling_params=None,
+                )
+            )
+
+        output = mocked_scheduler.schedule()
+
+        # _spyre_grammar_output should still be attached (even if None)
+        assert hasattr(output, "_spyre_grammar_output")
+
+
+def test_sparse_index_grammar_crash(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """In this scenario we schedule two requests with structured outputs. The
+    first one will drop out of the batch earlier, making a hole in the sparse
+    index. This is to trigger a known bug when the sparse index is not
+    contiguous.
+    """
+    pc_model_runner = InstrumentedModelRunner.build(
+        monkeypatch=monkeypatch,
+        max_num_batched_tokens=64,
+        available_blocks=100,
+    )
+    pc_model_runner.scheduler.structured_output_manager._use_async_grammar_compilation = False
+
+    model = REFERENCE_MODELS[InstrumentedModelRunner.DEFAULT_TEST_MODEL]
+    tokenizer = get_tokenizer(tokenizer_name=model.name, revision=model.revision)
+
+    prompt1 = random_prompt(model=model, seed=0, length=64)
+    request1 = create_request_for_scheduler_test(
+        model=model,
+        request_id=0,
+        add_step=0,
+        max_tokens=3,
+        prompt=prompt1,
+        use_golden_token_injection=False,
+        generate_hf_results=False,
+    )
+
+    request2 = create_request_for_scheduler_test(
+        model=model,
+        request_id=1,
+        add_step=0,
+        max_tokens=4,
+        prompt=prompt1,
+        use_golden_token_injection=False,
+        generate_hf_results=False,
+    )
+
+    # Initialize grammars and requests
+    for request in [request1, request2]:
+        assert (sampling_params := request.request.sampling_params) is not None
+        sampling_params.structured_outputs = StructuredOutputsParams(regex=".*")  # accept anything
+        request.request.structured_output_request = StructuredOutputRequest.from_sampling_params(
+            sampling_params
+        )
+        sampling_params._validate_structured_outputs(
+            pc_model_runner.vllm_config.structured_outputs_config, tokenizer
+        )
+        pc_model_runner.scheduler.structured_output_manager.grammar_init(request.request)
+
+        assert (structured := request.request.structured_output_request) is not None
+        # Wait for grammar to be ready
+        while not structured.is_grammar_ready:
+            pass
+
+    # Run prefill of request 1
+    pc_model_runner.execute_new_request(request=request1.request)
+    # Run first decode of request 1
+    pc_model_runner.execute_running_requests()
+
+    # Run prefill of request 2
+    pc_model_runner.execute_new_request(request=request2.request)
+
+    for i in range(4):
+        # Run decode of requests 1 and 2
+        pc_model_runner.execute_running_requests()

--- a/tests/v1/worker/mock_model.py
+++ b/tests/v1/worker/mock_model.py
@@ -13,6 +13,7 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 from vllm.v1.kv_cache_interface import KVCacheGroupSpec, KVCacheConfig
 from vllm.v1.structured_output import StructuredOutputManager
+from transformers import AutoTokenizer
 
 from sendnn_inference.model_executor.model_loader.spyre import SpyreAttentionMetadata
 from sendnn_inference.platform import SpyrePlatform
@@ -48,6 +49,10 @@ class MockSpyreCausalLM:
         self.last_masks: torch.Tensor | None = None
         self.last_is_prompt: bool | None = None
         self.last_attn_metadata: SpyreAttentionMetadata | None = None
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            vllm_config.model_config.model, revision=vllm_config.model_config.revision
+        )
+        self.a_token = self.tokenizer.encode("a", add_special_tokens=False)[0]
 
     def get_maybe_mm_embeddings(self, *args, **kwargs):
         # This model is not multimodal
@@ -77,9 +82,12 @@ class MockSpyreCausalLM:
 
         batch_size = input_ids_or_embeds.shape[0]
 
-        return torch.empty(
+        # make the logits predictable
+        logits = torch.zeros(
             (batch_size, self.vocab_size), dtype=torch.float32, device=input_ids_or_embeds.device
         )
+        logits[:, self.a_token] = 1
+        return logits
 
     def sample(
         self,
@@ -253,7 +261,7 @@ class InstrumentedModelRunner(ChunkedPrefillModelRunner):
         max_model_len: int = 512,
         max_num_batched_tokens: int = 128,
         available_blocks: int | None = None,
-    ) -> ChunkedPrefillModelRunner:
+    ) -> "InstrumentedModelRunner":
         """A fixture that returns a model runner configured for prefix caching."""
 
         os.environ.pop("VLLM_DT_MAX_BATCH_TKV_LIMIT", None)


### PR DESCRIPTION
## Description
Fix to server crash when sending multiple structured output requests. The problem is a mismatch between how the sendnn Inference batch stores requests and how the upstream vLLM grammar bitmask code expects them.

## Test Plan
Create a test script to send multiple requests for structured outputs
```
set -euo pipefail

TEST_MODE="${1:-mixed}"
BASE_URL="${2:-http://localhost:8002}"
ENDPOINT="${BASE_URL}/v1/chat/completions"
ROUNDS=5

# Auto-detect the served model name
MODEL=$(curl -s "${BASE_URL}/v1/models" 2>/dev/null \
  | python3 -c "import sys,json; print(json.load(sys.stdin)['data'][0]['id'])" 2>/dev/null || echo "ibm/granite-4.1-8b")

echo "Target:    ${ENDPOINT}"
echo "Model:     ${MODEL}"
echo "Test mode: ${TEST_MODE}"
echo "Rounds:    ${ROUNDS}"
echo ""

send_structured() {
  local tag="$1" round="$2" content="$3"
  curl -s -w "\n[${tag}] HTTP %{http_code} in %{time_total}s\n" \
    "${ENDPOINT}" \
    -H "Content-Type: application/json" \
    -d '{
      "model": "'"${MODEL}"'",
      "messages": [
        {"role": "system", "content": "Output ONLY a JSON object."},
        {"role": "user", "content": "'"${content}"'"}
      ],
      "response_format": {"type": "json_object"},
      "temperature": 0,
      "max_tokens": 128
    }' -o "/tmp/${tag}_${round}.json" &
}

send_regular() {
  local tag="$1" round="$2" content="$3"
  curl -s -w "\n[${tag}] HTTP %{http_code} in %{time_total}s\n" \
    "${ENDPOINT}" \
    -H "Content-Type: application/json" \
    -d '{
      "model": "'"${MODEL}"'",
      "messages": [
        {"role": "system", "content": "You are a helpful assistant."},
        {"role": "user", "content": "'"${content}"'"}
      ],
      "temperature": 0,
      "max_tokens": 128
    }' -o "/tmp/${tag}_${round}.json" &
}

for i in $(seq 1 $ROUNDS); do
  echo "=== Round $i ==="

  case "${TEST_MODE}" in
    mixed)
      # Mixed: structured + regular (should crash without the fix)
      send_structured "struct1" "$i" "Show all db2 systems"
      send_regular    "regular" "$i" "Show all operations"
      send_structured "struct2" "$i" "List all engines"
      ;;
    struct-only)
      # All structured (should survive if bug is mixed-batching only)
      send_structured "struct1" "$i" "Show all db2 systems"
      send_structured "struct2" "$i" "List all engines"
      send_structured "struct3" "$i" "Show all networks"
      ;;
    regular-only)
      # All regular (baseline, should always survive)
      send_regular "regular1" "$i" "Show all db2 systems"
      send_regular "regular2" "$i" "List all engines"
      send_regular "regular3" "$i" "Show all operations"
      ;;
    *)
      echo "Unknown test mode: ${TEST_MODE}"
      echo "Use: mixed | struct-only | regular-only"
      exit 1
      ;;
  esac

  wait
  echo ""
done

echo "=== Done ==="
echo ""
```
## Test Result
```
[root@b39-ocpai4 ocpai]# bash test.sh struct-only http://localhost:8002
Target:    http://localhost:8002/v1/chat/completions
Model:     ibm-granite/granite-4.1-8b
Test mode: struct-only
Rounds:    5

=== Round 1 ===

[struct1] HTTP 200 in 8.705190s

[struct3] HTTP 200 in 8.759679s

[struct2] HTTP 200 in 8.812166s

=== Round 2 ===

[struct3] HTTP 200 in 8.213496s

[struct2] HTTP 200 in 8.268425s

[struct1] HTTP 200 in 8.321426s

=== Round 3 ===

[struct3] HTTP 200 in 8.228278s

[struct1] HTTP 200 in 8.285084s

[struct2] HTTP 200 in 8.338866s

=== Round 4 ===

[struct3] HTTP 200 in 8.287179s

[struct1] HTTP 200 in 8.343845s

[struct2] HTTP 200 in 8.396179s

=== Round 5 ===

[struct1] HTTP 200 in 8.220125s

[struct3] HTTP 200 in 8.275086s

[struct2] HTTP 200 in 8.327450s

=== Done ===
```
Server logs
```
(APIServer pid=1) INFO:     10.88.0.1:44824 - "GET /v1/models HTTP/1.1" 200 OK
(APIServer pid=1) INFO 06-05 06:19:05 [logger.py:63] Received request chatcmpl-a299d171dd9e38fa: params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], thinking_token_budget=None, include_stop_str_in_output=False, ignore_eos=False, max_tokens=128, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, structured_outputs=StructuredOutputsParams(json=None, regex=None, choice=None, grammar=None, json_object=True, disable_any_whitespace=False, disable_additional_properties=False, whitespace_pattern=None, structural_tag=None, _backend=None, _backend_was_auto=False), extra_args=None), lora_request: None.
(APIServer pid=1) INFO 06-05 06:19:05 [async_llm.py:420] Added request chatcmpl-a299d171dd9e38fa-b6167469.
(APIServer pid=1) INFO 06-05 06:19:05 [logger.py:63] Received request chatcmpl-9800d0c814755a89: params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], thinking_token_budget=None, include_stop_str_in_output=False, ignore_eos=False, max_tokens=128, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, structured_outputs=StructuredOutputsParams(json=None, regex=None, choice=None, grammar=None, json_object=True, disable_any_whitespace=False, disable_additional_properties=False, whitespace_pattern=None, structural_tag=None, _backend=None, _backend_was_auto=False), extra_args=None), lora_request: None.
(APIServer pid=1) INFO 06-05 06:19:05 [async_llm.py:420] Added request chatcmpl-9800d0c814755a89-a096684c.
(APIServer pid=1) INFO 06-05 06:19:05 [logger.py:63] Received request chatcmpl-beccc4d147019952: params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], thinking_token_budget=None, include_stop_str_in_output=False, ignore_eos=False, max_tokens=128, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, structured_outputs=StructuredOutputsParams(json=None, regex=None, choice=None, grammar=None, json_object=True, disable_any_whitespace=False, disable_additional_properties=False, whitespace_pattern=None, structural_tag=None, _backend=None, _backend_was_auto=False), extra_args=None), lora_request: None.
(APIServer pid=1) INFO 06-05 06:19:05 [async_llm.py:420] Added request chatcmpl-beccc4d147019952-969d7db7.
(APIServer pid=1) INFO 06-05 06:19:12 [loggers.py:259] Engine 000: Avg prompt throughput: 6.1 tokens/s, Avg generation throughput: 24.1 tokens/s, Running: 3 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.1%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO:     10.88.0.1:44830 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=1) INFO:     10.88.0.1:44836 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=1) INFO:     10.88.0.1:44842 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```
## Checklist

- [x] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [x] My code follows the project's code style (run `bash format.sh`)
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)

---------

<!-- markdownlint-disable -->

## Description

<!-- Provide a clear description of your changes. -->

## Related Issues

<!-- Link related issues, e.g., `Fixes #` or `Relates to #456` -->

## Test Plan

<!-- Describe how you tested your changes. Include commands or steps to reproduce. -->

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
