### PR TITLE
Force pooling models to load in float16

### DIFF
--- a/sendnn_inference/v1/worker/spyre_model_runner.py
+++ b/sendnn_inference/v1/worker/spyre_model_runner.py
@@ -672,14 +672,10 @@ class SpyrePoolingModelRunner(
 
                 hidden_states = outputs[0]
             else:
-                mask = model_input.input_masks
-                full_mask = mask[:, None, None, :].repeat(1, 1, mask.shape[-1], 1)
-                full_mask = full_mask * full_mask.transpose(-1, -2)
-                full_mask = torch.where(full_mask > 0, 0.0, -torch.inf).to(torch.float16)
                 outputs = self.model(
                     input_ids=model_input.input_tokens,
                     position_ids=model_input.input_positions,
-                    attention_mask=full_mask,
+                    attention_mask=model_input.input_masks,
                     **model_kwargs,
                 )
 

--- a/sendnn_inference/v1/worker/spyre_model_runner.py
+++ b/sendnn_inference/v1/worker/spyre_model_runner.py
@@ -324,7 +324,9 @@ class SpyrePoolingModelRunner(
                 )
                 self._model = self._model.base_model
             else:
-                self._model = AutoModel.from_pretrained(self.model_config.model)
+                self._model = AutoModel.from_pretrained(
+                    self.model_config.model, dtype=torch.float16
+                )
         elif task == "classify":
             class_model = AutoModelForSequenceClassification.from_pretrained(
                 self.model_config.model
@@ -670,10 +672,14 @@ class SpyrePoolingModelRunner(
 
                 hidden_states = outputs[0]
             else:
+                mask = model_input.input_masks
+                full_mask = mask[:, None, None, :].repeat(1, 1, mask.shape[-1], 1)
+                full_mask = full_mask * full_mask.transpose(-1, -2)
+                full_mask = torch.where(full_mask > 0, 0.0, -torch.inf).to(torch.float16)
                 outputs = self.model(
                     input_ids=model_input.input_tokens,
                     position_ids=model_input.input_positions,
-                    attention_mask=model_input.input_masks,
+                    attention_mask=full_mask,
                     **model_kwargs,
                 )
 


### PR DESCRIPTION
Since [transfomers 5](https://github.com/huggingface/transformers/releases/tag/v5.0.0#:~:text=Default%20dtype%20update) the model load in the dtype that is specified in config.json instead of float32

The full mask expansion silences a torch_sendnn warning but it doesn't seem to be necessary.  ~I'm still benchmarking to see if it affects the performance.~ And it's slower, so for now we let sendnn print the warning.

