### PR TITLE
Add Power-specific threading configuration for multimodal models

### DIFF
--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -1,4 +1,5 @@
 import sys
+import platform
 from string import Template
 import multiprocessing
 import importlib.metadata
@@ -643,12 +644,16 @@ class SpyrePlatform(Platform):
 
         # NOTE: math.ceil can output a number for each worker that sums
         # to a total greater than cpu_count.
-        thread_factor = worker_count
         if cls._config.model_config.is_multimodal_model:
-            # thread_factor value/formula subject to further tuning
-            thread_factor = 1
-
-        cpus_per_worker = math.ceil(cpu_count / thread_factor) if cpu_count is not None else None
+            if platform.machine() == "ppc64le":
+                cpus_per_worker = (
+                    min(psutil.cpu_count(logical=True), 36) if cpu_count is not None else None
+                )
+            else:
+                # Formula for cpus_per_worker can be adjusted per architecture
+                cpus_per_worker = math.ceil(cpu_count) if cpu_count is not None else None
+        else:
+            cpus_per_worker = math.ceil(cpu_count / worker_count) if cpu_count is not None else None
 
         thread_warning = (
             "Excessive threads may result in CPU contention. "


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Add Power-specific threading configurations for multimodal models. If using a multimodal model on Power, workers will be assigned min(total threads, 36) based on tuning runs. If not on Power, then when using a multimodal model, workers will get be assigned # of physical cores. Threading configurations for other architectures can be added.

## Related Issues
https://github.com/torch-spyre/sendnn-inference/pull/992
https://github.com/torch-spyre/sendnn-inference/pull/1012

## Test Plan

```
(EngineCore pid=444) INFO 06-25 18:15:51 [platform.py:592] Initial threading configurations: OMP_NUM_THREADS=36 DT_PARALLEL_THREADS=36 OPENBLAS_NUM_THREADS=36 MKL_NUM_THREADS=36                     
(EngineCore pid=444) INFO 06-25 18:15:51 [platform.py:679] Detected 48.0 physical CPUs from psutil.cpu_count(logical=False) for 4 workers. Since SENDNN_INFERENCE_UPDATE_THREAD_CONFIG is enabled, set
ting threading configurations to 36 
```
Confirmed that threading configuration is set correctly on a Power system with 384 threads (48 physical CPUs, SMT8)

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
