### PR TITLE
Allow worker processing MM embedding to have more threads

### DIFF
--- a/docs/user_guide/configuration.md
+++ b/docs/user_guide/configuration.md
@@ -128,7 +128,7 @@ For multimodal models, vision encoding is offloaded to the CPU. In order to prev
 Text-only models set the number of available threads through dividing the number of available CPUs available by number of worker and only assigning that per worker.
 Multimodal models currently set the number of available threads to the number of available cpus available, ignoring the number of workers. This may be changed in the future.
 
-The maximum available number of CPUs also can be set using `SENDNN_INFERENCE_NUM_CPUS`. 
+The maximum available number of CPUs also can be set using `SENDNN_INFERENCE_NUM_CPUS`.
 
 ## Pooling Models
 

--- a/docs/user_guide/configuration.md
+++ b/docs/user_guide/configuration.md
@@ -125,8 +125,10 @@ When prefix caching is enabled, the `vllm:prefix_cache_queries` and `vllm:prefix
 
 For multimodal models, vision encoding is offloaded to the CPU. In order to prevent expensive duplication of vision encoding, prefill during multimodal models is slightly different than that of text-only models. Vision encoding is done once per request instead of per worker so the threading configuration for multimodal models is also slightly different to improve performance.
 
-Text-only models set the number of available threads through dividing the number of available cpus available by number of worker and only assigning that per worker.
+Text-only models set the number of available threads through dividing the number of available CPUs available by number of worker and only assigning that per worker.
 Multimodal models currently set the number of available threads to the number of available cpus available, ignoring the number of workers. This may be changed in the future.
+
+The maximum available number of CPUs also can be set using `SENDNN_INFERENCE_NUM_CPUS`. 
 
 ## Pooling Models
 

--- a/docs/user_guide/configuration.md
+++ b/docs/user_guide/configuration.md
@@ -121,6 +121,13 @@ Prefix caching mirrors upstream vLLM, though the requirement for fixed-size pref
 
 When prefix caching is enabled, the `vllm:prefix_cache_queries` and `vllm:prefix_cache_hits` metrics correctly report prefix cache stats in tokens.
 
+### Multimodal Models
+
+For multimodal models, vision encoding is offloaded to the CPU. In order to prevent expensive duplication of vision encoding, prefill during multimodal models is slightly different than that of text-only models. Vision encoding is done once per request instead of per worker so the threading configuration for multimodal models is also slightly different to improve performance.
+
+Text-only models set the number of available threads through dividing the number of available cpus available by number of worker and only assigning that per worker.
+Multimodal models currently set the number of available threads to the number of available cpus available, ignoring the number of workers. This may be changed in the future.
+
 ## Pooling Models
 
 For the embedding, scoring, and reranking tasks, vLLM supports running Pooling Models. More information on Pooling Models can be found in the [vLLM official documentation](https://docs.vllm.ai/en/latest/models/pooling_models/).

--- a/sendnn_inference/envs.py
+++ b/sendnn_inference/envs.py
@@ -92,6 +92,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Allow sendnn-inference to update env vars related to multi-threading (eg. OMP)
     # based on the detected CPU cores and server configuration
+    # Multimodal models will not take into account the number of workers for configuration.
     "SENDNN_INFERENCE_UPDATE_THREAD_CONFIG": lambda: bool(
         int(os.getenv("SENDNN_INFERENCE_UPDATE_THREAD_CONFIG", "1"))
     ),

--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -635,7 +635,12 @@ class SpyrePlatform(Platform):
 
         # NOTE: math.ceil can output a number for each worker that sums
         # to a total greater than cpu_count.
-        cpus_per_worker = math.ceil(cpu_count / worker_count) if cpu_count is not None else None
+        thread_factor = worker_count
+        if cls._config.model_config.is_multimodal_model:
+            # thread_factor value/formula subject to further tuning
+            thread_factor = 1
+
+        cpus_per_worker = math.ceil(cpu_count / thread_factor) if cpu_count is not None else None
 
         thread_warning = (
             "Excessive threads may result in CPU contention. "


### PR DESCRIPTION


<!-- markdownlint-disable -->

## Description

Allow worker processing MM embedding to have more threads. Current implementation removes dividing cores by number of cards though further tuning with different values/formulas can be investigated later

## Related Issues

https://github.com/torch-spyre/sendnn-inference/pull/992

## Test Plan
Tested with the following models

granite-3.3-8b TP4
(EngineCore pid=39871) INFO 06-19 15:42:43 [platform.py:583] Initial threading configurations: OMP_NUM_THREADS=12 DT_PARALLEL_THREADS=12 OPENBLAS_NUM_THREADS=12 MKL_NUM_THREADS=12
(EngineCore pid=39871) INFO 06-19 15:42:43 [platform.py:666] Detected 48.0 physical CPUs from psutil.cpu_count(logical=False) for 4 workers. Since SENDNN_INFERENCE_UPDATE_THREAD_CONFIG is enabled, setting threading configurations to 12

mistral TP2
(EngineCore pid=40334) INFO 06-19 15:47:19 [platform.py:583] Initial threading configurations: OMP_NUM_THREADS=48 DT_PARALLEL_THREADS=48 OPENBLAS_NUM_THREADS=48 MKL_NUM_THREADS=48
(EngineCore pid=40334) INFO 06-19 15:47:19 [platform.py:666] Detected 48.0 physical CPUs from psutil.cpu_count(logical=False) for 2 workers. Since SENDNN_INFERENCE_UPDATE_THREAD_CONFIG is enabled, setting threading configurations to 48

ministral TP4
(EngineCore pid=40846) INFO 06-19 15:51:24 [platform.py:583] Initial threading configurations: OMP_NUM_THREADS=48 DT_PARALLEL_THREADS=48 OPENBLAS_NUM_THREADS=48 MKL_NUM_THREADS=48
(EngineCore pid=40846) INFO 06-19 15:51:24 [platform.py:666] Detected 48.0 physical CPUs from psutil.cpu_count(logical=False) for 4 workers. Since SENDNN_INFERENCE_UPDATE_THREAD_CONFIG is enabled, setting threading configurations to 48

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
