### PR TITLE
Fix for prefix cache hit rate overcounting 

### DIFF
--- a/sendnn_inference/v1/core/scheduler.py
+++ b/sendnn_inference/v1/core/scheduler.py
@@ -533,7 +533,10 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
             # NB: self.kv_cache_manager comes from the parent class, and we are being super nosy.
             # This update ensures that we know when we're scheduling the last prefix chunk, in the
             # case where most of the prompt hits prefix cache and we only run a single chunk.
+            prev_log_stats = self.kv_cache_manager.log_stats
+            self.kv_cache_manager.log_stats = False
             _, num_computed_tokens = self.kv_cache_manager.get_computed_blocks(request)
+            self.kv_cache_manager.log_stats = prev_log_stats
 
         is_first_chunk = request.num_computed_tokens == 0
         is_last_chunk = (request.num_prompt_tokens - num_computed_tokens) <= self.chunk_size

--- a/tests/e2e/test_chunked_prefill.py
+++ b/tests/e2e/test_chunked_prefill.py
@@ -213,6 +213,9 @@ async def test_chunked_prefill_kv_cache_stats(
     # Prefix cache rate won't be 100% because of chunking, but we should still
     # hit _some_ cache
     assert hit_tokens / total_tokens > 0.1
+    # Prefix cache rate shouldn't be over theoretical max.
+    # First order math - 1st prompt all chunks miss, subsequent prompts all chunks hit
+    assert hit_tokens / total_tokens < (requests_finished - 1) / requests_finished
 
 
 async def get_metrics(client: openai.AsyncOpenAI) -> list[str]:


### PR DESCRIPTION
Fix for prefix cache hit rate overcounting when checking constraints during scheduling

<!-- markdownlint-disable -->

## Description

When batching requests, _satisfies_constraints() is called for each request to check if it can be scheduled. Each call to get_computed_blocks() records prefix cache hits as a side effect (when log_stats=True) so prefix cache hit rate when batching is inflated

PR fixes this issue by disabling logging prefix cache hits in _satisfies_constraints() when calling get_computed_blocks()

## Related Issues

#1928

## Test Plan

Tested on Mistral so far. (8 identical requests, 17k input, 1k output)

1. Without patch - when sending 8 requests, 7 requests are batched and show inflated prefix cache hit rate (96%) that is indicative of 20+ requests. First order math on this would have expected maximum 85% prefix cache hit rate (1st request misses cache, 6 requests all hit)
```
(APIServer pid=780) INFO 07-14 19:41:51 [loggers.py:273] Engine 000: Avg prompt throughput: 1558.3 tokens/s, Avg generation throughput: 1.4 tokens/s, Running: 4 reqs, Waiting: 4 reqs, GPU KV cache usage: 3.0%, Prefix cache hit rate: 84.4%                                                                                                                                                              
(APIServer pid=780) INFO 07-14 19:42:01 [loggers.py:273] Engine 000: Avg prompt throughput: 12.0 tokens/s, Avg generation throughput: 24.5 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 3.1%, Prefix cache hit rate: 95.1%                                                                                                                                                               
(APIServer pid=780) INFO 07-14 19:42:11 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 36.4 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 3.1%, Prefix cache hit rate: 96.1%                                                                                                                                                                
(APIServer pid=780) INFO 07-14 19:42:21 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 36.4 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 3.2%, Prefix cache hit rate: 96.3%
(APIServer pid=780) INFO 07-14 19:42:31 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 36.4 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 3.3%, Prefix cache hit rate: 96.5%
(APIServer pid=780) INFO 07-14 19:42:41 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 36.4 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 3.4%, Prefix cache hit rate: 96.5%
(APIServer pid=780) INFO 07-14 19:42:51 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 36.4 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 3.5%, Prefix cache hit rate: 96.6%
(APIServer pid=780) INFO 07-14 19:43:01 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 36.4 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 3.5%, Prefix cache hit rate: 96.6%
(APIServer pid=780) INFO 07-14 19:43:11 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 36.4 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 3.5%, Prefix cache hit rate: 96.7%
(APIServer pid=780) INFO 07-14 19:43:21 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 36.4 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 3.6%, Prefix cache hit rate: 96.7%
(APIServer pid=780) INFO 07-14 19:43:31 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 36.4 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 3.7%, Prefix cache hit rate: 96.7%
(APIServer pid=780) INFO 07-14 19:43:41 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 36.4 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 3.8%, Prefix cache hit rate: 96.7%
(APIServer pid=780) INFO 07-14 19:43:51 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 36.4 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 3.9%, Prefix cache hit rate: 96.7%
(APIServer pid=780) INFO 07-14 19:44:01 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 36.4 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 3.9%, Prefix cache hit rate: 96.7%
(APIServer pid=780) INFO 07-14 19:44:11 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 37.1 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 4.0%, Prefix cache hit rate: 96.7%
```
2. Individual 8 requests show accurate prefix cache hit rate.
```
(APIServer pid=5150) INFO 07-14 21:33:52 [loggers.py:273] Engine 000: Avg prompt throughput: 1546.5 tokens/s, Avg generation throughput: 3.3 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 3.0%, Prefix cache hit rate: 0.0%  
(APIServer pid=5150) INFO 07-14 21:36:42 [loggers.py:273] Engine 000: Avg prompt throughput: 4.0 tokens/s, Avg generation throughput: 5.6 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 3.0%, Prefix cache hit rate: 48.4%
(APIServer pid=5150) INFO 07-14 21:39:02 [loggers.py:273] Engine 000: Avg prompt throughput: 4.0 tokens/s, Avg generation throughput: 1.0 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 3.0%, Prefix cache hit rate: 64.6%
(APIServer pid=5150) INFO 07-14 21:43:12 [loggers.py:273] Engine 000: Avg prompt throughput: 4.0 tokens/s, Avg generation throughput: 1.9 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 3.0%, Prefix cache hit rate: 72.6%
(APIServer pid=5150) INFO 07-14 21:49:42 [loggers.py:273] Engine 000: Avg prompt throughput: 4.0 tokens/s, Avg generation throughput: 1.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 3.0%, Prefix cache hit rate: 77.5%
(APIServer pid=5150) INFO 07-14 21:52:22 [loggers.py:273] Engine 000: Avg prompt throughput: 4.0 tokens/s, Avg generation throughput: 2.6 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 3.0%, Prefix cache hit rate: 80.7%
(APIServer pid=5150) INFO 07-14 21:55:02 [loggers.py:273] Engine 000: Avg prompt throughput: 4.0 tokens/s, Avg generation throughput: 1.9 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 3.0%, Prefix cache hit rate: 83.0%
(APIServer pid=5150) INFO 07-14 21:57:32 [loggers.py:273] Engine 000: Avg prompt throughput: 4.0 tokens/s, Avg generation throughput: 0.9 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 3.0%, Prefix cache hit rate: 84.7%
```
3. Running 8 identical requests in same method as (1) using PR. Prefix cache hit rate for batch matches that of individual requests in (2). 
```
(APIServer pid=5899) INFO 07-14 22:14:49 [loggers.py:273] Engine 000: Avg prompt throughput: 1550.4 tokens/s, Avg generation throughput: 0.3 tokens/s, Running: 2 reqs, Waiting: 6 reqs, GPU KV cache usage: 3.0%, Prefix cache hit rate: 48.4%
(APIServer pid=5899) INFO 07-14 22:14:59 [loggers.py:273] Engine 000: Avg prompt throughput: 20.0 tokens/s, Avg generation throughput: 9.5 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 3.0%, Prefix cache hit rate: 83.0%
(APIServer pid=5899) INFO 07-14 22:15:09 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 39.2 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 3.1%, Prefix cache hit rate: 83.0%
(APIServer pid=5899) INFO 07-14 22:15:19 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 39.2 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 3.2%, Prefix cache hit rate: 83.0%
(APIServer pid=5899) INFO 07-14 22:15:29 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 38.5 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 3.3%, Prefix cache hit rate: 83.0%
(APIServer pid=5899) INFO 07-14 22:15:39 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 39.9 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 3.4%, Prefix cache hit rate: 83.0%
(APIServer pid=5899) INFO 07-14 22:15:49 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 38.5 tokens/s, Running: 7 reqs, Waiting: 1 reqs, GPU KV cache usage: 3.5%, Prefix cache hit rate: 83.0%
...
(APIServer pid=5899) INFO 07-14 22:20:19 [loggers.py:273] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 84.7%
```

## Checklist

- [x] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [x] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
