### PR TITLE
Revert conditional kv_cache assignment to save memory

### DIFF
--- a/sendnn_inference/model_executor/model_loader/spyre.py
+++ b/sendnn_inference/model_executor/model_loader/spyre.py
@@ -475,11 +475,11 @@ class SpyreCausalLM(nn.Module):
 
         # The second item in the output tuple is the KV cache.
         # However, on spyre these are ghost tensors- the data in these tensors does not reflect the
-        # actual kv cache data on the device. They exist only for proper compilation, so we don't
-        # waste any time assigning these tensors back to anything.
-        logits, kv_cache = output
-        if not self.on_spyre:
-            self.past_key_value_states = kv_cache
+        # actual kv cache data on the device. They exist only for proper compilation.
+        # Assigning self.past_key_value_states results in a minor (~1ms)
+        # performance decrease but avoids a ~20gb memory increase when
+        # the value is conditionally assigned.
+        logits, self.past_key_value_states = output
 
         if is_prompt:
             # assert that indeed received the last block of logits


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

### Summary
This PR reverts the changes introduced in [#905](https://github.com/torch-spyre/sendnn-inference/pull/905), which made the kv_cache assignment conditional based on Spyre card usage.

### Background
PR #905 modified the kv_cache assignment logic (which uses dummy values when running on Spyre) from unconditional to conditional assignment. This change was motivated by profiling results indicating a ~1ms performance overhead from the assignment operation.

### Issue
While the conditional assignment provided a minor performance improvement, it introduced a significant memory overhead: torch.compile allocates an additional ~20GB of memory to accommodate the branching code paths.

### Decision
After team discussion, we determined that memory conservation is more critical than the marginal performance gain. Therefore, we are reverting PR #905 to restore the original unconditional assignment behavior.



## Checklist

- [x] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [x] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
