### PR TITLE
Model config_format and tokenizer_mode conditional defaults fix

### DIFF
--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -849,7 +849,7 @@ def _compute_config_format(namespace: argparse.Namespace) -> str:
 
     This uses any_pattern_in_repo_files which correctly handles both local paths
     and HuggingFace cache, including offline mode support.
-    
+
     Note: params.json in the 'original/' subdirectory (found in some Llama models)
     is ignored as it doesn't indicate mistral format.
     """

--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -845,12 +845,15 @@ class SpyrePlatform(Platform):
 
 
 def _compute_config_format(namespace: argparse.Namespace) -> str:
-    """Check if a model is in mistral format.
+    """Check if a model is in mistral format by looking for params.json.
 
-    Uses vLLM's is_mistral_model_repo which checks for consolidated*.safetensors
-    files that are characteristic of Mistral-format models.
+    This uses any_pattern_in_repo_files which correctly handles both local paths
+    and HuggingFace cache, including offline mode support.
+    
+    Note: params.json in the 'original/' subdirectory (found in some Llama models)
+    is ignored as it doesn't indicate mistral format.
     """
-    from vllm.transformers_utils.repo_utils import is_mistral_model_repo, get_model_path
+    from vllm.transformers_utils.repo_utils import any_pattern_in_repo_files, get_model_path
 
     # Check both 'model' and 'model_tag' since vLLM uses different
     # attribute names in different contexts
@@ -867,12 +870,21 @@ def _compute_config_format(namespace: argparse.Namespace) -> str:
     if huggingface_hub.constants.HF_HUB_OFFLINE:
         model = get_model_path(model, revision)
 
-    # Use vLLM's built-in function to detect Mistral-format models
-    if is_mistral_model_repo(
-        model_name_or_path=model,
+    # Look for params.json which indicates a mistral-format model
+    if any_pattern_in_repo_files(
+        model,
+        allow_patterns=["params.json"],
         revision=revision,
         token=token,
     ):
+        # Check if params.json is in the 'original/' subdirectory
+        # If so, it's not a mistral model (e.g., Llama models with original/ directory)
+        if any_pattern_in_repo_files(
+            model,
+            allow_patterns=["original/params.json"],
+            revision=revision,
+            token=token,
+        ):
+            return "auto"
         return "mistral"
-
     return "auto"

--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -875,6 +875,10 @@ def _compute_config_format(namespace: argparse.Namespace) -> str:
 
     This uses any_pattern_in_repo_files which correctly handles both local paths
     and HuggingFace cache, including offline mode support.
+    
+    Note: Only root-level params.json indicates mistral format. Files in
+    subdirectories like original/params.json (found in some Llama models)
+    should be ignored.
     """
     from vllm.transformers_utils.repo_utils import any_pattern_in_repo_files, get_model_path
 
@@ -894,9 +898,11 @@ def _compute_config_format(namespace: argparse.Namespace) -> str:
         model = get_model_path(model, revision)
 
     # Look for params.json which indicates a mistral-format model
+    # Exclude subdirectories like original/ to avoid false positives with Llama models
     if any_pattern_in_repo_files(
         model,
         allow_patterns=["params.json"],
+        ignore_patterns=["original/**", "**/original/**"],
         revision=revision,
         token=token,
     ):

--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -873,14 +873,14 @@ class SpyrePlatform(Platform):
 def _compute_config_format(namespace: argparse.Namespace) -> str:
     """Check if a model is in mistral format by looking for params.json.
 
-    This uses any_pattern_in_repo_files which correctly handles both local paths
+    This uses get_repo_files which correctly handles both local paths
     and HuggingFace cache, including offline mode support.
     
     Note: Only root-level params.json indicates mistral format. Files in
     subdirectories like original/params.json (found in some Llama models)
     should be ignored.
     """
-    from vllm.transformers_utils.repo_utils import any_pattern_in_repo_files, get_model_path
+    from vllm.transformers_utils.repo_utils import get_repo_files, get_model_path
 
     # Check both 'model' and 'model_tag' since vLLM uses different
     # attribute names in different contexts
@@ -898,15 +898,20 @@ def _compute_config_format(namespace: argparse.Namespace) -> str:
         model = get_model_path(model, revision)
 
     # Look for params.json which indicates a mistral-format model
-    # Exclude subdirectories like original/ to avoid false positives with Llama models
-    if any_pattern_in_repo_files(
-        model,
-        allow_patterns=["params.json"],
-        ignore_patterns=["original/**", "**/original/**"],
-        revision=revision,
-        token=token,
-    ):
-        return "mistral"
+    # Only root-level params.json should trigger mistral format, not files in subdirectories
+    try:
+        files = get_repo_files(
+            model,
+            allow_patterns=["**/params.json"],
+            revision=revision,
+            token=token,
+        )
+        # Check if params.json exists at root level (not in subdirectories)
+        if "params.json" in files:
+            return "mistral"
+    except Exception as e:
+        logger.debug("Error checking for params.json: %s", e)
+    
     return "auto"
 
 

--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -871,16 +871,12 @@ class SpyrePlatform(Platform):
 
 
 def _compute_config_format(namespace: argparse.Namespace) -> str:
-    """Check if a model is in mistral format by looking for params.json.
+    """Check if a model is in mistral format.
 
-    This uses get_repo_files which correctly handles both local paths
-    and HuggingFace cache, including offline mode support.
-    
-    Note: Only root-level params.json indicates mistral format. Files in
-    subdirectories like original/params.json (found in some Llama models)
-    should be ignored.
+    Uses vLLM's is_mistral_model_repo which checks for consolidated*.safetensors
+    files that are characteristic of Mistral-format models.
     """
-    from vllm.transformers_utils.repo_utils import get_repo_files, get_model_path
+    from vllm.transformers_utils.repo_utils import is_mistral_model_repo
 
     # Check both 'model' and 'model_tag' since vLLM uses different
     # attribute names in different contexts
@@ -893,24 +889,13 @@ def _compute_config_format(namespace: argparse.Namespace) -> str:
     revision = getattr(namespace, "revision", None)
     token = getattr(namespace, "hf_token", None)
 
-    # Resolve local path in offline mode (if not already a local path)
-    if huggingface_hub.constants.HF_HUB_OFFLINE:
-        model = get_model_path(model, revision)
-
-    # Look for params.json which indicates a mistral-format model
-    # Only root-level params.json should trigger mistral format, not files in subdirectories
-    try:
-        files = get_repo_files(
-            model,
-            allow_patterns=["**/params.json"],
-            revision=revision,
-            token=token,
-        )
-        # Check if params.json exists at root level (not in subdirectories)
-        if "params.json" in files:
-            return "mistral"
-    except Exception as e:
-        logger.debug("Error checking for params.json: %s", e)
+    # Use vLLM's built-in function to detect Mistral-format models
+    if is_mistral_model_repo(
+        model_name_or_path=model,
+        revision=revision,
+        token=token,
+    ):
+        return "mistral"
     
     return "auto"
 

--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -900,7 +900,7 @@ def _compute_config_format(namespace: argparse.Namespace) -> str:
         token=token,
     ):
         return "mistral"
-    
+
     return "auto"
 
 

--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -876,7 +876,7 @@ def _compute_config_format(namespace: argparse.Namespace) -> str:
     Uses vLLM's is_mistral_model_repo which checks for consolidated*.safetensors
     files that are characteristic of Mistral-format models.
     """
-    from vllm.transformers_utils.repo_utils import is_mistral_model_repo
+    from vllm.transformers_utils.repo_utils import is_mistral_model_repo, get_model_path
 
     # Check both 'model' and 'model_tag' since vLLM uses different
     # attribute names in different contexts
@@ -888,6 +888,10 @@ def _compute_config_format(namespace: argparse.Namespace) -> str:
     # Get optional HF arguments
     revision = getattr(namespace, "revision", None)
     token = getattr(namespace, "hf_token", None)
+
+    # Resolve local path in offline mode (if not already a local path)
+    if huggingface_hub.constants.HF_HUB_OFFLINE:
+        model = get_model_path(model, revision)
 
     # Use vLLM's built-in function to detect Mistral-format models
     if is_mistral_model_repo(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This PR updates the logic used to apply conditional defaults for `config_format` and `tokenizer_mode`. 

The previous implementation was incorrectly assigning mistral formatting to Llama models from HF as it was recursively searching the model files for a `params.json` file which was present in a subdirectory of some Llama models.

The new implementation uses `is_mistral_model_repo` which checks for `consolidated*.safetensors` file which is a more accurate check for mistral models.

## Related Issues

## Test Plan

Tested with various supported models and it correctly detects mistral for supported mistral family models while defaulting to auto for non-mistral models.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [x] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
