### PR TITLE
Feature: support --load-format dummy for random-init model loading

### DIFF
--- a/examples/offline_inference/long_context.py
+++ b/examples/offline_inference/long_context.py
@@ -45,6 +45,18 @@ if __name__ == "__main__":
     )
     parser.add_argument("--max-num-batched-tokens", type=int, default=1024)
     parser.add_argument("--backend", type=str, default="sendnn", choices=["eager", "sendnn"])
+    parser.add_argument(
+        "--tokenizer",
+        type=str,
+        default=None,
+        help="HF tokenizer id or path. Defaults to --model.",
+    )
+    parser.add_argument(
+        "--load-format",
+        type=str,
+        default="auto",
+        help="vLLM load format: auto, dummy, safetensors, pt, ... `dummy` random-inits weights.",
+    )
 
     args = parser.parse_args()
 
@@ -95,7 +107,7 @@ if __name__ == "__main__":
     prompts = prompts * (args.num_prompts // len(prompts) + 1)
     prompts = prompts[0 : args.num_prompts]
 
-    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer or args.model)
 
     tokenized_prompts = tokenizer(prompts)["input_ids"]
     tokenized_prompts = [p[: args.max_prompt_len] for p in tokenized_prompts]
@@ -124,7 +136,8 @@ if __name__ == "__main__":
     # Create an LLM.
     llm = LLM(
         model=args.model,
-        tokenizer=args.model,
+        tokenizer=args.tokenizer or args.model,
+        load_format=args.load_format,
         max_model_len=args.max_model_len,
         max_num_seqs=args.max_num_seqs,
         tensor_parallel_size=args.tp,

--- a/examples/offline_inference/text_inference.py
+++ b/examples/offline_inference/text_inference.py
@@ -29,6 +29,18 @@ if __name__ == "__main__":
     )
     parser.add_argument("--max-num-batched-tokens", type=int, default=1024)
     parser.add_argument("--backend", type=str, default="eager", choices=["eager", "sendnn"])
+    parser.add_argument(
+        "--tokenizer",
+        type=str,
+        default=None,
+        help="HF tokenizer id or path. Defaults to --model.",
+    )
+    parser.add_argument(
+        "--load-format",
+        type=str,
+        default="auto",
+        help="vLLM load format: auto, dummy, safetensors, pt, ... `dummy` random-inits weights.",
+    )
 
     args = parser.parse_args()
 
@@ -84,7 +96,8 @@ if __name__ == "__main__":
     # Create an LLM.
     llm = LLM(
         model=args.model,
-        tokenizer=args.model,
+        tokenizer=args.tokenizer or args.model,
+        load_format=args.load_format,
         max_model_len=args.max_model_len,
         max_num_seqs=args.max_num_seqs,
         tensor_parallel_size=args.tp,

--- a/sendnn_inference/model_executor/model_loader/spyre.py
+++ b/sendnn_inference/model_executor/model_loader/spyre.py
@@ -72,6 +72,7 @@ class SpyreCausalLM(nn.Module):
         self.parallel_config = vllm_config.parallel_config
         self.cache_config = vllm_config.cache_config
         self.scheduler_config = vllm_config.scheduler_config
+        self.load_config = vllm_config.load_config
         self.dtype = self.get_dtype()
 
         # Wrappers for utils for multimodal
@@ -171,16 +172,30 @@ class SpyreCausalLM(nn.Module):
                     self.dtype,
                 )
 
-        is_local = os.path.isdir(model_config.model)
-        model_path = model_config.model
-        # Get location of model from HF cache.
-        if not is_local:
-            model_path = download_weights_from_hf(
-                model_name_or_path=model_path,
-                cache_dir=None,
-                allow_patterns=["*.safetensors", "*.bin", "*.pt"],
-                revision=model_config.revision,
+        # `--load-format dummy` skips the checkpoint download and routes through
+        # FMS's `hf_configured` path, which fetches only config.json and then
+        # random-inits the model via `reset_parameters()`.
+        variant: str | None = None
+        if self.load_config.load_format == "dummy":
+            logger.info(
+                "Loading model %s with random weights.",
+                model_config.model,
             )
+            architecture = "hf_configured"
+            variant = model_config.model
+            model_path: str | None = None
+        else:
+            architecture = "hf_pretrained"
+            is_local = os.path.isdir(model_config.model)
+            model_path = model_config.model
+            # Get location of model from HF cache.
+            if not is_local:
+                model_path = download_weights_from_hf(
+                    model_name_or_path=model_path,
+                    cache_dir=None,
+                    allow_patterns=["*.safetensors", "*.bin", "*.pt"],
+                    revision=model_config.revision,
+                )
 
         # Get any fixes needed that must be patched into the kwargs;
         # currently this is only use for multimodal models / llava next
@@ -192,7 +207,8 @@ class SpyreCausalLM(nn.Module):
             kwargs["rank"],
         ):
             self.fms_model = get_model(
-                architecture="hf_pretrained",
+                architecture=architecture,
+                variant=variant,
                 model_path=model_path,
                 distributed_strategy=distributed_strategy,
                 group=dist.group.WORLD,

--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -242,6 +242,12 @@ class SpyrePlatform(Platform):
         if not is_decoder and not is_pooling:
             raise ValueError("Only the 'generate' and 'pooling' runners are supported")
 
+        if vllm_config.load_config.load_format == "dummy" and model_config.is_multimodal_model:
+            raise ValueError(
+                "--load-format dummy is not supported for multimodal models; "
+                "random-weight init is currently only supported for text models."
+            )
+
         if parallel_config.worker_cls == "auto":
             parallel_config.worker_cls = "sendnn_inference.v1.worker.spyre_worker.SpyreWorker"
 

--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -242,10 +242,12 @@ class SpyrePlatform(Platform):
         if not is_decoder and not is_pooling:
             raise ValueError("Only the 'generate' and 'pooling' runners are supported")
 
-        if vllm_config.load_config.load_format == "dummy" and model_config.is_multimodal_model:
+        if vllm_config.load_config.load_format == "dummy" and (
+            model_config.is_multimodal_model or is_pooling
+        ):
             raise ValueError(
-                "--load-format dummy is not supported for multimodal models; "
-                "random-weight init is currently only supported for text models."
+                "--load-format dummy is only supported for text generation models; "
+                "random-weight init is not implemented for multimodal or pooling models."
             )
 
         if parallel_config.worker_cls == "auto":

--- a/tests/e2e/test_load_format_dummy.py
+++ b/tests/e2e/test_load_format_dummy.py
@@ -1,0 +1,39 @@
+"""Smoke test for `--load-format dummy` (random init, no checkpoint load)."""
+
+import pytest
+from spyre_util import ModelInfo, get_chicken_soup_prompts
+from vllm import LLM, SamplingParams
+
+from sendnn_inference import envs as envs_spyre
+
+
+@pytest.mark.cpu
+def test_load_format_dummy_generates_tokens(
+    model: ModelInfo,
+    max_model_len: int,
+    max_num_seqs: int,
+    max_num_batched_tokens: int,
+):
+    """The dummy load path random-inits weights and still produces tokens
+    (output content is meaningless and not checked)."""
+    envs_spyre.override("SENDNN_INFERENCE_DYNAMO_BACKEND", "eager")
+
+    prompts = get_chicken_soup_prompts(1)
+    max_new_tokens = 4
+
+    llm = LLM(
+        model=model.name,
+        revision=model.revision,
+        load_format="dummy",
+        max_model_len=max_model_len,
+        max_num_seqs=max_num_seqs,
+        max_num_batched_tokens=max_num_batched_tokens,
+    )
+
+    outputs = llm.generate(
+        prompts,
+        SamplingParams(max_tokens=max_new_tokens, temperature=0.0, ignore_eos=True),
+    )
+
+    assert len(outputs) == 1
+    assert len(outputs[0].outputs[0].token_ids) == max_new_tokens


### PR DESCRIPTION
## Description

Adds support for loading any causal-LM model with `--load-format dummy`, so weights are random-initialized and no checkpoint needs to be downloaded.

Note: Pooling and multimodal are out of scope (separate code paths). 

## Related Issues

This substantially simplifies model enablement and bench-marking without an available checkpoint. 

## Test Plan

added `tests/e2e/test_load_format_dummy.py`

## Checklist

- [x] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [x] My code follows the project's code style (run `bash format.sh`)
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
