### PR TITLE
:triangular_flag_on_post: Enable MM encoding feature by default for a…

### DIFF
--- a/sendnn_inference/envs.py
+++ b/sendnn_inference/envs.py
@@ -35,7 +35,7 @@ logger = init_logger(__name__)
 
 _cache: dict[str, Any] = {}
 
-_CPU_MM_DTYPE_PLATFORM_DEFAULTS = {"s390x": "float32", "ppc64le": "bfloat16"}
+_CPU_MM_DTYPE_PLATFORM_DEFAULTS = {"s390x": "float32", "ppc64le": "float32"}
 
 
 def override(name: str, value: str) -> None:

--- a/sendnn_inference/envs.py
+++ b/sendnn_inference/envs.py
@@ -184,12 +184,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # its embedding is available.  Only effective for decoder models with TP > 1.
     # Defaults to 0 (disabled) — uses the Phase 1 blocking encode path.
     "SENDNN_INFERENCE_ASYNC_MM_ENCODER": lambda: bool(
-        int(
-            os.getenv(
-                "SENDNN_INFERENCE_ASYNC_MM_ENCODER",
-                "0" if platform.machine() == "ppc64le" else "1",
-            )
-        )
+        int(os.getenv("SENDNN_INFERENCE_ASYNC_MM_ENCODER", "1"))
     ),
     # When "1" (default), rank 0 runs the vision encoder and shares the result
     # with other TP ranks via POSIX shared memory (one encoder call instead of

--- a/tests/utils/test_envs.py
+++ b/tests/utils/test_envs.py
@@ -48,7 +48,7 @@ def test_env_vars_override_for_invalid_config():
     "machine,expected",
     [
         ("s390x", torch.float32),
-        ("ppc64le", torch.bfloat16),
+        ("ppc64le", torch.float32),
         ("x86_64", torch.float16),
         ("aarch64", torch.float16),
     ],


### PR DESCRIPTION
…ll platform

<!-- markdownlint-disable -->

## Description

Enable separate encoder for power by default.

## Related Issues

<!-- Link related issues, e.g., `Fixes #` or `Relates to #456` -->

## Test Plan

<!-- Describe how you tested your changes. Include commands or steps to reproduce. -->

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
