### PR TITLE
:zap: try pre-computing random noise

### DIFF
--- a/sendnn_inference/envs.py
+++ b/sendnn_inference/envs.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     SENDNN_INFERENCE_TP_MM_SHARING: bool = True
     SENDNN_INFERENCE_LONG_OUT_PRIO: bool = False
     SENDNN_INFERENCE_PAUSING_ENABLED: bool = True
+    SENDNN_INFERENCE_SAMPLER_NOISE_POOL_SIZE: int = 1024
 
 logger = init_logger(__name__)
 
@@ -209,6 +210,17 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # is rotated for fairness.
     "SENDNN_INFERENCE_PAUSING_ENABLED": lambda: bool(
         int(os.getenv("SENDNN_INFERENCE_PAUSING_ENABLED", "1"))
+    ),
+    # Number of rows in the pre-generated exponential noise pool used by the
+    # Spyre random sampler (see sendnn_inference/v1/sample/spyre_sampler.py).
+    # The sampler runs on the host CPU on Spyre, where drawing fresh noise
+    # (q.exponential_()) every step is expensive on s390x. We instead build a
+    # [pool_size x vocab] pool of exponential noise once at load and slice rows
+    # from it at sample time. Host memory cost is roughly
+    # pool_size * vocab_size * 4 bytes. Set to 0 to disable pooling and fall
+    # back to per-step noise generation.
+    "SENDNN_INFERENCE_SAMPLER_NOISE_POOL_SIZE": lambda: int(
+        os.getenv("SENDNN_INFERENCE_SAMPLER_NOISE_POOL_SIZE", "1024")
     ),
 }
 # --8<-- [end:env-vars-definition]

--- a/sendnn_inference/model_executor/model_loader/spyre.py
+++ b/sendnn_inference/model_executor/model_loader/spyre.py
@@ -17,9 +17,9 @@ from vllm.logger import init_logger
 from vllm.model_executor.model_loader.weight_utils import download_weights_from_hf
 from vllm.v1.outputs import SamplerOutput
 from vllm.v1.sample.metadata import SamplingMetadata
-from vllm.v1.sample.sampler import Sampler
 
 import sendnn_inference.envs as envs_spyre
+from sendnn_inference.v1.sample.spyre_sampler import SpyreSampler
 import sendnn_inference.multimodal as spyre_mm
 import sendnn_inference.utils as utils_spyre
 from sendnn_inference.platform import SpyrePlatform
@@ -113,7 +113,11 @@ class SpyreCausalLM(nn.Module):
     ) -> None:
         super().__init__()
 
-        self.sampler = Sampler()
+        # Spyre runs the sampler on the host CPU. SpyreSampler serves random
+        # sampling noise from a pool built once at load, avoiding a costly
+        # per-step q.exponential_() on s390x. The pool is built up front in
+        # load_weights() via prebuild_noise_pool().
+        self.sampler = SpyreSampler()
 
         # boolean tensor of length batch size with indices:
         # True for unfinished sequences and
@@ -355,6 +359,19 @@ class SpyreCausalLM(nn.Module):
                 self._cast_to_f32()
 
         logger.debug("Model weights loaded successfully.")
+
+        # Pre-generate the sampler's exponential noise pool now that the model
+        # is loaded. The sampler runs on the host CPU, so the pool lives there.
+        # vocab_size is a best guess: if the actual logits width differs the
+        # pool is transparently rebuilt on first use.
+        try:
+            self.sampler.prebuild_noise_pool(
+                vocab_size=self.model_config.get_vocab_size(),
+                device=torch.device("cpu"),
+            )
+        except Exception as e:
+            # Prebuilding is a pure optimization; never fail model load over it.
+            logger.warning("Could not prebuild sampler noise pool: %s", e)
 
     def _cast_params_for_spyre(self):
         """Cast the LLM to fp16 for Spyre, then place the multimodal submodules

--- a/sendnn_inference/v1/sample/spyre_sampler.py
+++ b/sendnn_inference/v1/sample/spyre_sampler.py
@@ -1,0 +1,175 @@
+"""Spyre-specific sampler with a pre-generated exponential noise pool.
+
+vLLM's random sampler (``vllm.v1.sample.ops.topk_topp_sampler``) draws fresh
+Gumbel/exponential noise on every step via ``q.exponential_()`` over a
+``[batch, vocab]`` tensor. On the s390x host this call cannot be compiled and
+costs ~50ms for a large batch on a real model, which dominates our per-step
+latency (the sampler runs on the host CPU on Spyre, not on the accelerator).
+
+To avoid paying that cost every step we generate a large pool of exponential
+noise once, up front, and slice rows out of it at sample time instead of
+calling ``exponential_()`` on the hot path. Statistically each pool row is an
+i.i.d. exponential vector, exactly what ``random_sample`` would have produced;
+the only difference is that noise vectors are reused over the lifetime of the
+process. We advance a rolling offset through the pool so that a given batch
+slot rarely sees the same row on consecutive steps, and the sampled logits
+differ every step anyway, so the reuse is not observable in practice.
+
+Requests that carry their own seeded ``torch.Generator`` still need
+reproducible noise, so those rows are drawn with ``exponential_(generator=...)``
+as upstream does — the pool only serves the common, unseeded case.
+"""
+
+import torch
+from vllm.config.model import LogprobsMode
+from vllm.logger import init_logger
+from vllm.v1.sample.ops.topk_topp_sampler import (
+    TopKTopPSampler,
+    apply_top_k_top_p,
+    sample_with_exponential_noise,
+)
+from vllm.v1.sample.sampler import Sampler
+
+import sendnn_inference.envs as envs_spyre
+
+logger = init_logger(__name__)
+
+
+class SpyreTopKTopPSampler(TopKTopPSampler):
+    """``TopKTopPSampler`` that serves exponential noise from a fixed pool."""
+
+    def __init__(
+        self,
+        logprobs_mode: LogprobsMode = "raw_logprobs",
+        use_fp64_gumbel: bool = False,
+        pool_size: int | None = None,
+    ) -> None:
+        super().__init__(logprobs_mode, use_fp64_gumbel)
+        # Spyre is an out-of-tree platform, so the base class already binds
+        # ``forward_native``. Pin it explicitly so we keep using our overridden
+        # implementation even if upstream's platform dispatch changes.
+        self.forward = self.forward_native
+
+        if pool_size is None:
+            pool_size = envs_spyre.SENDNN_INFERENCE_SAMPLER_NOISE_POOL_SIZE
+        self._pool_size = pool_size
+        # Lazily allocated on first use (or via ``prebuild``) once we know the
+        # vocab width / dtype / device of the logits.
+        self._noise_pool: torch.Tensor | None = None
+        self._noise_offset = 0
+
+    def prebuild(self, vocab_size: int, device: torch.device) -> None:
+        """Eagerly build the noise pool, e.g. right after model load.
+
+        Safe to call with a best-guess ``vocab_size``: if the actual logits
+        width differs at sample time the pool is transparently rebuilt.
+        """
+        dtype = torch.float64 if self.use_fp64_gumbel else torch.float32
+        self._build_pool(vocab_size, dtype, device)
+
+    def _build_pool(
+        self, vocab_size: int, dtype: torch.dtype, device: torch.device
+    ) -> torch.Tensor:
+        if self._pool_size <= 0:
+            # Pool disabled: callers fall back to fresh per-step noise.
+            self._noise_pool = None
+            return torch.empty(0, device=device, dtype=dtype)
+
+        logger.info(
+            "Building sampler noise pool: shape=[%d, %d], dtype=%s, device=%s (~%.0f MB)",
+            self._pool_size,
+            vocab_size,
+            dtype,
+            device,
+            self._pool_size * vocab_size * torch.empty(0, dtype=dtype).element_size() / 1e6,
+        )
+        pool = torch.empty((self._pool_size, vocab_size), dtype=dtype, device=device)
+        pool.exponential_()
+        self._noise_pool = pool
+        self._noise_offset = 0
+        return pool
+
+    def _get_pooled_noise(self, probs: torch.Tensor) -> torch.Tensor:
+        """Return a ``[batch, vocab]`` slice of exponential noise.
+
+        The returned tensor may be a view into the shared pool; callers must
+        not mutate it in place (see ``forward_native``).
+        """
+        batch = probs.shape[0]
+        vocab_size = probs.shape[1]
+        dtype = torch.float64 if self.use_fp64_gumbel else probs.dtype
+
+        pool = self._noise_pool
+        if (
+            pool is None
+            or pool.shape[1] != vocab_size
+            or pool.dtype != dtype
+            or pool.device != probs.device
+        ):
+            pool = self._build_pool(vocab_size, dtype, probs.device)
+
+        # A pool of size 0 (disabled) or a batch larger than the pool can't be
+        # served from the pool — fall back to fresh noise for this step.
+        if self._noise_pool is None or batch > pool.shape[0]:
+            q = torch.empty((batch, vocab_size), dtype=dtype, device=probs.device)
+            q.exponential_()
+            return q
+
+        if self._noise_offset + batch > pool.shape[0]:
+            self._noise_offset = 0
+        start = self._noise_offset
+        self._noise_offset += batch
+        return pool[start : start + batch]
+
+    def forward_native(
+        self,
+        logits: torch.Tensor,
+        generators: dict[int, torch.Generator],
+        k: torch.Tensor | None,
+        p: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Mirror of the upstream native path, but noise comes from the pool."""
+        logits = apply_top_k_top_p(logits, k, p)
+        logits_to_return = None
+        if self.logprobs_mode == "processed_logits":
+            logits_to_return = logits
+        elif self.logprobs_mode == "processed_logprobs":
+            logits_to_return = logits.log_softmax(dim=-1, dtype=torch.float32)
+
+        probs = logits.softmax(dim=-1, dtype=torch.float32)
+        q = self._get_pooled_noise(probs)
+
+        # We must not mutate the shared pool. ``sample_with_exponential_noise``
+        # only mutates ``q`` in place when its dtype differs from ``probs``
+        # (the fp64-gumbel reciprocal path); seeded generators also require
+        # overwriting rows. Clone in those cases; otherwise use the view
+        # directly for a zero-copy hot path.
+        if generators or q.dtype != probs.dtype:
+            q = q.clone()
+            for i, generator in generators.items():
+                q[i].exponential_(generator=generator)
+
+        return sample_with_exponential_noise(probs, q), logits_to_return
+
+
+class SpyreSampler(Sampler):
+    """``Sampler`` that swaps in :class:`SpyreTopKTopPSampler`.
+
+    Drop-in replacement for ``vllm.v1.sample.sampler.Sampler`` used by
+    ``SpyreCausalLM`` so random sampling avoids per-step ``exponential_()``.
+    """
+
+    def __init__(
+        self,
+        logprobs_mode: LogprobsMode = "raw_logprobs",
+        use_fp64_gumbel: bool = False,
+    ) -> None:
+        super().__init__(logprobs_mode, use_fp64_gumbel)
+        self.topk_topp_sampler = SpyreTopKTopPSampler(logprobs_mode, use_fp64_gumbel)
+
+    def prebuild_noise_pool(self, vocab_size: int, device: torch.device) -> None:
+        """Build the noise pool up front (best-effort; rebuilt on mismatch)."""
+        # nn.Module attribute access is typed as Module | Tensor; narrow it.
+        sampler = self.topk_topp_sampler
+        assert isinstance(sampler, SpyreTopKTopPSampler)
+        sampler.prebuild(vocab_size, device)

--- a/tests/v1/sample/test_spyre_sampler.py
+++ b/tests/v1/sample/test_spyre_sampler.py
@@ -1,0 +1,180 @@
+# # SPDX-License-Identifier: Apache-2.0
+"""Tests for the pooled-noise Spyre sampler.
+
+These validate that :class:`SpyreTopKTopPSampler` is a faithful, faster stand-in
+for vLLM's ``random_sample``: it produces the same shaped output, samples from
+the correct distribution, honors per-request seeded generators, and builds its
+noise pool exactly once (the whole point — no per-step ``exponential_()``).
+"""
+
+import torch
+import pytest
+
+from sendnn_inference.v1.sample.spyre_sampler import (
+    SpyreSampler,
+    SpyreTopKTopPSampler,
+)
+
+VOCAB_SIZE = 512
+
+
+def _make_logits(batch: int, peak_token: int | None = None) -> torch.Tensor:
+    logits = torch.randn(batch, VOCAB_SIZE, dtype=torch.float32)
+    if peak_token is not None:
+        # Make one token dominate so argmax sampling is deterministic-ish.
+        logits[:, peak_token] = 100.0
+    return logits
+
+
+@pytest.mark.cpu
+def test_pool_built_once_and_lazily():
+    sampler = SpyreTopKTopPSampler(pool_size=64)
+    assert sampler._noise_pool is None
+
+    logits = _make_logits(4)
+    out, _ = sampler.forward_native(logits, generators={}, k=None, p=None)
+
+    assert out.shape == (4,)
+    pool = sampler._noise_pool
+    assert pool is not None
+    assert pool.shape == (64, VOCAB_SIZE)
+
+    # A second call must reuse the same pool object, not rebuild it.
+    sampler.forward_native(_make_logits(4), generators={}, k=None, p=None)
+    assert sampler._noise_pool is pool
+
+
+@pytest.mark.cpu
+def test_prebuild_allocates_pool_up_front():
+    sampler = SpyreTopKTopPSampler(pool_size=32)
+    sampler.prebuild(vocab_size=VOCAB_SIZE, device=torch.device("cpu"))
+    pool = sampler._noise_pool
+    assert pool is not None
+    assert pool.shape == (32, VOCAB_SIZE)
+
+    # Sampling should reuse the prebuilt pool.
+    sampler.forward_native(_make_logits(2), generators={}, k=None, p=None)
+    assert sampler._noise_pool is pool
+
+
+@pytest.mark.cpu
+def test_rebuild_on_vocab_mismatch():
+    sampler = SpyreTopKTopPSampler(pool_size=16)
+    # Prebuild with a wrong (smaller) vocab guess.
+    sampler.prebuild(vocab_size=VOCAB_SIZE // 2, device=torch.device("cpu"))
+    assert sampler._noise_pool.shape[1] == VOCAB_SIZE // 2
+
+    out, _ = sampler.forward_native(_make_logits(3), generators={}, k=None, p=None)
+    assert out.shape == (3,)
+    # Pool transparently rebuilt to the real width.
+    assert sampler._noise_pool.shape[1] == VOCAB_SIZE
+
+
+@pytest.mark.cpu
+def test_offset_wraps_around_pool():
+    sampler = SpyreTopKTopPSampler(pool_size=8)
+    sampler.prebuild(vocab_size=VOCAB_SIZE, device=torch.device("cpu"))
+
+    # batch=6 -> offset 6; next batch=6 would overflow (6+6 > 8) -> reset to 0.
+    sampler.forward_native(_make_logits(6), generators={}, k=None, p=None)
+    assert sampler._noise_offset == 6
+    sampler.forward_native(_make_logits(6), generators={}, k=None, p=None)
+    assert sampler._noise_offset == 6  # wrapped to 0, then advanced by 6
+
+
+@pytest.mark.cpu
+def test_batch_larger_than_pool_falls_back():
+    sampler = SpyreTopKTopPSampler(pool_size=4)
+    sampler.prebuild(vocab_size=VOCAB_SIZE, device=torch.device("cpu"))
+    # batch (10) > pool (4): must still produce valid output via fresh noise.
+    out, _ = sampler.forward_native(_make_logits(10), generators={}, k=None, p=None)
+    assert out.shape == (10,)
+
+
+@pytest.mark.cpu
+def test_disabled_pool_uses_fresh_noise():
+    sampler = SpyreTopKTopPSampler(pool_size=0)
+    out, _ = sampler.forward_native(_make_logits(4), generators={}, k=None, p=None)
+    assert out.shape == (4,)
+    assert sampler._noise_pool is None
+
+
+@pytest.mark.cpu
+def test_samples_peaked_distribution():
+    # With one token overwhelmingly likely, sampling should almost always
+    # return it — confirms noise is applied to the right (softmax) axis.
+    sampler = SpyreTopKTopPSampler(pool_size=64)
+    peak = 123
+    out, _ = sampler.forward_native(
+        _make_logits(32, peak_token=peak), generators={}, k=None, p=None
+    )
+    assert (out == peak).float().mean() > 0.95
+
+
+@pytest.mark.cpu
+def test_pool_not_mutated_by_sampling():
+    # sample_with_exponential_noise divides probs in place, not the noise. The
+    # shared pool must survive unchanged so later steps get valid noise.
+    sampler = SpyreTopKTopPSampler(pool_size=8)
+    sampler.prebuild(vocab_size=VOCAB_SIZE, device=torch.device("cpu"))
+    before = sampler._noise_pool.clone()
+    sampler.forward_native(_make_logits(4), generators={}, k=None, p=None)
+    torch.testing.assert_close(sampler._noise_pool, before)
+
+
+@pytest.mark.cpu
+def test_seeded_generator_is_reproducible_and_pool_safe():
+    sampler = SpyreTopKTopPSampler(pool_size=8)
+    sampler.prebuild(vocab_size=VOCAB_SIZE, device=torch.device("cpu"))
+    pool_before = sampler._noise_pool.clone()
+
+    logits = _make_logits(2)
+
+    def run():
+        g = torch.Generator()
+        g.manual_seed(1234)
+        # Seed every row so the whole batch is reproducible.
+        gens = {0: g, 1: torch.Generator().manual_seed(1234)}
+        return sampler.forward_native(logits.clone(), generators=gens, k=None, p=None)[0]
+
+    out1 = run()
+    out2 = run()
+    torch.testing.assert_close(out1, out2)
+    # Seeded rows are cloned before overwriting, so the pool is untouched.
+    torch.testing.assert_close(sampler._noise_pool, pool_before)
+
+
+@pytest.mark.cpu
+def test_distribution_matches_reference():
+    # Statistically compare sampled frequencies against the exact softmax
+    # probabilities over many draws for a small vocab.
+    torch.manual_seed(0)
+    small_vocab = 8
+    sampler = SpyreTopKTopPSampler(pool_size=1000)
+    sampler.prebuild(vocab_size=small_vocab, device=torch.device("cpu"))
+
+    base_logits = torch.tensor([3.0, 2.0, 1.0, 0.0, -1.0, -2.0, 0.5, 1.5])
+    expected = torch.softmax(base_logits, dim=-1)
+
+    counts = torch.zeros(small_vocab)
+    draws = 200
+    per = 100
+    for _ in range(draws):
+        logits = base_logits.unsqueeze(0).expand(per, -1).contiguous()
+        out, _ = sampler.forward_native(logits, generators={}, k=None, p=None)
+        counts += torch.bincount(out, minlength=small_vocab).float()
+
+    freq = counts / counts.sum()
+    # Loose tolerance: reused pool noise adds correlation, but marginals hold.
+    assert torch.allclose(freq, expected, atol=0.05)
+
+
+@pytest.mark.cpu
+def test_spyre_sampler_installs_pooled_topk_topp():
+    sampler = SpyreSampler()
+    assert isinstance(sampler.topk_topp_sampler, SpyreTopKTopPSampler)
+    sampler.prebuild_noise_pool(vocab_size=VOCAB_SIZE, device=torch.device("cpu"))
+    assert sampler.topk_topp_sampler._noise_pool.shape == (
+        sampler.topk_topp_sampler._pool_size,
+        VOCAB_SIZE,
+    )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Preallocates a pool of exponential noise to use during sampling instead of calling `tensor.exponential_()` on every forward pass

## Related Issues


## Test Plan

Dumping here to be able to run tests on spyre hardware

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
