### PR TITLE
Improve model config/tokenizer format defaults

### DIFF
--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -21,7 +21,6 @@ import os
 from typing import TYPE_CHECKING, cast, Literal
 
 import torch
-import huggingface_hub
 from vllm.logger import init_logger
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
@@ -886,15 +885,18 @@ class SpyrePlatform(Platform):
 
 
 def _compute_config_format(namespace: argparse.Namespace) -> str:
-    """Check if a model is in mistral format by looking for params.json.
+    """Check if a model is in mistral format by looking for params.json
+    at the root of the model directory.
 
-    This uses any_pattern_in_repo_files which correctly handles both local paths
-    and HuggingFace cache, including offline mode support.
+    A root-level params.json indicates a mistral-format model.
+    params.json found only inside the 'original/' subdirectory (as seen in
+    some Llama HF checkpoints) does NOT indicate mistral format and is ignored.
 
-    Note: params.json in the 'original/' subdirectory (found in some Llama models)
-    is ignored as it doesn't indicate mistral format.
+    To avoid ambiguity with glob/fnmatch pattern matching across local and remote
+    repos, the model path is always resolved to a local directory first, then
+    checked with os.path.isfile for exact root-level presence.
     """
-    from vllm.transformers_utils.repo_utils import any_pattern_in_repo_files, get_model_path
+    from vllm.transformers_utils.repo_utils import get_model_path
 
     # Check both 'model' and 'model_tag' since vLLM uses different
     # attribute names in different contexts
@@ -905,27 +907,12 @@ def _compute_config_format(namespace: argparse.Namespace) -> str:
 
     # Get optional HF arguments
     revision = getattr(namespace, "revision", None)
-    token = getattr(namespace, "hf_token", None)
 
-    # Resolve local path in offline mode (if not already a local path)
-    if huggingface_hub.constants.HF_HUB_OFFLINE:
-        model = get_model_path(model, revision)
+    # Resolve to a local path (works for both explicit local paths and HF cache)
+    model_path = get_model_path(model, revision)
 
-    # Look for params.json which indicates a mistral-format model
-    if any_pattern_in_repo_files(
-        model,
-        allow_patterns=["params.json"],
-        revision=revision,
-        token=token,
-    ):
-        # Check if params.json is in the 'original/' subdirectory
-        # If so, it's not a mistral model (e.g., Llama models with original/ directory)
-        if any_pattern_in_repo_files(
-            model,
-            allow_patterns=["original/params.json"],
-            revision=revision,
-            token=token,
-        ):
-            return "auto"
+    # A root-level params.json (and only root-level) indicates mistral format.
+    # os.path.isfile gives an unambiguous exact check — no glob/fnmatch involved.
+    if os.path.isfile(os.path.join(model_path, "params.json")):
         return "mistral"
     return "auto"

--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -20,6 +20,7 @@ import operator
 import os
 from typing import TYPE_CHECKING, cast, Literal
 
+import huggingface_hub
 import torch
 from vllm.logger import init_logger
 from vllm.utils.argparse_utils import FlexibleArgumentParser
@@ -897,7 +898,6 @@ def _compute_config_format(namespace: argparse.Namespace) -> str:
     avoids the os.path.basename stripping done by any_pattern_in_repo_files,
     which made the original subdirectory guard inoperable.
     """
-    import huggingface_hub
     from vllm.transformers_utils.repo_utils import get_model_path, list_repo_files
 
     # Check both 'model' and 'model_tag' since vLLM uses different

--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -892,11 +892,13 @@ def _compute_config_format(namespace: argparse.Namespace) -> str:
     params.json found only inside the 'original/' subdirectory (as seen in
     some Llama HF checkpoints) does NOT indicate mistral format and is ignored.
 
-    Uses list_repo_files which handles both local paths and remote HF repos,
-    then checks for an exact path match of "params.json" to avoid the
-    os.path.basename stripping done by any_pattern_in_repo_files/fnmatch.
+    Uses list_repo_files which returns full relative paths for both local
+    directories and remote HF repos. An exact membership check on "params.json"
+    avoids the os.path.basename stripping done by any_pattern_in_repo_files,
+    which made the original subdirectory guard inoperable.
     """
-    from vllm.transformers_utils.repo_utils import list_repo_files
+    import huggingface_hub
+    from vllm.transformers_utils.repo_utils import get_model_path, list_repo_files
 
     # Check both 'model' and 'model_tag' since vLLM uses different
     # attribute names in different contexts
@@ -908,6 +910,12 @@ def _compute_config_format(namespace: argparse.Namespace) -> str:
     # Get optional HF arguments
     revision = getattr(namespace, "revision", None)
     token = getattr(namespace, "hf_token", None)
+
+    # In offline mode, list_repo_files raises OfflineModeIsEnabled and returns []
+    # for non-local repo IDs. Resolve to the local cache path first so that
+    # list_repo_files takes the local directory branch instead.
+    if huggingface_hub.constants.HF_HUB_OFFLINE:
+        model = get_model_path(model, revision)
 
     # list_repo_files returns full relative paths (e.g. "params.json",
     # "original/params.json") for both local directories and remote HF repos.

--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -892,11 +892,11 @@ def _compute_config_format(namespace: argparse.Namespace) -> str:
     params.json found only inside the 'original/' subdirectory (as seen in
     some Llama HF checkpoints) does NOT indicate mistral format and is ignored.
 
-    To avoid ambiguity with glob/fnmatch pattern matching across local and remote
-    repos, the model path is always resolved to a local directory first, then
-    checked with os.path.isfile for exact root-level presence.
+    Uses list_repo_files which handles both local paths and remote HF repos,
+    then checks for an exact path match of "params.json" to avoid the
+    os.path.basename stripping done by any_pattern_in_repo_files/fnmatch.
     """
-    from vllm.transformers_utils.repo_utils import get_model_path
+    from vllm.transformers_utils.repo_utils import list_repo_files
 
     # Check both 'model' and 'model_tag' since vLLM uses different
     # attribute names in different contexts
@@ -907,12 +907,13 @@ def _compute_config_format(namespace: argparse.Namespace) -> str:
 
     # Get optional HF arguments
     revision = getattr(namespace, "revision", None)
+    token = getattr(namespace, "hf_token", None)
 
-    # Resolve to a local path (works for both explicit local paths and HF cache)
-    model_path = get_model_path(model, revision)
-
-    # A root-level params.json (and only root-level) indicates mistral format.
-    # os.path.isfile gives an unambiguous exact check — no glob/fnmatch involved.
-    if os.path.isfile(os.path.join(model_path, "params.json")):
+    # list_repo_files returns full relative paths (e.g. "params.json",
+    # "original/params.json") for both local directories and remote HF repos.
+    # An exact match on "params.json" unambiguously detects a root-level file,
+    # avoiding the os.path.basename stripping that any_pattern_in_repo_files uses.
+    files = list_repo_files(model, revision=revision, token=token)
+    if "params.json" in files:
         return "mistral"
     return "auto"

--- a/tests/fixtures/model_configs/meta-llama/llama-dummy/config.json
+++ b/tests/fixtures/model_configs/meta-llama/llama-dummy/config.json
@@ -1,0 +1,19 @@
+{
+  "architectures": ["LlamaForCausalLM"],
+  "model_type": "llama",
+  "vocab_size": 32000,
+  "hidden_size": 128,
+  "intermediate_size": 256,
+  "num_hidden_layers": 2,
+  "num_attention_heads": 2,
+  "num_key_value_heads": 2,
+  "hidden_act": "silu",
+  "max_position_embeddings": 2048,
+  "initializer_range": 0.02,
+  "rms_norm_eps": 1e-05,
+  "use_cache": true,
+  "bos_token_id": 1,
+  "eos_token_id": 2,
+  "rope_theta": 10000.0,
+  "torch_dtype": "bfloat16"
+}

--- a/tests/fixtures/model_configs/meta-llama/llama-dummy/original/params.json
+++ b/tests/fixtures/model_configs/meta-llama/llama-dummy/original/params.json
@@ -1,0 +1,1 @@
+{"dim": 4096, "multiple_of": 256, "n_heads": 32, "n_layers": 32, "norm_eps": 1e-06, "vocab_size": 32000}

--- a/tests/utils/test_platform_validation.py
+++ b/tests/utils/test_platform_validation.py
@@ -319,6 +319,33 @@ class TestPreRegisterAndUpdate:
         assert args.config_format == "mistral"
         assert args.tokenizer_mode == "mistral"
 
+    def test_config_format_defaults_to_auto_for_llama_with_only_original_params_json(
+        self, arg_parsers
+    ):
+        """Test that a Llama HF checkpoint whose params.json lives only inside the
+        'original/' subdirectory is not misidentified as a mistral-format model.
+
+        Uses the tests/fixtures/model_configs/meta-llama/llama-dummy fixture which
+        contains original/params.json but no root-level params.json.
+        """
+        main_parser, serve_parser = arg_parsers
+
+        from pathlib import Path
+
+        llama_dummy_dir = str(
+            Path(__file__).parent.parent
+            / "fixtures"
+            / "model_configs"
+            / "meta-llama"
+            / "llama-dummy"
+        )
+
+        SpyrePlatform.pre_register_and_update(serve_parser)
+        args = main_parser.parse_args(["serve", llama_dummy_dir])
+
+        assert args.config_format == "auto"
+        assert args.tokenizer_mode == "auto"
+
     def test_config_format_defaults_to_auto_for_models_without_params_json(
         self, tmp_path, arg_parsers
     ):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This PR improves upon the faulty logic used in https://github.com/torch-spyre/sendnn-inference/pull/1027. 

The previous fix attempted to exclude Llama models from mistral-format detection by checking whether params.json existed only inside an original/ subdirectory, using two calls to `any_pattern_in_repo_files`. This did not work as the vLLM implementation of `any_pattern_in_repo_files` delegates to `list_filtered_repo_files`, which matches patterns using `fnmatch.fnmatch(os.path.basename(file), pattern)`. This always returns false since `os.path.basename` is applied to every file path before fnmatch runs. Llama models with only original/params.json were still being assigned mistral format.

fix: correctly detect root-level params.json for mistral format detection. 

Replace both `any_pattern_in_repo_files calls` with a single `list_repo_files` call followed by an exact string membership test.

## Related Issues

## Test Plan

## Checklist

- [x] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [x] My code follows the project's code style (run `bash format.sh`)
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
