### PR TITLE
:sparkles: Add precomputed noise pool for sampler

### DIFF
--- a/sendnn_inference/envs.py
+++ b/sendnn_inference/envs.py
@@ -30,12 +30,25 @@ if TYPE_CHECKING:
     SENDNN_INFERENCE_TP_MM_SHARING: bool = True
     SENDNN_INFERENCE_LONG_OUT_PRIO: bool = False
     SENDNN_INFERENCE_PAUSING_ENABLED: bool = True
+    SENDNN_INFERENCE_USE_NOISE_POOL: bool = False
+    SENDNN_INFERENCE_NOISE_POOL_MULTIPLIER: int = 32
+    SENDNN_INFERENCE_SAMPLER_TIMING: int = 0
 
 logger = init_logger(__name__)
 
 _cache: dict[str, Any] = {}
 
 _CPU_MM_DTYPE_PLATFORM_DEFAULTS = {"s390x": "float32", "ppc64le": "float32"}
+
+
+def get_noise_pool_dtype() -> torch.dtype:
+    """Resolve the dtype for the sampler's exponential-noise pool.
+
+    Follows the same platform defaults as SENDNN_INFERENCE_CPU_MM_DTYPE:
+    float32 on s390x/ppc64le (where reduced-precision RNG is undesirable),
+    float16 elsewhere.
+    """
+    return parse_cpu_mm_dtype(_CPU_MM_DTYPE_PLATFORM_DEFAULTS.get(platform.machine(), "float16"))
 
 
 def override(name: str, value: str) -> None:
@@ -209,6 +222,28 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # is rotated for fairness.
     "SENDNN_INFERENCE_PAUSING_ENABLED": lambda: bool(
         int(os.getenv("SENDNN_INFERENCE_PAUSING_ENABLED", "1"))
+    ),
+    # When "1", the Spyre sampler draws its Gumbel-max exponential noise from a
+    # large pool of random values generated once at model load, instead of
+    # calling Tensor.exponential_() on every decode step. This avoids the slow
+    # per-step random number generation observed on s390x. Defaults to "0"
+    # (disabled), which uses upstream vLLM's on-the-fly random_sample.
+    "SENDNN_INFERENCE_USE_NOISE_POOL": lambda: bool(
+        int(os.getenv("SENDNN_INFERENCE_USE_NOISE_POOL", "0"))
+    ),
+    # Size of the pre-generated exponential-noise pool, expressed as a multiple
+    # of (max_num_seqs * vocab_size). A larger multiplier lengthens the reuse
+    # period (better statistical variety) at the cost of memory. Only used when
+    # SENDNN_INFERENCE_USE_NOISE_POOL is enabled.
+    "SENDNN_INFERENCE_NOISE_POOL_MULTIPLIER": lambda: int(
+        os.getenv("SENDNN_INFERENCE_NOISE_POOL_MULTIPLIER", "32")
+    ),
+    # When > 0, the Spyre sampler times the noise-generation + weighted-sampling
+    # step and logs the average latency every this many sampling calls. Set to
+    # 0 (default) to disable. Useful for comparing the noise pool against
+    # upstream's on-the-fly exponential_().
+    "SENDNN_INFERENCE_SAMPLER_TIMING": lambda: int(
+        os.getenv("SENDNN_INFERENCE_SAMPLER_TIMING", "0")
     ),
 }
 # --8<-- [end:env-vars-definition]

--- a/sendnn_inference/model_executor/model_loader/spyre.py
+++ b/sendnn_inference/model_executor/model_loader/spyre.py
@@ -17,9 +17,9 @@ from vllm.logger import init_logger
 from vllm.model_executor.model_loader.weight_utils import download_weights_from_hf
 from vllm.v1.outputs import SamplerOutput
 from vllm.v1.sample.metadata import SamplingMetadata
-from vllm.v1.sample.sampler import Sampler
 
 import sendnn_inference.envs as envs_spyre
+from sendnn_inference.v1.sample.spyre_sampler import ExponentialNoisePool, SpyreSampler
 import sendnn_inference.multimodal as spyre_mm
 import sendnn_inference.utils as utils_spyre
 from sendnn_inference.platform import SpyrePlatform
@@ -113,7 +113,7 @@ class SpyreCausalLM(nn.Module):
     ) -> None:
         super().__init__()
 
-        self.sampler = Sampler()
+        self.sampler = self._build_sampler(vllm_config)
 
         # boolean tensor of length batch size with indices:
         # True for unfinished sequences and
@@ -578,6 +578,33 @@ class SpyreCausalLM(nn.Module):
             is_decode,
             self.mm_device,
         )
+
+    @staticmethod
+    def _build_sampler(vllm_config: VllmConfig) -> SpyreSampler:
+        """Build the sampler, optionally backed by a pre-generated noise pool.
+
+        When SENDNN_INFERENCE_USE_NOISE_POOL is disabled, the returned
+        SpyreSampler behaves identically to upstream vllm's Sampler.
+        """
+        noise_pool: ExponentialNoisePool | None = None
+        if envs_spyre.SENDNN_INFERENCE_USE_NOISE_POOL:
+            vocab_size = vllm_config.model_config.get_vocab_size()
+            max_num_seqs = vllm_config.scheduler_config.max_num_seqs
+            multiplier = envs_spyre.SENDNN_INFERENCE_NOISE_POOL_MULTIPLIER
+            numel = multiplier * max_num_seqs * vocab_size
+            dtype = envs_spyre.get_noise_pool_dtype()
+            logger.info(
+                "Building exponential-noise pool: %d elements "
+                "(%d x max_num_seqs=%d x vocab_size=%d), dtype=%s (~%.2f GiB)",
+                numel,
+                multiplier,
+                max_num_seqs,
+                vocab_size,
+                dtype,
+                numel * torch.empty(0, dtype=dtype).element_size() / (1024**3),
+            )
+            noise_pool = ExponentialNoisePool(numel=numel, dtype=dtype, device="cpu")
+        return SpyreSampler(noise_pool=noise_pool)
 
     def sample(
         self,

--- a/sendnn_inference/v1/sample/spyre_sampler.py
+++ b/sendnn_inference/v1/sample/spyre_sampler.py
@@ -1,0 +1,248 @@
+"""Spyre sampler with a pre-generated exponential-noise pool.
+
+Random number generation via ``Tensor.exponential_()`` is slow on s390x, and
+vLLM's ``random_sample`` calls it once per decode step to draw the Gumbel-max
+noise ``q`` used for weighted sampling (``argmax(probs / q)``).
+
+To avoid that per-step cost, ``ExponentialNoisePool`` generates a large buffer
+of i.i.d. Exp(1) values a single time at model load and, on each step, returns
+a fresh random slice of it. A contiguous slice of an i.i.d. pool is itself a
+valid i.i.d. draw, so sampling stays statistically sound; the random offset
+decorrelates successive steps. Per-request seeded generators pick their pool
+offset *from the seed* (see ``pooled_random_sample``) so reproducible requests
+stay reproducible while also skipping the slow per-step generation.
+
+This is opt-in via ``SENDNN_INFERENCE_USE_NOISE_POOL``; when disabled the
+classes below behave identically to upstream vLLM.
+"""
+
+import random
+import time
+
+import torch
+from vllm.config.model import LogprobsMode
+from vllm.logger import init_logger
+from vllm.v1.sample.ops.topk_topp_sampler import (
+    TopKTopPSampler,
+    apply_top_k_top_p,
+    random_sample,
+)
+from vllm.v1.sample.sampler import Sampler
+
+import sendnn_inference.envs as envs_spyre
+
+logger = init_logger(__name__)
+
+
+class ExponentialNoisePool:
+    """A fixed buffer of Exp(1) noise generated once, sliced at random per draw.
+
+    The pool is filled a single time at construction (the one slow
+    ``exponential_()`` call, paid at model load). ``draw`` then returns a
+    random contiguous view of the requested shape with no further RNG on the
+    hot path beyond picking a single integer offset.
+    """
+
+    def __init__(
+        self,
+        numel: int,
+        dtype: torch.dtype,
+        device: torch.device | str = "cpu",
+        seed: int = 0,
+    ) -> None:
+        if numel <= 0:
+            raise ValueError(f"Noise pool size must be positive, got {numel}")
+        self.numel = numel
+        self.dtype = dtype
+        self.device = torch.device(device)
+        # Deterministic pool so runs are reproducible given the same seed; the
+        # per-step offset uses Python's (fast, non-torch) RNG so we never touch
+        # the slow s390x torch RNG on the hot path.
+        gen = torch.Generator(device=self.device)
+        gen.manual_seed(seed)
+        self.pool = torch.empty(numel, dtype=dtype, device=self.device)
+        self.pool.exponential_(generator=gen)
+        self._offset_rng = random.Random(seed)
+
+    def draw(self, shape: torch.Size) -> torch.Tensor:
+        """Return a fresh Exp(1) tensor of ``shape`` sliced from the pool."""
+        n = 1
+        for dim in shape:
+            n *= dim
+        if n > self.numel:
+            raise ValueError(
+                f"Noise pool too small: need {n} elements for shape {tuple(shape)} "
+                f"but pool holds {self.numel}. Increase "
+                f"SENDNN_INFERENCE_NOISE_POOL_MULTIPLIER."
+            )
+        offset = self._offset_rng.randint(0, self.numel - n)
+        logger.debug(
+            "Noise pool draw: shape=%s (%d elems) from offset %d/%d",
+            tuple(shape),
+            n,
+            offset,
+            self.numel,
+        )
+        return self.pool[offset : offset + n].view(shape)
+
+    def draw_row(self, width: int, generator: torch.Generator) -> torch.Tensor:
+        """Return one ``width``-element row whose offset is chosen by ``generator``.
+
+        Used for seeded requests: the per-request generator deterministically
+        selects *where* in the pool to read, so the same seed yields the same
+        noise (reproducible) without generating any new random values in bulk.
+        The generator advances by a single int per call, so successive decode
+        steps for the same request read different slices.
+        """
+        if width > self.numel:
+            raise ValueError(
+                f"Noise pool too small: need {width} elements for a row but pool "
+                f"holds {self.numel}. Increase SENDNN_INFERENCE_NOISE_POOL_MULTIPLIER."
+            )
+        offset = int(
+            torch.randint(
+                0, self.numel - width + 1, (1,), generator=generator, device=self.device
+            ).item()
+        )
+        return self.pool[offset : offset + width]
+
+
+def pooled_random_sample(
+    probs: torch.Tensor,
+    generators: dict[int, torch.Generator],
+    pool: ExponentialNoisePool,
+) -> torch.Tensor:
+    """Drop-in for vLLM ``random_sample`` backed by ``pool``.
+
+    Seeded requests use their per-request generator to *select an offset* into
+    the pool (via ``pool.draw_row``) rather than generating fresh noise. This
+    keeps their sampling reproducible for a given seed while still skipping the
+    slow per-step ``exponential_()``. Unseeded rows read a random pool slice.
+
+    Note: because seeded rows now read pool values instead of freshly generated
+    ones, seeded outputs are reproducible run-to-run (given the same pool) but
+    are NOT bit-identical to upstream vLLM's seeded outputs.
+
+    If the requested batch x vocab exceeds the pool capacity, this falls back
+    to upstream's on-the-fly ``random_sample`` for that step rather than
+    failing -- so an unexpectedly large batch degrades to the (slower) fresh
+    noise path instead of erroring.
+    """
+    n = probs.shape.numel()
+    if n > pool.numel:
+        logger.warning_once(
+            "Sampling batch needs %d noise elements but the pool holds only %d; "
+            "falling back to on-the-fly exponential_() for oversized steps. "
+            "Increase SENDNN_INFERENCE_NOISE_POOL_MULTIPLIER to avoid this.",
+            n,
+            pool.numel,
+        )
+        return random_sample(probs, generators)
+    q = pool.draw(probs.shape)
+    if generators:
+        # draw() returns a view into the shared pool; clone before overwriting
+        # seeded rows so we never mutate the pool buffer itself.
+        q = q.clone()
+        width = probs.shape[1]
+        for i, generator in generators.items():
+            q[i] = pool.draw_row(width, generator)
+        logger.debug(
+            "Pooled sample: batch=%d, %d seeded row(s) via seed-selected offset",
+            probs.shape[0],
+            len(generators),
+        )
+    else:
+        logger.debug("Pooled sample: batch=%d, all rows from pool", probs.shape[0])
+    # Mirror upstream random_sample's Gumbel-max trick. probs is a fresh
+    # softmax output, so the in-place div is safe; q (a pool view when no
+    # seeded rows) is only read.
+    return probs.div_(q).argmax(dim=-1).view(-1)
+
+
+class SpyreTopKTopPSampler(TopKTopPSampler):
+    """``TopKTopPSampler`` that draws sampling noise from a pre-generated pool.
+
+    When ``noise_pool`` is ``None`` this is equivalent to the upstream
+    PyTorch-native path.
+    """
+
+    def __init__(
+        self,
+        logprobs_mode: LogprobsMode = "raw_logprobs",
+        noise_pool: ExponentialNoisePool | None = None,
+    ) -> None:
+        super().__init__(logprobs_mode)
+        self.noise_pool = noise_pool
+        # The parent picks a forward_* implementation based on current_platform;
+        # pin ours so the pool path is used deterministically on Spyre.
+        self.forward = self.forward_native
+
+        # Opt-in latency instrumentation for the noise + sampling step.
+        self._timing_interval = envs_spyre.SENDNN_INFERENCE_SAMPLER_TIMING
+        self._timing_enabled = self._timing_interval > 0
+        self._timing_calls = 0
+        self._timing_total_s = 0.0
+
+        logger.info(
+            "SpyreTopKTopPSampler initialized: noise_pool=%s, timing=%s",
+            "on" if self.noise_pool is not None else "off",
+            f"every {self._timing_interval} calls" if self._timing_enabled else "off",
+        )
+
+    def forward_native(
+        self,
+        logits: torch.Tensor,
+        generators: dict[int, torch.Generator],
+        k: torch.Tensor | None,
+        p: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        logits = apply_top_k_top_p(logits, k, p)
+        logits_to_return = None
+        if self.logprobs_mode == "processed_logits":
+            logits_to_return = logits
+        elif self.logprobs_mode == "processed_logprobs":
+            logits_to_return = logits.log_softmax(dim=-1, dtype=torch.float32)
+        probs = logits.softmax(dim=-1, dtype=torch.float32)
+
+        start = time.perf_counter() if self._timing_enabled else 0.0
+        if self.noise_pool is None:
+            sampled = random_sample(probs, generators)
+        else:
+            sampled = pooled_random_sample(probs, generators, self.noise_pool)
+        if self._timing_enabled:
+            self._record_timing(time.perf_counter() - start, probs.shape)
+        return sampled, logits_to_return
+
+    def _record_timing(self, elapsed_s: float, shape: torch.Size) -> None:
+        """Accumulate sampling latency and log a running average periodically."""
+        self._timing_calls += 1
+        self._timing_total_s += elapsed_s
+        if self._timing_calls >= self._timing_interval:
+            path = "pool" if self.noise_pool is not None else "exponential_"
+            logger.info(
+                "Spyre sampler [%s]: %.3f ms/call avg over %d calls "
+                "(last shape: batch=%d, vocab=%d)",
+                path,
+                1000.0 * self._timing_total_s / self._timing_calls,
+                self._timing_calls,
+                shape[0],
+                shape[1],
+            )
+            self._timing_calls = 0
+            self._timing_total_s = 0.0
+
+
+class SpyreSampler(Sampler):
+    """``Sampler`` that routes weighted sampling through ``SpyreTopKTopPSampler``.
+
+    All other behaviour (penalties, temperature, greedy path, logprobs) is
+    inherited unchanged from upstream.
+    """
+
+    def __init__(
+        self,
+        logprobs_mode: LogprobsMode = "raw_logprobs",
+        noise_pool: ExponentialNoisePool | None = None,
+    ) -> None:
+        super().__init__(logprobs_mode)
+        self.topk_topp_sampler = SpyreTopKTopPSampler(logprobs_mode, noise_pool=noise_pool)

--- a/sendnn_inference/v1/sample/spyre_sampler.py
+++ b/sendnn_inference/v1/sample/spyre_sampler.py
@@ -62,6 +62,12 @@ class ExponentialNoisePool:
         gen.manual_seed(seed)
         self.pool = torch.empty(numel, dtype=dtype, device=self.device)
         self.pool.exponential_(generator=gen)
+        # exponential_() can underflow to exactly 0.0 in low-precision dtypes
+        # (float16 hits it at ~6e-8), which would make probs.div_(q) produce
+        # +inf/nan and select a wrong or top-k/top-p-masked token. Clamp to the
+        # smallest positive normal so the pool never contains a zero. This is a
+        # no-op in practice for float32 (its tiny is ~1e-38).
+        self.pool.clamp_(min=torch.finfo(dtype).tiny)
         self._offset_rng = random.Random(seed)
 
     def draw(self, shape: torch.Size) -> torch.Tensor:

--- a/tests/v1/sample/test_spyre_noise_pool.py
+++ b/tests/v1/sample/test_spyre_noise_pool.py
@@ -35,6 +35,35 @@ def test_pool_dtype_follows_request():
     assert pool.draw(torch.Size([2, 8])).dtype == torch.float16
 
 
+def test_pool_has_no_values_below_tiny_after_clamp():
+    # exponential_() underflows to subnormal/zero values in float16 (~6e-5 of
+    # samples fall below `tiny`); the clamp must lift them all to `tiny` so
+    # probs.div_(q) can never divide by zero or a subnormal. This reliably
+    # fails without the clamp (a 2M pool has ~120 sub-tiny values).
+    tiny = torch.finfo(torch.float16).tiny
+    for seed in range(4):
+        pool = ExponentialNoisePool(numel=2_000_000, dtype=torch.float16, seed=seed)
+        assert pool.pool.min().item() >= tiny
+        assert not torch.any(pool.pool == 0)
+
+
+def test_zero_noise_would_select_masked_token_but_clamp_prevents_it():
+    # Demonstrates the hazard the clamp fixes: a zero in q makes 0/0 -> nan for
+    # a masked (prob 0) token, and argmax then selects that masked index.
+    vocab = 8
+    probs = torch.zeros(1, vocab)
+    probs[:, :4] = 0.25  # tokens 4..7 are masked out (prob 0)
+
+    bad_q = torch.full((vocab,), 0.5, dtype=torch.float16)
+    bad_q[5] = 0.0  # an unclamped underflow
+    corrupted = probs.clone().div_(bad_q).argmax(dim=-1)
+    assert corrupted.item() == 5  # masked token wrongly selected
+
+    # The real pool is clamped at fill, so it can never contain that zero.
+    pool = ExponentialNoisePool(numel=100_000, dtype=torch.float16, seed=0)
+    assert pool.pool.min().item() >= torch.finfo(torch.float16).tiny
+
+
 def test_pool_too_small_raises():
     pool = ExponentialNoisePool(numel=16, dtype=torch.float32, seed=0)
     with pytest.raises(ValueError, match="Noise pool too small"):

--- a/tests/v1/sample/test_spyre_noise_pool.py
+++ b/tests/v1/sample/test_spyre_noise_pool.py
@@ -1,0 +1,168 @@
+"""Unit tests for the pre-generated exponential-noise sampler.
+
+These are pure CPU unit tests -- they exercise ExponentialNoisePool and the
+pooled sampling path directly, without spinning up an engine.
+"""
+
+import pytest
+import torch
+from vllm.v1.sample.ops.topk_topp_sampler import random_sample
+
+from sendnn_inference.v1.sample.spyre_sampler import (
+    ExponentialNoisePool,
+    SpyreSampler,
+    SpyreTopKTopPSampler,
+    pooled_random_sample,
+)
+
+pytestmark = pytest.mark.cpu
+
+
+def test_pool_draw_shape_dtype_and_membership():
+    pool = ExponentialNoisePool(numel=10_000, dtype=torch.float32, seed=0)
+    shape = torch.Size([4, 50])
+    q = pool.draw(shape)
+
+    assert q.shape == shape
+    assert q.dtype == torch.float32
+    # Every drawn value must come from the pool and be positive (Exp(1)).
+    assert torch.all(q > 0)
+    assert torch.isin(q.flatten(), pool.pool).all()
+
+
+def test_pool_dtype_follows_request():
+    pool = ExponentialNoisePool(numel=1024, dtype=torch.float16, seed=1)
+    assert pool.draw(torch.Size([2, 8])).dtype == torch.float16
+
+
+def test_pool_too_small_raises():
+    pool = ExponentialNoisePool(numel=16, dtype=torch.float32, seed=0)
+    with pytest.raises(ValueError, match="Noise pool too small"):
+        pool.draw(torch.Size([4, 8]))  # needs 32 > 16
+
+
+def test_pooled_sample_falls_back_when_batch_exceeds_pool():
+    # A batch x vocab larger than the pool must not raise: it degrades to
+    # upstream's on-the-fly random_sample and still returns valid tokens.
+    pool = ExponentialNoisePool(numel=16, dtype=torch.float32, seed=0)
+    vocab = 8
+    probs = torch.full((4, vocab), 1.0 / vocab)  # 32 elements > pool of 16
+    torch.manual_seed(0)
+    sampled = pooled_random_sample(probs.clone(), {}, pool)
+    assert sampled.shape == (4,)
+    assert torch.all(sampled >= 0) and torch.all(sampled < vocab)
+
+
+def test_pool_rejects_nonpositive_size():
+    with pytest.raises(ValueError, match="must be positive"):
+        ExponentialNoisePool(numel=0, dtype=torch.float32)
+
+
+def test_pooled_sample_peaked_probs_is_deterministic():
+    # One token dominates -> argmax(probs / q) must always pick it regardless
+    # of which noise slice is drawn.
+    pool = ExponentialNoisePool(numel=100_000, dtype=torch.float32, seed=0)
+    vocab = 32
+    probs = torch.full((3, vocab), 1e-6)
+    probs[:, 7] = 1.0
+    for _ in range(50):
+        sampled = pooled_random_sample(probs.clone(), {}, pool)
+        assert torch.equal(sampled, torch.tensor([7, 7, 7]))
+
+
+def test_pooled_sample_uniform_probs_covers_vocab():
+    # Flat probs -> sampled token is argmin(q) over the slice, which should be
+    # roughly uniform across the vocab given a large i.i.d. pool.
+    pool = ExponentialNoisePool(numel=1_000_000, dtype=torch.float32, seed=0)
+    vocab = 8
+    probs = torch.full((1, vocab), 1.0 / vocab)
+    counts = torch.zeros(vocab, dtype=torch.long)
+    n_draws = 4000
+    for _ in range(n_draws):
+        tok = pooled_random_sample(probs.clone(), {}, pool)
+        counts[tok.item()] += 1
+
+    # Every token should be selected, and no token should dominate wildly.
+    expected = n_draws / vocab
+    assert torch.all(counts > 0)
+    assert counts.max().item() < 3 * expected
+
+
+def test_seeded_row_is_reproducible():
+    # A row with a per-request generator must produce identical results across
+    # runs with the same seed: the seed selects a deterministic pool offset.
+    pool = ExponentialNoisePool(numel=50_000, dtype=torch.float32, seed=0)
+    vocab = 64
+    torch.manual_seed(123)
+    probs = torch.softmax(torch.randn(2, vocab), dim=-1)
+
+    def sample_with_seed(seed):
+        gen = torch.Generator().manual_seed(seed)
+        return pooled_random_sample(probs.clone(), {0: gen}, pool)
+
+    first = sample_with_seed(999)
+    second = sample_with_seed(999)
+    # Only the seeded row (0) is reproducible; the unseeded row (1) correctly
+    # varies as the pool offset advances between draws.
+    assert first[0].item() == second[0].item()
+
+
+def test_seeded_row_reads_pool_values_not_fresh_noise():
+    # The seeded row's noise must come from the pool (seed selects the offset),
+    # so its selected token equals argmax(probs / pool_slice) for some offset.
+    pool = ExponentialNoisePool(numel=20_000, dtype=torch.float32, seed=0)
+    vocab = 32
+    torch.manual_seed(7)
+    probs = torch.softmax(torch.randn(1, vocab), dim=-1)
+
+    gen = torch.Generator().manual_seed(555)
+    sampled = pooled_random_sample(probs.clone(), {0: gen}, pool)
+
+    # Recompute the offset the same generator would have chosen and confirm the
+    # sampled token matches a pooled slice (i.e. no fresh exponential_ noise).
+    check_gen = torch.Generator().manual_seed(555)
+    offset = int(torch.randint(0, pool.numel - vocab + 1, (1,), generator=check_gen).item())
+    expected_q = pool.pool[offset : offset + vocab]
+    expected = probs.clone().div_(expected_q).argmax(dim=-1)
+    assert sampled.item() == expected.item()
+
+
+def test_different_seeds_generally_differ():
+    # Different seeds should pick different offsets and (usually) different
+    # tokens under a flat distribution.
+    pool = ExponentialNoisePool(numel=1_000_000, dtype=torch.float32, seed=0)
+    vocab = 64
+    probs = torch.full((1, vocab), 1.0 / vocab)
+    toks = set()
+    for seed in range(20):
+        gen = torch.Generator().manual_seed(seed)
+        toks.add(pooled_random_sample(probs.clone(), {0: gen}, pool).item())
+    assert len(toks) > 1
+
+
+def test_no_pool_matches_upstream_random_sample():
+    # SpyreTopKTopPSampler with noise_pool=None must reproduce upstream's
+    # PyTorch-native path bit-for-bit given the same global RNG state.
+    vocab = 128
+    torch.manual_seed(7)
+    logits = torch.randn(4, vocab)
+
+    sampler = SpyreTopKTopPSampler(noise_pool=None)
+
+    torch.manual_seed(42)
+    spyre_out, _ = sampler.forward_native(logits.clone(), {}, None, None)
+
+    torch.manual_seed(42)
+    probs = logits.clone().softmax(dim=-1, dtype=torch.float32)
+    upstream_out = random_sample(probs, {})
+
+    assert torch.equal(spyre_out, upstream_out)
+
+
+def test_spyre_sampler_wires_pool_into_topk_sampler():
+    pool = ExponentialNoisePool(numel=1024, dtype=torch.float32, seed=0)
+    sampler = SpyreSampler(noise_pool=pool)
+    assert isinstance(sampler.topk_topp_sampler, SpyreTopKTopPSampler)
+    assert sampler.topk_topp_sampler.noise_pool is pool
+    # forward must be pinned to the native (pooled) path.
+    assert sampler.topk_topp_sampler.forward == sampler.topk_topp_sampler.forward_native


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

- Add optional exponential-noise pool for the custom `SpyreSampler` to avoid slow per-step `Tensor.exponential_()` random number generation on `s390x` platform
    - `ExponentialNoisePool` - fills a buffer of Exp(1) noise once at model load. `draw()` returns a `random-offset` slice, `draw_row()` returns a seed-selected slice.
    - `SpyreTopKTopPSampler` - pins `forward_native`, sources sampling noise from the pool (falls back to upstream random_sample when no pool)
    - `SpyreSampler` - swaps the pooled top-k/top-p sampler into vLLM's Sampler; all other sampler behavior inherited unchanged 
- Oversized batches `(batch × vocab` > `pool`) fall back to upstream random_sample with a one-time warning instead of erroring
- Wire `SpyreSampler` into `SpyreCausalLM` via `_build_sampler`. This behaves identically to upstream when the pool is disabled
- New env variables:
    - `SENDNN_INFERENCE_USE_NOISE_POOL` (bool, default 0) - enable the pool
    - `SENDNN_INFERENCE_NOISE_POOL_MULTIPLIER` (int, default 32) - pool size = multiplier × max_num_seqs × vocab_size
    - `SENDNN_INFERENCE_SAMPLER_TIMING` (int, default 0) - log average sampling latency every N calls

- Pool dtype follows the existing platform defaults for consistency and correctness

### Notes

If request contains seed, then we use per-request generator to pick a deterministic pool offset (reproducible per seed, skips bulk generation) instead of regenerating noise. So this is still cheaper than random generation and aligns with non-seeded request for performance.


## Related Issues

<!-- Link related issues, e.g., `Fixes #` or `Relates to #456` -->

## Test Plan

- New `tests/v1/sample/test_spyre_noise_pool.py` (CPU-marked), covering:
    - Pool draw shape, dtype, and value membership
    - Pool dtype follows the requested dtype
    - Pool-too-small raises, and non-positive pool size raises
    - Oversized batch falls back to on-the-fly noise instead of raising
    - Peaked distribution samples deterministically (argmax)
    - Uniform distribution covers the vocab without dominance
    - Seeded row is reproducible across runs with the same seed
    - Seeded row reads pool values (seed-selected offset), not fresh noise
    - Different seeds generally produce different tokens
    - No-pool path matches upstream `random_sample` bit-for-bit given the same RNG state
    - `SpyreSampler` correctly wires the pool into `SpyreTopKTopPSampler`

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
