### PR TITLE
Add platform-based model filtering

### DIFF
--- a/sendnn_inference/config/model_config.py
+++ b/sendnn_inference/config/model_config.py
@@ -232,6 +232,8 @@ class ModelConfig:
     Attributes:
         name: Model name/identifier
         architecture: Architecture pattern for matching
+        platforms: List of supported CPU architectures (["x86_64", "s390x", "ppc64le"]).
+            An empty list means the model is supported on all platforms.
         static_batching_configs: List of static batching configurations (pooling models only)
         continuous_batching_configs: List of continuous batching configurations (decoder models)
             (each may have its own device_config)
@@ -239,6 +241,7 @@ class ModelConfig:
 
     name: str
     architecture: ArchitecturePattern
+    platforms: list[str] = field(default_factory=list)
     static_batching_configs: list[StaticBatchingConfig] = field(default_factory=list)
     continuous_batching_configs: list[ContinuousBatchingConfig] = field(default_factory=list)
 
@@ -255,6 +258,9 @@ class ModelConfig:
         """
         # Parse architecture (pass model name for better logging)
         architecture = ArchitecturePattern.from_dict(name, data["architecture"])
+
+        # Parse supported platforms
+        platforms = data.get("platforms", [])
 
         # Parse static batching configs
         static_configs = []
@@ -301,6 +307,7 @@ class ModelConfig:
         return cls(
             name=name,
             architecture=architecture,
+            platforms=platforms,
             static_batching_configs=static_configs,
             continuous_batching_configs=continuous_configs,
         )

--- a/sendnn_inference/config/model_configs.yaml
+++ b/sendnn_inference/config/model_configs.yaml
@@ -3,6 +3,8 @@
 #
 # Each model entry contains:
 # - architecture: Pattern for matching HuggingFace model configs
+# - platforms: List of supported CPU architectures (e.g. [x86_64, s390x, ppc64le]).
+#              If omitted, the model is supported on all platforms.
 # - static_batching_configs: List of static batching configurations (optional)
 # - continuous_batching_configs: List of continuous batching configurations (optional)
 #   - Each CB config may have a nested device_config for device-specific settings
@@ -177,6 +179,7 @@ models:
   # Granite 3.3 8B Instruct
   ibm-granite/granite-3.3-8b-instruct:
     architecture: *granite_33_8b_architecture
+    platforms: [x86_64, ppc64le, s390x]
 
     # Continuous batching configurations
     continuous_batching_configs:
@@ -200,6 +203,7 @@ models:
       <<: *granite_33_8b_architecture
       quantization_config:
         format: float-quantized
+    platforms: [x86_64, ppc64le, s390x]
 
     # Continuous batching configurations only
     continuous_batching_configs:
@@ -218,6 +222,7 @@ models:
   # Llama 3.1 8B Instruct
   meta-llama/Llama-3.1-8B-Instruct:
     architecture: *llama3_8b_architecture
+    platforms: [x86_64, ppc64le]
     continuous_batching_configs:
       - tp_size: 1
         max_model_len: 3072
@@ -237,6 +242,7 @@ models:
       <<: *granite_4_8b_architecture
       model_type: granitemoehybrid
       num_experts_per_tok: 0
+    platforms: [x86_64, ppc64le, s390x]
 
     # Continuous batching configurations
     continuous_batching_configs:
@@ -258,6 +264,7 @@ models:
   ibm-granite/granite-4-8b-dense:
     architecture:
       <<: *granite_4_8b_architecture
+    platforms: [x86_64, ppc64le, s390x]
 
     # Continuous batching configurations
     continuous_batching_configs:
@@ -280,6 +287,7 @@ models:
       <<: *granite_4_8b_architecture
       quantization_config:
         format: float-quantized
+    platforms: [x86_64, ppc64le, s390x]
 
     # Continuous batching configurations
     continuous_batching_configs:
@@ -298,6 +306,7 @@ models:
   # Granite 4.1 30B
   ibm-granite/granite-4.1-30b:
     architecture: *granite_41_30b_architecture
+    platforms: [x86_64, ppc64le, s390x]
     continuous_batching_configs:
       - tp_size: 4
         max_model_len: 32768
@@ -308,6 +317,7 @@ models:
   # TODO (ysc) update with real hf id once the model is public
   ibm-granite/swa-20b:
     architecture: *granite_swa_20b_architecture
+    platforms: [x86_64, ppc64le, s390x]
     continuous_batching_configs:
       - tp_size: 4
         max_model_len: 32768
@@ -317,6 +327,7 @@ models:
   # Granite Vision 3.3 2B
   ibm-granite/granite-vision-3.3-2b:
     architecture: *granite_vision_33_2b_architecture
+    platforms: [x86_64, ppc64le, s390x]
     continuous_batching_configs:
       - tp_size: 1
         max_model_len: 8192
@@ -333,6 +344,7 @@ models:
   # Mistral Small 3.2 24B Instruct
   mistralai/Mistral-Small-3.2-24B-Instruct-2506:
     architecture: *mistral3_24b_architecture
+    platforms: [x86_64, ppc64le]
     continuous_batching_configs:
       - tp_size: 2
         max_model_len: 8192
@@ -345,6 +357,7 @@ models:
   # Ministral 3 14B Instruct
   mistralai/Ministral-3-14B-Instruct-2512-BF16:
     architecture: *ministral3_14b_architecture
+    platforms: [x86_64, ppc64le, s390x]
     continuous_batching_configs:
       - tp_size: 1
         max_model_len: 4096
@@ -357,6 +370,7 @@ models:
   # Ministral 3 8B Instruct
   mistralai/Ministral-3-8B-Instruct-2512-BF16:
     architecture: *ministral3_8b_architecture
+    platforms: [x86_64, ppc64le, s390x]
     continuous_batching_configs:
       - tp_size: 1
         max_model_len: 4096
@@ -373,7 +387,7 @@ models:
       model_type: roberta
       num_hidden_layers: 6
       vocab_size: 50265
-
+    platforms: [x86_64, ppc64le, s390x]
     static_batching_configs:
       - tp_size: 1
         warmup_shapes:
@@ -385,6 +399,7 @@ models:
       model_type: xlm-roberta
       num_hidden_layers: 6
       vocab_size: 250002
+    platforms: [x86_64, ppc64le, s390x]
 
     static_batching_configs:
       - tp_size: 1
@@ -397,6 +412,7 @@ models:
       model_type: roberta
       num_hidden_layers: 12
       vocab_size: 50265
+    platforms: [x86_64, ppc64le, s390x]
 
     static_batching_configs:
       - tp_size: 1
@@ -409,6 +425,7 @@ models:
       model_type: xlm-roberta
       num_hidden_layers: 12
       vocab_size: 250002
+    platforms: [x86_64, ppc64le, s390x]
 
     static_batching_configs:
       - tp_size: 1
@@ -421,6 +438,7 @@ models:
       model_type: xlm-roberta
       num_hidden_layers: 24
       vocab_size: 250002
+    platforms: [x86_64, ppc64le]
 
     static_batching_configs:
       - tp_size: 1
@@ -433,6 +451,7 @@ models:
       model_type: xlm-roberta
       num_hidden_layers: 24
       vocab_size: 250002
+    platforms: [x86_64, ppc64le]
 
     static_batching_configs:
       - tp_size: 1
@@ -448,6 +467,7 @@ models:
       max_position_embeddings: 8194
       num_hidden_layers: 24
       vocab_size: 250002
+    platforms: [x86_64, ppc64le]
 
     static_batching_configs:
       - tp_size: 1
@@ -461,6 +481,7 @@ models:
       max_position_embeddings: 514
       num_hidden_layers: 24
       vocab_size: 250002
+    platforms: [x86_64, ppc64le]
 
     static_batching_configs:
       - tp_size: 1
@@ -473,6 +494,7 @@ models:
       model_type: roberta
       num_hidden_layers: 24
       vocab_size: 50265
+    platforms: [x86_64, ppc64le]
 
     static_batching_configs:
       - tp_size: 1

--- a/sendnn_inference/config/model_registry.py
+++ b/sendnn_inference/config/model_registry.py
@@ -1,5 +1,6 @@
 """Model configuration registry."""
 
+import platform
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -145,6 +146,7 @@ class ModelConfigRegistry:
             logger.debug("No HF config available for matching")
             return None
 
+        current_platform = platform.machine()
         best_match: ModelConfig | None = None
         best_field_count = -1
 
@@ -163,6 +165,15 @@ class ModelConfigRegistry:
                     best_field_count = field_count
 
         if best_match:
+            if best_match.platforms and current_platform not in best_match.platforms:
+                logger.warning(
+                    "Model '%s' (matched config '%s') is not officially supported "
+                    "on platform '%s'. Supported platforms: %s",
+                    vllm_model_config.model,
+                    best_match.name,
+                    current_platform,
+                    best_match.platforms,
+                )
             logger.info(
                 "Matched model '%s' to configuration '%s' (%d fields)",
                 vllm_model_config.model,


### PR DESCRIPTION
## Description
Introduce a `platforms` field on each model entry in model_configs.yaml so the registry can filter supported models by architecture (x86_64, s390x, ppc64le) at runtime using platform.machine().
## Related Issues

## Test Plan

<!-- Describe how you tested your changes. Include commands or steps to reproduce. -->

## Checklist

- [x] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [x] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
