### PR TITLE
chore: bumps vllm to v0.27.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,33 @@ jobs:
               flags: "--timeout=300"
             os: "ubuntu-latest"
             python_version: "3.12"
+          - vllm_version:
+              name: "vLLM:0.25.1"
+              repo: "git+https://github.com/vllm-project/vllm --tag v0.25.1"
+            test_suite:
+              name: "backward compat"
+              markers: "compat or (cpu and basic and not quantized)"
+              flags: "--timeout=300"
+            os: "ubuntu-latest"
+            python_version: "3.12"
+          - vllm_version:
+              name: "vLLM:0.26.0"
+              repo: "git+https://github.com/vllm-project/vllm --tag v0.26.0"
+            test_suite:
+              name: "backward compat"
+              markers: "compat or (cpu and basic and not quantized)"
+              flags: "--timeout=300"
+            os: "ubuntu-latest"
+            python_version: "3.12"
+          - vllm_version:
+              name: "vLLM:0.27.0"
+              repo: "git+https://github.com/vllm-project/vllm --tag v0.27.0"
+            test_suite:
+              name: "backward compat"
+              markers: "compat or (cpu and basic and not quantized)"
+              flags: "--timeout=300"
+            os: "ubuntu-latest"
+            python_version: "3.12"
 
         # Only run vllm:main jobs on PRs with `vllm:main` label
         exclude: >-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "ibm-fms>=1.13.0,<2",
     # NB: use strict < with the next patch version to not exclude versions with
     # build metadata suffixes
-    "vllm>=0.24.0,<0.25.2",
+    "vllm>=0.24.0,<0.27.2",
     # transformers 5.12.1 includes fixes required for our mistral and granite-4.1-8b models.
     "transformers>=5.12.1",
 
@@ -95,7 +95,7 @@ build-constraint-dependencies = []
 extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "empty" } }
 
 [tool.uv.sources]
-vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.25.1" }
+vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.27.1" }
 torch = [
   { index = "pytorch-cpu" },
 ]

--- a/sendnn_inference/v1/core/scheduler.py
+++ b/sendnn_inference/v1/core/scheduler.py
@@ -502,7 +502,7 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         # log_stats off here to avoid double-counting.
         prev_log_stats = self.kv_cache_manager.log_stats
         self.kv_cache_manager.log_stats = False
-        _, prefix_token_len = self.kv_cache_manager.get_computed_blocks(new_prefill)
+        _, prefix_token_len, _ = self.kv_cache_manager.get_computed_blocks(new_prefill)
         self.kv_cache_manager.log_stats = prev_log_stats
         if prefix_token_len >= self.chunk_size - left_padding:
             return self.chunk_size
@@ -519,7 +519,7 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         if request.num_computed_tokens == 0:
             old_log_stats = self.kv_cache_manager.log_stats
             self.kv_cache_manager.log_stats = False
-            new_computed_blocks, num_new_local_computed_tokens = (
+            new_computed_blocks, num_new_local_computed_tokens, _ = (
                 self.kv_cache_manager.get_computed_blocks(request)
             )
             self.kv_cache_manager.log_stats = old_log_stats
@@ -543,6 +543,7 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
             new_computed_blocks=new_computed_blocks.blocks,
             num_encoder_tokens=0,
             total_computed_tokens=num_computed_tokens,
+            num_local_computed_tokens=num_new_local_computed_tokens,
             num_tokens_main_model=num_tokens,
         )
 
@@ -812,7 +813,7 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
             # case where most of the prompt hits prefix cache and we only run a single chunk.
             prev_log_stats = self.kv_cache_manager.log_stats
             self.kv_cache_manager.log_stats = False
-            _, num_computed_tokens = self.kv_cache_manager.get_computed_blocks(request)
+            _, num_computed_tokens, _ = self.kv_cache_manager.get_computed_blocks(request)
             self.kv_cache_manager.log_stats = prev_log_stats
 
         is_first_chunk = request.num_computed_tokens == 0
@@ -1101,7 +1102,7 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
         self,
         request_ids: Union[str, Iterable[str], None],
         finished_status: RequestStatus,
-    ) -> list[tuple[str, int]]:
+    ) -> list[Request]:
         """
         Handles removing finished requests from ongoing_prefills and
         paused_decoding_requests

--- a/sendnn_inference/v1/core/scheduler.py
+++ b/sendnn_inference/v1/core/scheduler.py
@@ -416,7 +416,7 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
     def _free_request(self, request, delay_free_blocks: bool = False):
         """Override to inject Spyre bench metrics into kv_transfer_params so
         they travel over ZMQ to the API server process in EngineCoreOutput."""
-        kv_xfer_params = super()._free_request(request, delay_free_blocks)
+        kv_xfer_params, ec_xfer_params = super()._free_request(request, delay_free_blocks)
 
         if self._bench is not None:
             req_id = request.request_id
@@ -474,7 +474,7 @@ class ChunkedPrefillSpyreScheduler(SpyreScheduler):
             else:
                 kv_xfer_params["__spyre__"] = spyre_data
 
-        return kv_xfer_params
+        return kv_xfer_params, ec_xfer_params
 
     def _current_chunk_token_threshold(self, new_prefill_candidates: list[Request]) -> int:
         """Returns the `long_prefill_token_threshold` to use for this step.

--- a/tests/benchmarks/test_bench_metrics.py
+++ b/tests/benchmarks/test_bench_metrics.py
@@ -698,10 +698,10 @@ def test_scheduler_bench_metrics_accumulated(
             captured[req_id] = snap
         else:
             captured[req_id] = {}
-        kv_params = original_free(self, request, delay_free_blocks)
+        kv_params, ec_params = original_free(self, request, delay_free_blocks)
         if kv_params and "__spyre__" in kv_params:
             captured_spyre[req_id] = dict(kv_params["__spyre__"])
-        return kv_params
+        return kv_params, ec_params
 
     scheduler._free_request = _capturing_free.__get__(scheduler)
 

--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -261,6 +261,7 @@ def test_sendnn_bench__kv_transfer_params_survives_to_request_output():
     assert "finished" in ro_params, (
         "RequestOutput.__init__ no longer accepts 'finished'; patch_serving gates the "
         "'__spyre__' read on res.finished and must be updated."
+    )
 
 
 @pytest.mark.utils
@@ -317,4 +318,3 @@ def test_finish_requests_returns_list_of_request():
     assert args is not None and args[0] is Request, (
         f"finish_requests return type is {annotation!r}, expected list[Request]. "
         "Update the return annotation on SpyreScheduler.finish_requests when vLLM:lowest > v0.27.1."
-    )

--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -318,3 +318,4 @@ def test_finish_requests_returns_list_of_request():
     assert args is not None and args[0] is Request, (
         f"finish_requests return type is {annotation!r}, expected list[Request]. "
         "Update the return annotation on SpyreScheduler.finish_requests when vLLM:lowest > v0.27.1."
+    )

--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -319,3 +319,24 @@ def test_finish_requests_returns_list_of_request():
         f"finish_requests return type is {annotation!r}, expected list[Request]. "
         "Update the return annotation on SpyreScheduler.finish_requests when vLLM:lowest > v0.27.1."
     )
+
+
+@pytest.mark.utils
+def test_free_request_returns_2_tuple():
+    """Scheduler._free_request returns a 2-tuple (kv_xfer_params, ec_xfer_params)
+    as of vLLM v0.27.1 (previously returned kv_xfer_params directly).
+
+    When vLLM:lowest is bumped past v0.27.1, the unpack-to-2 in
+    SpyreScheduler._free_request can be simplified and this test deleted.
+    """
+    from vllm.v1.core.sched.scheduler import Scheduler
+    import inspect
+
+    sig = inspect.signature(Scheduler._free_request)
+    annotation = sig.return_annotation
+    assert annotation != inspect.Parameter.empty
+    args = getattr(annotation, "__args__", None)
+    assert args is not None and len(args) == 2, (
+        f"_free_request returns {len(args) if args else '?'}-tuple, expected 2. "
+        "Update the unpack in SpyreScheduler._free_request when vLLM:lowest > v0.27.1."
+    )

--- a/tests/utils/test_upstream_compatibility.py
+++ b/tests/utils/test_upstream_compatibility.py
@@ -261,4 +261,60 @@ def test_sendnn_bench__kv_transfer_params_survives_to_request_output():
     assert "finished" in ro_params, (
         "RequestOutput.__init__ no longer accepts 'finished'; patch_serving gates the "
         "'__spyre__' read on res.finished and must be updated."
+
+
+@pytest.mark.utils
+def test_get_computed_blocks_returns_3_tuple():
+    """KVCacheManager.get_computed_blocks returns a 3-tuple as of vLLM v0.27.1
+    (previously a 2-tuple). When vLLM:lowest is bumped past v0.27.1, the
+    unpack-to-3 shims in sendnn_inference/v1/core/scheduler.py and the mock
+    return_value fixtures can be simplified and this test deleted.
+    """
+    from vllm.v1.core.kv_cache_manager import KVCacheManager
+
+    sig = inspect.signature(KVCacheManager.get_computed_blocks)
+    annotation = sig.return_annotation
+    assert annotation != inspect.Parameter.empty
+    args = getattr(annotation, "__args__", None)
+    assert args is not None and len(args) >= 3, (
+        f"get_computed_blocks returns {len(args) if args else '?'} values, expected >=3. "
+        "Remove 3-value unpack shims in scheduler.py when vLLM:lowest > v0.27.1."
+    )
+
+
+@pytest.mark.utils
+def test_get_num_blocks_to_allocate_has_num_local_computed_tokens():
+    """KVCacheCoordinator.get_num_blocks_to_allocate gained
+    num_local_computed_tokens in vLLM v0.27.1. When vLLM:lowest is bumped
+    past v0.27.1, the explicit kwarg in scheduler.py is no longer a shim
+    and this test can be deleted.
+    """
+    from vllm.v1.core.kv_cache_coordinator import KVCacheCoordinator
+    from sendnn_inference.compat_utils import has_argument
+
+    assert has_argument(
+        KVCacheCoordinator.get_num_blocks_to_allocate, "num_local_computed_tokens"
+    ), (
+        "get_num_blocks_to_allocate no longer accepts num_local_computed_tokens. "
+        "Remove the kwarg from the call site in scheduler.py when vLLM:lowest > v0.27.1."
+    )
+
+
+@pytest.mark.utils
+def test_finish_requests_returns_list_of_request():
+    """Scheduler.finish_requests returns list[Request] as of vLLM v0.27.1
+    (previously list[tuple[str, int]]). When vLLM:lowest is bumped past
+    v0.27.1, the return type annotation on SpyreScheduler.finish_requests is
+    no longer a shim and this test can be deleted.
+    """
+    from vllm.v1.core.sched.scheduler import Scheduler
+    from vllm.v1.request import Request
+
+    sig = inspect.signature(Scheduler.finish_requests)
+    annotation = sig.return_annotation
+    assert annotation != inspect.Parameter.empty
+    args = getattr(annotation, "__args__", None)
+    assert args is not None and args[0] is Request, (
+        f"finish_requests return type is {annotation!r}, expected list[Request]. "
+        "Update the return annotation on SpyreScheduler.finish_requests when vLLM:lowest > v0.27.1."
     )

--- a/tests/v1/core/test_grammar_compilation.py
+++ b/tests/v1/core/test_grammar_compilation.py
@@ -38,6 +38,7 @@ import pytest
 from vllm.sampling_params import StructuredOutputsParams
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import RequestStatus
+from vllm.v1.structured_output import StructuredOutputGrammar
 from vllm.v1.structured_output.request import StructuredOutputRequest
 
 from scheduling_utils import create_request_for_scheduler_test, random_prompt
@@ -51,7 +52,7 @@ pytestmark = [
 ]
 
 
-class _PermissiveStubGrammar:
+class _PermissiveStubGrammar(StructuredOutputGrammar):
     """Minimal ``StructuredOutputGrammar`` stub: accepts any tokens, never
     terminates. The scheduler advances the FSM by calling ``accept_tokens``
     each step a structured request samples; this stub keeps the scheduler
@@ -59,6 +60,9 @@ class _PermissiveStubGrammar:
 
     def accept_tokens(self, request_id: str, tokens) -> bool:
         return True
+
+    def validate_tokens(self, tokens) -> list:
+        return list(tokens)
 
     def rollback(self, num_tokens: int) -> None:
         return None

--- a/tests/v1/core/test_scheduler_mm_encoding.py
+++ b/tests/v1/core/test_scheduler_mm_encoding.py
@@ -74,7 +74,7 @@ def scheduler():
     sched._get_required_blocks = lambda req, *a, **k: (0, 0)
     sched._get_free_blocks = lambda: 100
     sched.kv_cache_manager = Mock()
-    sched.kv_cache_manager.get_computed_blocks.return_value = (None, 0)
+    sched.kv_cache_manager.get_computed_blocks.return_value = (None, 0, 0)
     sched.kv_cache_manager.block_pool = Mock()
     # scheduler_config needed by _current_chunk_token_threshold inside schedule()
     sched.scheduler_config = Mock()

--- a/tests/v1/core/test_scheduler_structured_outputs.py
+++ b/tests/v1/core/test_scheduler_structured_outputs.py
@@ -94,7 +94,7 @@ def mocked_scheduler():
     scheduler.long_output_prio = False
 
     scheduler.kv_cache_manager = Mock()
-    scheduler.kv_cache_manager.get_computed_blocks.return_value = (None, 0)
+    scheduler.kv_cache_manager.get_computed_blocks.return_value = (None, 0, 0)
 
     real_output = SchedulerOutput.make_empty()
 

--- a/uv.lock
+++ b/uv.lock
@@ -31,7 +31,7 @@ overrides = [
     { name = "torch", specifier = "==2.11.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torchvision", specifier = "==0.26.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "triton", marker = "sys_platform == 'never'" },
-    { name = "vllm", marker = "platform_machine not in 's390x, ppc64le'", git = "https://github.com/vllm-project/vllm?rev=v0.25.1" },
+    { name = "vllm", marker = "platform_machine not in 's390x, ppc64le'", git = "https://github.com/vllm-project/vllm?rev=v0.27.1" },
 ]
 
 [[package]]
@@ -774,15 +774,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
-]
-
-[[package]]
-name = "diskcache"
-version = "5.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
 ]
 
 [[package]]
@@ -3940,7 +3931,7 @@ requires-dist = [
     { name = "torch", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torchvision", index = "https://download.pytorch.org/whl/cpu" },
     { name = "transformers", specifier = ">=5.12.1" },
-    { name = "vllm", git = "https://github.com/vllm-project/vllm?rev=v0.25.1" },
+    { name = "vllm", git = "https://github.com/vllm-project/vllm?rev=v0.27.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -4298,13 +4289,13 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "platform_machine != 'aarch64' and sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "platform_machine != 'aarch64' and sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "platform_machine != 'aarch64' and sys_platform == 'darwin'" },
-    { name = "networkx", marker = "platform_machine != 'aarch64' and sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "platform_machine != 'aarch64' and sys_platform == 'darwin'" },
-    { name = "sympy", marker = "platform_machine != 'aarch64' and sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and sys_platform == 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d75eadcd97fe0dc7cd0eedc4d72152484c19cb2cfe46ce55766c8e129116425f", upload-time = "2026-03-23T15:16:54Z" },
@@ -4332,13 +4323,13 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'aarch64'",
 ]
 dependencies = [
-    { name = "filelock", marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
-    { name = "networkx", marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
-    { name = "setuptools", marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
-    { name = "sympy", marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:5214b203ee187f8746c66f1378b72611b7c1e15c5cb325037541899e705ea24e", upload-time = "2026-04-27T21:55:40Z" },
@@ -4387,9 +4378,9 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "platform_machine != 'aarch64' and sys_platform == 'darwin'" },
-    { name = "pillow", marker = "platform_machine != 'aarch64' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'aarch64' and sys_platform == 'darwin'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.26.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55bd6ad4ae77be01ba67a410b05b51f53b0d0ee45f146eb6a0dfb9007e70ab3c", upload-time = "2026-03-23T15:36:09Z" },
@@ -4417,9 +4408,9 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'aarch64'",
 ]
 dependencies = [
-    { name = "numpy", marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
-    { name = "pillow", marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
-    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.26.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:c11e55041f6b84a6c4fb28981b901475aa81c38695ccec6ddfcc54c3fa9fac4f", upload-time = "2026-03-23T15:36:09Z" },
@@ -4597,8 +4588,8 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.25.1+empty"
-source = { git = "https://github.com/vllm-project/vllm?rev=v0.25.1#752a3a504485790a2e8491cacbb35c137339ad34" }
+version = "0.27.1+empty"
+source = { git = "https://github.com/vllm-project/vllm?rev=v0.27.1#6e448d0ea9bf3d88d898b65449ca6dc2aec170ac" }
 dependencies = [
     { name = "aiohttp" },
     { name = "anthropic" },
@@ -4608,7 +4599,6 @@ dependencies = [
     { name = "cloudpickle" },
     { name = "compressed-tensors" },
     { name = "depyf" },
-    { name = "diskcache" },
     { name = "einops" },
     { name = "fastapi", extra = ["standard"] },
     { name = "filelock" },
@@ -4840,8 +4830,8 @@ dependencies = [
     { name = "apache-tvm-ffi" },
     { name = "numpy" },
     { name = "pydantic" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'aarch64' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'ppc64le' and sys_platform == 'darwin') or (platform_machine == 's390x' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin')" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'arm64' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64') or sys_platform != 'darwin'" },
     { name = "transformers" },
     { name = "triton", marker = "sys_platform == 'never'" },
     { name = "typing-extensions" },


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

- Bumps vllm support to v0.27.1 (release notes: https://github.com/vllm-project/vllm/releases/tag/v0.27.1)
- `KVCacheManager.get_computed_blocks` now returns a 3-tuple `(KVCacheBlocks, int, int)` — updated 4 unpack call sites in `scheduler.py` and 2 mock `return_value` fixtures in unit tests
- `KVCacheCoordinator.get_num_blocks_to_allocate` gained a new required `num_local_computed_tokens` kwarg — added to the call site in `scheduler.py`
- `Scheduler.finish_requests` return type changed from `list[tuple[str, int]]` to `list[Request]` — updated the override annotation on `SpyreScheduler.finish_requests`
- `_PermissiveStubGrammar` in `test_grammar_compilation.py` updated to subclass `StructuredOutputGrammar` and implement `validate_tokens` (new abstract method in v0.27.1)
- `sendnn_inference/v1/core/scheduler.py` — unpack` _free_request` return as `kv_xfer_params, ec_xfer_params` and return both
- `_capturing_free` monkey-patch in `test_bench_metrics.py` updated to unpack and re-return the 2-tuple from `_free_request`
- `tests/utils/test_upstream_compatibility.py` — `test_free_request_returns_2_tuple` added
- `torch==2.11.0` / `torchvision==0.26.0` overrides intentionally kept (upstream pins torch 2.13)
- `opencv-python-headless==4.12.0.88` override kept (upstream now requires `>=4.13.0`)
- `llguidance>=1.7.3` override still load-bearing for s390x endianness fix; remains within upstream's `>=1.7.0,<1.8.0` range

## Test Plan

- CPU + compat suites pass locally
- Hardware tests pending bot:test (run after PR opens)

## Checklist

- [x] I have read the [contributing guidelines](https://docs.vllm.ai/projects/spyre/en/latest/contributing)
- [x] My code follows the project's code style (run `bash format.sh`)
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
