### PR TITLE
vllm-update-procedure document updates

### DIFF
--- a/docs/contributing/vllm-update-procedure.md
+++ b/docs/contributing/vllm-update-procedure.md
@@ -7,7 +7,7 @@ This procedure has produced clean upgrades for past patch releases (0.20.1, 0.20
 !!! note "AI Assistant Skills"
     This procedure is referenced by both Claude Code's `/update-vllm` skill and IBM Bob's `update-vllm` skill. When using these assistants, they will automatically follow this procedure and replace `{VERSION}` with the actual version number you specify.
 
-!!! note Do not attempt to upgrade vLLM on Mac systems. Upstream vLLM forcefully overrides VLLM_TARGET_DEVICE to cpu on Macs which results in an incorrect vLLM resolution and the addition of uneeded dependencies to the generated lockfile.
+!!! note Do not attempt to upgrade vLLM on Mac systems. Upstream vLLM forcefully overrides VLLM_TARGET_DEVICE to cpu on Macs which results in an incorrect vLLM resolution and the addition of unneeded dependencies to the generated lockfile.
 
 The companion doc at [`maintaining.md`](./maintaining.md) provides the high-level workflow context. This document is the operational checklist: exact commands, ordered tests, and the compat-shim playbook.
 

--- a/docs/contributing/vllm-update-procedure.md
+++ b/docs/contributing/vllm-update-procedure.md
@@ -7,6 +7,8 @@ This procedure has produced clean upgrades for past patch releases (0.20.1, 0.20
 !!! note "AI Assistant Skills"
     This procedure is referenced by both Claude Code's `/update-vllm` skill and IBM Bob's `update-vllm` skill. When using these assistants, they will automatically follow this procedure and replace `{VERSION}` with the actual version number you specify.
 
+!!! note Do not attempt to upgrade vLLM on Mac systems. Upstream vLLM forcefully overrides VLLM_TARGET_DEVICE to cpu on Macs which results in an incorrect vLLM resolution and the addition of uneeded dependencies to the generated lockfile.
+
 The companion doc at [`maintaining.md`](./maintaining.md) provides the high-level workflow context. This document is the operational checklist: exact commands, ordered tests, and the compat-shim playbook.
 
 ## Phase 0 — Preflight
@@ -116,17 +118,11 @@ In `.github/workflows/test.yml`, add a new entry under `include:` for **every re
 ## Phase 5 — Verify and audit
 
 1. Re-run `bash format.sh`. (ruff, typos, ty, actionlint should all pass.)
-2. Verify the vLLM lockfile entry resolved to the `+empty` build (not `+cpu`):
-
-   ```bash
-   grep -A3 '^name = "vllm"' uv.lock | grep version
-   # Expected: version = "0.X.Y+empty"
-   ```
-3. Audit `git diff --stat uv.lock`:
+2. Audit `git diff --stat uv.lock`:
    - **Tiny** (~10 lines) → patch bump, only the vLLM rev moved. Expected.
    - **Huge** (~3000+ lines) → vLLM minor release reshuffled transitives. Expected.
    - **Medium** (50–500 lines) → look closely. Make sure unrelated packages didn't drift in surprising ways.
-4. Verify only expected files changed:
+3. Verify only expected files changed:
 
    ```bash
    git status

--- a/docs/contributing/vllm-update-procedure.md
+++ b/docs/contributing/vllm-update-procedure.md
@@ -111,16 +111,22 @@ When in doubt, check past upgrade PRs for precedent: `gh pr list --search "vllm"
 
 ## Phase 4 — Extend the CI matrix
 
-In `.github/workflows/test.yml`, add a new entry under `include:` for the **previous** version (the old default). Mirror the format of the existing `vLLM:0.20.x` entries — only `name` and `repo` change. Keep `vLLM:lowest`, `vLLM:main`, and existing intermediates.
+In `.github/workflows/test.yml`, add a new entry under `include:` for **every released version between `vLLM:lowest` and the new target version** that does not already have an entry. The goal is that every supported version (i.e. every version satisfying the `>=lower,<upper` constraint in `pyproject.toml`) has a backwards-compat test job. Mirror the format of the existing intermediate entries — only `name` and `repo` change. Keep `vLLM:lowest`, `vLLM:main`, and any existing intermediates unchanged.
 
 ## Phase 5 — Verify and audit
 
 1. Re-run `bash format.sh`. (ruff, typos, ty, actionlint should all pass.)
-2. Audit `git diff --stat uv.lock`:
+2. Verify the vLLM lockfile entry resolved to the `+empty` build (not `+cpu`):
+
+   ```bash
+   grep -A3 '^name = "vllm"' uv.lock | grep version
+   # Expected: version = "0.X.Y+empty"
+   ```
+3. Audit `git diff --stat uv.lock`:
    - **Tiny** (~10 lines) → patch bump, only the vLLM rev moved. Expected.
    - **Huge** (~3000+ lines) → vLLM minor release reshuffled transitives. Expected.
    - **Medium** (50–500 lines) → look closely. Make sure unrelated packages didn't drift in surprising ways.
-3. Verify only expected files changed:
+4. Verify only expected files changed:
 
    ```bash
    git status


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Some proposed updates to the vllm-update-procedure.md document after using it to upgrade vllm.
- Use more verbose language when explaining how to extend the CI matrix
- Add a note telling users to not attempt the upgrade on Mac due to upstream vLLM force override of VLLM_TARGET_DEVICE to cpu

## Related Issues

<!-- Link related issues, e.g., `Fixes #` or `Relates to #456` -->

## Test Plan

<!-- Describe how you tested your changes. Include commands or steps to reproduce. -->

## Checklist

- [x] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [x] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
