### PR TITLE
Supported model update on HTML 

### DIFF
--- a/docs/mkdocs/hooks/generate_model_tables.py
+++ b/docs/mkdocs/hooks/generate_model_tables.py
@@ -20,7 +20,6 @@ POOLING_END_MARKER = "<!-- GENERATED_POOLING_MODELS_END -->"
 EXCLUDED_MODELS = {
     "ibm-granite/granite-4-8b-dense-hybrid",
     "ibm-granite/granite-4-8b-dense",
-    "ibm-granite/granite-4-8b-dense-FP8",
     "Qwen/Qwen3-Embedding-0.6B",
     "Qwen/Qwen3-Embedding-4B",
 }

--- a/sendnn_inference/config/model_configs.yaml
+++ b/sendnn_inference/config/model_configs.yaml
@@ -314,6 +314,30 @@ models:
 
 
   # Embedding models (static batching only, no device configs needed)
+  ibm-granite/granite-embedding-30m-english:
+    architecture:
+      model_type: roberta
+      num_hidden_layers: 6
+      vocab_size: 50265
+
+    static_batching_configs:
+      - tp_size: 1
+        warmup_shapes:
+          - prompt_len: 512
+            batch_size: 64
+
+  ibm-granite/granite-embedding-107m-multilingual:
+    architecture:
+      model_type: xlm-roberta
+      num_hidden_layers: 6
+      vocab_size: 250002
+
+    static_batching_configs:
+      - tp_size: 1
+        warmup_shapes:
+          - prompt_len: 512
+            batch_size: 64
+
   ibm-granite/granite-embedding-125m-english:
     architecture:
       model_type: roberta

--- a/sendnn_inference/config/model_configs.yaml
+++ b/sendnn_inference/config/model_configs.yaml
@@ -243,7 +243,7 @@ models:
         max_num_seqs: 32
         device_config: *granite_8b_tp4_device_config
 
-  ibm-granite/granite-4-8b-dense-FP8:
+  ibm-granite/granite-4.1-8b-fp8:
     architecture:
       <<: *granite_4_8b_architecture
       quantization_config:
@@ -362,8 +362,7 @@ models:
           - prompt_len: 512
             batch_size: 64
 
-  # Other supported models (static batching only)
-  intfloat/multilingual-e5-large:
+    intfloat/multilingual-e5-large:
     architecture:
       model_type: xlm-roberta
       num_hidden_layers: 24
@@ -374,6 +373,20 @@ models:
         warmup_shapes:
           - prompt_len: 512
             batch_size: 64
+
+    intfloat/multilingual-e5-large-instruct:
+    architecture:
+      model_type: xlm-roberta
+      num_hidden_layers: 24
+      vocab_size: 250002
+
+    static_batching_configs:
+      - tp_size: 1
+        warmup_shapes:
+          - prompt_len: 512
+            batch_size: 256
+
+  # Other supported models (static batching only)
 
   BAAI/bge-reranker-v2-m3:
     architecture:

--- a/sendnn_inference/config/model_configs.yaml
+++ b/sendnn_inference/config/model_configs.yaml
@@ -389,7 +389,7 @@ models:
           - prompt_len: 512
             batch_size: 64
 
-    intfloat/multilingual-e5-large:
+  intfloat/multilingual-e5-large:
     architecture:
       model_type: xlm-roberta
       num_hidden_layers: 24
@@ -401,7 +401,7 @@ models:
           - prompt_len: 512
             batch_size: 64
 
-    intfloat/multilingual-e5-large-instruct:
+  intfloat/multilingual-e5-large-instruct:
     architecture:
       model_type: xlm-roberta
       num_hidden_layers: 24
@@ -411,7 +411,7 @@ models:
       - tp_size: 1
         warmup_shapes:
           - prompt_len: 512
-            batch_size: 256
+            batch_size: 4
 
   # Other supported models (static batching only)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

<!-- Provide a clear description of your changes. -->

This pull request is to update the website [`https://docs.vllm.ai/projects/spyre/en/stable/user_guide/supported_models.html`](https://docs.vllm.ai/projects/spyre/en/stable/user_guide/supported_models.html) to show the supported models that were missing: granite-4.1-8b-fp8, granite-embedding-30m-english, granite-embedding-107m-multilingual, and multilingual-e5-large-instruct.

Changes made in models_configs.yaml

- Update the granite-4-8b-dense-fp8 name to 4.1 version on huggingface
- Added the missing embedding models into the yaml file

## Related Issues

<!-- Link related issues, e.g., `Fixes #` or `Relates to #456` -->

## Test Plan

<!-- Describe how you tested your changes. Include commands or steps to reproduce. -->

Ran `mkdocs serve` locally to verify the changes.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [x] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
