### PR TITLE
Add logic for ppc64le to use logical cores when using psutil cpu_count

### DIFF
--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -667,9 +667,7 @@ class SpyrePlatform(Platform):
                 else:
                     use_logical_cpus = False
                 cpu_count = float(psutil.cpu_count(logical=use_logical_cpus))
-                detection_message = (
-                    f"Detected {cpu_count} physical CPUs from psutil.cpu_count(logical={use_logical_cpus})"
-                )
+                detection_message = f"Detected {cpu_count} physical CPUs from psutil.cpu_count(logical={use_logical_cpus})"
             except ImportError:
                 logger.info("Install psutil to count physical CPU cores")
             except Exception as e:

--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -625,7 +625,7 @@ class SpyrePlatform(Platform):
         ConditionalDefaultManager.apply(parser)
 
     @classmethod
-    def get_cpu_count(cls) -> tuple[float | None, str]:
+    def get_cpu_count(cls, use_logical_cpus=False) -> tuple[float | None, str]:
         """Return (cpu_count, detection_message) for threading configuration.
 
         Priority:
@@ -659,15 +659,10 @@ class SpyrePlatform(Platform):
             try:
                 import psutil
 
-                if platform.machine() == "ppc64le":
-                    use_logical_cpus = (
-                        cls._config.model_config.is_multimodal_model
-                        and envs_spyre.SENDNN_INFERENCE_ASYNC_MM_ENCODER
-                    )
-                else:
-                    use_logical_cpus = False
                 cpu_count = float(psutil.cpu_count(logical=use_logical_cpus))
-                detection_message = f"Detected {cpu_count} physical CPUs from psutil.cpu_count(logical={use_logical_cpus})"
+                detection_message = (
+                    f"Detected {cpu_count} CPUs from psutil.cpu_count(logical={use_logical_cpus})"
+                )
             except ImportError:
                 logger.info("Install psutil to count physical CPU cores")
             except Exception as e:

--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -659,9 +659,16 @@ class SpyrePlatform(Platform):
             try:
                 import psutil
 
-                cpu_count = float(psutil.cpu_count(logical=False))
+                if platform.machine() == "ppc64le":
+                    use_logical_cpus = (
+                        cls._config.model_config.is_multimodal_model
+                        and envs_spyre.SENDNN_INFERENCE_ASYNC_MM_ENCODER
+                    )
+                else:
+                    use_logical_cpus = False
+                cpu_count = float(psutil.cpu_count(logical=use_logical_cpus))
                 detection_message = (
-                    f"Detected {cpu_count} physical CPUs from psutil.cpu_count(logical=False)"
+                    f"Detected {cpu_count} physical CPUs from psutil.cpu_count(logical={use_logical_cpus})"
                 )
             except ImportError:
                 logger.info("Install psutil to count physical CPU cores")

--- a/sendnn_inference/platform.py
+++ b/sendnn_inference/platform.py
@@ -661,7 +661,8 @@ class SpyrePlatform(Platform):
 
                 cpu_count = float(psutil.cpu_count(logical=use_logical_cpus))
                 detection_message = (
-                    f"Detected {cpu_count} CPUs from psutil.cpu_count(logical={use_logical_cpus})"
+                    f"Detected {cpu_count} {'logical' if use_logical_cpus else 'physical'} CPUs "
+                    "from psutil.cpu_count(logical={use_logical_cpus})"
                 )
             except ImportError:
                 logger.info("Install psutil to count physical CPU cores")

--- a/sendnn_inference/v1/worker/mm_encoder_process.py
+++ b/sendnn_inference/v1/worker/mm_encoder_process.py
@@ -164,7 +164,7 @@ def _configure_encoder_threads() -> None:
         encoder_cpu_count = None
     elif platform.machine() == "ppc64le":
         cpu_count, _ = SpyrePlatform.get_cpu_count(use_logical_cpus=True)
-        encoder_cpu_count = min(cpu_count, 36.0)
+        encoder_cpu_count = min(math.ceil(cpu_count), 36)
     else:
         encoder_cpu_count = math.ceil(cpu_count)
 

--- a/sendnn_inference/v1/worker/mm_encoder_process.py
+++ b/sendnn_inference/v1/worker/mm_encoder_process.py
@@ -163,6 +163,7 @@ def _configure_encoder_threads() -> None:
     if cpu_count is None:
         encoder_cpu_count = None
     elif platform.machine() == "ppc64le":
+        cpu_count, _ = SpyrePlatform.get_cpu_count(use_logical_cpus=True)
         encoder_cpu_count = min(cpu_count, 36.0)
     else:
         encoder_cpu_count = math.ceil(cpu_count)

--- a/sendnn_inference/v1/worker/mm_encoder_process.py
+++ b/sendnn_inference/v1/worker/mm_encoder_process.py
@@ -164,7 +164,10 @@ def _configure_encoder_threads() -> None:
         encoder_cpu_count = None
     elif platform.machine() == "ppc64le":
         cpu_count, _ = SpyrePlatform.get_cpu_count(use_logical_cpus=True)
-        encoder_cpu_count = min(math.ceil(cpu_count), 36)
+        if cpu_count is None:
+            encoder_cpu_count = None
+        else:
+            encoder_cpu_count = min(math.ceil(cpu_count), 36)
     else:
         encoder_cpu_count = math.ceil(cpu_count)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

For ppc64le we want to use logical cpus to determine cpus per worker in multimodal models

## Related Issues

#1945

## Test Plan

Start a vllm server on a machine with <36 physical cores and check cpus per worker is set correctly

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
