### PR TITLE
Set attn backend to eager for pooling models

### DIFF
--- a/sendnn_inference/v1/worker/spyre_model_runner.py
+++ b/sendnn_inference/v1/worker/spyre_model_runner.py
@@ -328,11 +328,11 @@ class SpyrePoolingModelRunner(
                 self._model = self._model.base_model
             else:
                 self._model = AutoModel.from_pretrained(
-                    self.model_config.model, dtype=torch.float16
+                    self.model_config.model, dtype=torch.float16, attn_implementation="eager"
                 )
         elif task == "classify":
             class_model = AutoModelForSequenceClassification.from_pretrained(
-                self.model_config.model
+                self.model_config.model, dtype=torch.float16, attn_implementation="eager"
             )
             if hasattr(class_model, "bert"):
                 self._model = class_model.bert

--- a/sendnn_inference/v1/worker/spyre_model_runner.py
+++ b/sendnn_inference/v1/worker/spyre_model_runner.py
@@ -332,7 +332,7 @@ class SpyrePoolingModelRunner(
                 )
         elif task == "classify":
             class_model = AutoModelForSequenceClassification.from_pretrained(
-                self.model_config.model, dtype=torch.float16, attn_implementation="eager"
+                self.model_config.model, attn_implementation="eager"
             )
             if hasattr(class_model, "bert"):
                 self._model = class_model.bert


### PR DESCRIPTION
With transformers 5 the default became "sdpa" and that is causing very long compilation times as well as
compiler crashes
