### PR TITLE
Granite-vision-3.3-2b, TP=2 fix max model len value

### DIFF
--- a/sendnn_inference/config/model_configs.yaml
+++ b/sendnn_inference/config/model_configs.yaml
@@ -255,7 +255,7 @@ models:
         max_model_len: 8192
         max_num_seqs: 16
       - tp_size: 2
-        max_model_len: 16382
+        max_model_len: 16384
         max_num_seqs: 16
         device_config: *granite_vision_2b_tp2_device_config
       - tp_size: 4


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

<!-- Provide a clear description of your changes. -->

Fix the value for granite-vision-3.3-2b tp=2 max model len to be the correct value of 16384 instead of 16382 

## Related Issues

<!-- Link related issues, e.g., `Fixes #` or `Relates to #456` -->

## Test Plan

<!-- Describe how you tested your changes. Include commands or steps to reproduce. -->
1) Edit the change in model_configs.yaml
2) Start up the vllm server on Power System: `./container-scripts/vllm_start_ppc64le.sh -tp 2 --model /models/granite-vision-3.3-2b/ --max-model-len 16384 --max-num-seqs 16`
3) Wait until server is up

## Checklist

- [x] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [x] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
